### PR TITLE
Renovate controller should watch build pipelines configMap instead of

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -69,8 +69,9 @@ const (
 	ImageRepoGenerateAnnotationName = "image.redhat.com/generate"
 	buildPipelineServiceAccountName = "appstudio-pipeline"
 
-	buildPipelineSelectorResourceName = "build-pipeline-selector"
-	defaultBuildPipelineAnnotation    = "build.appstudio.openshift.io/pipeline"
+	buildPipelineSelectorResourceName  = "build-pipeline-selector"
+	defaultBuildPipelineAnnotation     = "build.appstudio.openshift.io/pipeline"
+	buildPipelineConfigMapResourceName = "build-pipeline-config"
 )
 
 type BuildStatus struct {

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -33,19 +33,19 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 
-	buildappstudiov1alpha1 "github.com/konflux-ci/build-service/api/v1alpha1"
 	. "github.com/konflux-ci/build-service/pkg/common"
 	"github.com/konflux-ci/build-service/pkg/git"
 	"github.com/konflux-ci/build-service/pkg/k8s"
 	l "github.com/konflux-ci/build-service/pkg/logs"
 	"github.com/konflux-ci/build-service/pkg/renovate"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	NextReconcile = 6 * time.Hour
 )
 
-// GitTektonResourcesRenovater watches AppStudio BuildPipelineSelector object in order to update
+// GitTektonResourcesRenovater watches build pipeline ConfigMap object in order to update
 // existing .tekton directories.
 type GitTektonResourcesRenovater struct {
 	taskProviders  []renovate.TaskProvider
@@ -72,15 +72,15 @@ func NewGitTektonResourcesRenovater(client client.Client, scheme *runtime.Scheme
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GitTektonResourcesRenovater) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).For(&buildappstudiov1alpha1.BuildPipelineSelector{}, builder.WithPredicates(predicate.Funcs{
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.ConfigMap{}, builder.WithPredicates(predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetNamespace() == BuildServiceNamespaceName && e.Object.GetName() == buildPipelineSelectorResourceName
+			return e.Object.GetNamespace() == BuildServiceNamespaceName && e.Object.GetName() == buildPipelineConfigMapResourceName
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetNamespace() == BuildServiceNamespaceName && e.ObjectNew.GetName() == buildPipelineSelectorResourceName
+			return e.ObjectNew.GetNamespace() == BuildServiceNamespaceName && e.ObjectNew.GetName() == buildPipelineConfigMapResourceName
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			return false

--- a/controllers/git_tekton_resources_renovater_test.go
+++ b/controllers/git_tekton_resources_renovater_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 		})
 
 		_ = AfterEach(func() {
-			deleteBuildPipelineRunSelector(defaultSelectorKey)
+			deleteBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			deleteJobs(BuildServiceNamespaceName)
 			os.Unsetenv(renovate.InstallationsPerJobEnvName)
 			deleteSecret(pacSecretKey)
@@ -66,7 +66,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 				return []github.ApplicationInstallation{generateInstallation(repositories)}, "slug", nil
 			}
 			componentNamespacedName := createComponentForPaCBuild(getComponentData(componentConfig{componentKey: types.NamespacedName{Name: "testtrigger"}, gitURL: "https://github/test/repo1"}))
-			createDefaultBuildPipelineRunSelector(defaultSelectorKey)
+			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			Eventually(listJobs).WithArguments(BuildServiceNamespaceName).WithTimeout(timeout).Should(HaveLen(1))
 			deleteComponent(componentNamespacedName)
 		})
@@ -84,7 +84,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 			componentsData.Spec.Source.GitSource.Revision = ""
 			componentNamespacedName := createComponentForPaCBuild(componentsData)
 			os.Setenv(renovate.InstallationsPerJobEnvName, "0")
-			createDefaultBuildPipelineRunSelector(defaultSelectorKey)
+			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			Eventually(listJobs).WithArguments(BuildServiceNamespaceName).WithTimeout(timeout).Should(HaveLen(1))
 			deleteComponent(componentNamespacedName)
 		})
@@ -114,7 +114,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 					componentsNs = append(componentsNs, createComponentForPaCBuild(getComponentData(componentConfig{componentKey: types.NamespacedName{Name: fmt.Sprintf("test%v-%v", i, j)}, gitURL: installedRepositoryUrl})))
 				}
 			}
-			createDefaultBuildPipelineRunSelector(defaultSelectorKey)
+			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			Eventually(listJobs).WithArguments(BuildServiceNamespaceName).WithTimeout(timeout).Should(HaveLen(2))
 			//now delete all components
 			for _, componentNs := range componentsNs {
@@ -134,7 +134,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 			componentNamespacedName := createComponentForPaCBuild(getComponentData(componentConfig{componentKey: types.NamespacedName{Name: "testpacmissing"}, gitURL: "https://github/test/repo1"}))
 
 			deleteSecret(pacSecretKey)
-			createDefaultBuildPipelineRunSelector(defaultSelectorKey)
+			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			Eventually(listEvents).WithArguments("default").WithTimeout(timeout).ShouldNot(BeEmpty())
 			allEvents := listEvents("default")
 			Expect(allEvents[0].Reason).To(Equal("ErrorReadingPaCSecret"))
@@ -151,7 +151,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 				return []github.ApplicationInstallation{generateInstallation(repositories)}, "slug", nil
 			}
 			componentNamespacedName := createComponentForPaCBuild(getComponentData(componentConfig{componentKey: types.NamespacedName{Name: "testnottrigger"}, gitURL: "https://github/test/repo3"}))
-			createDefaultBuildPipelineRunSelector(defaultSelectorKey)
+			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			Consistently(listJobs).WithArguments(BuildServiceNamespaceName).WithTimeout(time.Second * 5).Should(BeEmpty())
 
 			deleteComponent(componentNamespacedName)


### PR DESCRIPTION
build pipeline selector

[STONEBLD-2291](https://issues.redhat.com//browse/STONEBLD-2291)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable