### PR TITLE
Update image reference to quay.io/konflux-ci

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/redhat-appstudio/build-service
+  newName: quay.io/konflux-ci/build-service
   newTag: next


### PR DESCRIPTION
[STONEBLD-2336](https://issues.redhat.com//browse/STONEBLD-2336)

The downstream release configuration has been updated to release the
repo to quay.io/konflux-ci. Update the kustomize config accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable