### PR TITLE
feat(RELEASE-230): update release service ref to konflux ci org

### DIFF
--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	l "github.com/konflux-ci/build-service/pkg/logs"
+	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	applicationapi "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,12 +27,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 require (
 	github.com/openshift-pipelines/pipelines-as-code v0.18.0
 	github.com/redhat-appstudio/application-api v0.0.0-20231026192857-89515ad2504f
-	github.com/redhat-appstudio/release-service v0.0.0-20231213200646-9aea1dba75c0
+	github.com/konflux-ci/release-service v0.0.0-20240507194006-aaf11b05c47a
 	github.com/tektoncd/pipeline v0.49.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -998,8 +998,8 @@ github.com/redhat-appstudio/application-service/cdq-analysis v0.0.0-202403241340
 github.com/redhat-appstudio/application-service/cdq-analysis v0.0.0-20240324134056-ac595a80c5cf/go.mod h1:tX9brsCdcc5JPtEZgllVzfsmW3apPjLtd9BMcqUrcFU=
 github.com/redhat-appstudio/operator-toolkit v0.0.0-20231201124606-2087182322ae h1:98thWrMrr9YUNCVNGqkZxKfZkaWUmMC5dmkgAI7p3uY=
 github.com/redhat-appstudio/operator-toolkit v0.0.0-20231201124606-2087182322ae/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
-github.com/redhat-appstudio/release-service v0.0.0-20231213200646-9aea1dba75c0 h1:4yvI07Wt4Xjm7s9BD4g7oYYG3VSpG2+pMvWqxUM2kwk=
-github.com/redhat-appstudio/release-service v0.0.0-20231213200646-9aea1dba75c0/go.mod h1:lhbPcRSIvwyqDl4D86Eza1vnsD7cENkMD2IU6vcs1p0=
+github.com/konflux-ci/release-service v0.0.0-20231213200646-9aea1dba75c0 h1:qYUaU/UHfvYeGa4O2tQy7rhFvXy3B1AzkW4VNGb5zLQ=
+github.com/konflux-ci/release-service v0.0.0-20231213200646-9aea1dba75c0/go.mod h1:lhbPcRSIvwyqDl4D86Eza1vnsD7cENkMD2IU6vcs1p0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/main.go
+++ b/main.go
@@ -50,9 +50,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	appstudioredhatcomv1alpha1 "github.com/konflux-ci/build-service/api/v1alpha1"


### PR DESCRIPTION
 This commit updates the `release-service` reference
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable