### PR TITLE
Make availability code less noisy in the logs

### DIFF
--- a/pkg/bometrics/metrics.go
+++ b/pkg/bometrics/metrics.go
@@ -99,19 +99,16 @@ func (m *BuildMetrics) StartAvailabilityProbes(ctx context.Context) {
 
 func (m *BuildMetrics) checkProbes(ctx context.Context) {
 	for _, probe := range m.probes {
-		pingErr := probe.CheckAvailability(ctx)
-		if pingErr != nil {
-			log := ctrllog.FromContext(ctx)
-			log.Error(pingErr, "Error checking availability probe", "probe", probe)
-			probe.AvailabilityGauge().Set(0)
-		} else {
+		if probe.CheckAvailability(ctx) {
 			probe.AvailabilityGauge().Set(1)
+		} else {
+			probe.AvailabilityGauge().Set(0)
 		}
 	}
 }
 
 // AvailabilityProbe represents a probe that checks the availability of a certain aspects of the service
 type AvailabilityProbe interface {
-	CheckAvailability(ctx context.Context) error
+	CheckAvailability(ctx context.Context) bool
 	AvailabilityGauge() prometheus.Gauge
 }


### PR DESCRIPTION
### What does this PR do?
- {SUBJ}


### Screenshot/screencast of this PR
github app not set

<img width="1718" alt="Знімок екрана 2024-04-19 о 14 41 04" src="https://github.com/redhat-appstudio/build-service/assets/1614429/2aea24b6-32f0-441c-8c63-f3d58a19f03b">
<img width="1724" alt="Знімок екрана 2024-04-19 о 14 40 55" src="https://github.com/redhat-appstudio/build-service/assets/1614429/9481c547-193f-405b-bcc8-e884fa08bf28">

github app is set 
<img width="1723" alt="Знімок екрана 2024-04-19 о 14 47 04" src="https://github.com/redhat-appstudio/build-service/assets/1614429/50b07af7-3d54-4a07-8216-2a057d7e0548">

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/STONEBLD-2352


### How to test this PR?
-  Redeploy new image
-  Run 
```
kubectl exec $(kubectl get pods -n build-service -l control-plane=controller-manager --no-headers -o custom-columns=":metadata.name" ) -c manager -n build-service  --  curl -s  http://localhost:8080/metrics | grep redhat_appstudio_buildservice_global_github_app_available
```
