### PR TITLE
Support retrieving latest bundle in Build Service

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -72,6 +72,7 @@ const (
 	buildPipelineSelectorResourceName  = "build-pipeline-selector"
 	defaultBuildPipelineAnnotation     = "build.appstudio.openshift.io/pipeline"
 	buildPipelineConfigMapResourceName = "build-pipeline-config"
+	buildPipelineConfigName            = "config.yaml"
 )
 
 type BuildStatus struct {
@@ -252,7 +253,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	pipelineRef, err := GetBuildPipelineFromComponentAnnotation(&component)
+	pipelineRef, err := r.GetBuildPipelineFromComponentAnnotation(ctx, &component)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Failed to read %s annotation on component %s", defaultBuildPipelineAnnotation, component.Name), l.Action, l.ActionView)
 

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -245,7 +245,7 @@ func TestGenerateInitialPipelineRunForComponentDevfileError(t *testing.T) {
 		browseRepositoryAtShaLink: "https://githost.com/user/repo?rev=" + commitSha,
 	}
 
-	_, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo)
+	_, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo, false)
 	if err == nil {
 		t.Error("generateInitialPipelineRunForComponentDevfileError(): Didn't return error")
 	} else {
@@ -303,7 +303,7 @@ func TestGenerateInitialPipelineRunForComponentDockerfileContext(t *testing.T) {
 		return &dockerfileImage, nil
 	}
 
-	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, &buildGitInfo{})
+	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, &buildGitInfo{}, false)
 
 	if err != nil {
 		t.Error("generateInitialPipelineRunForComponentDockerfileContext(): Failed to generate pipeline run")
@@ -377,7 +377,7 @@ func TestGenerateInitialPipelineRunForComponentDockerfileContextPipelineFromAnno
 		return &dockerfileImage, nil
 	}
 
-	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, &buildGitInfo{})
+	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, &buildGitInfo{}, true)
 
 	if err != nil {
 		t.Error("generateInitialPipelineRunForComponentDockerfileContext(): Failed to generate pipeline run")
@@ -449,7 +449,7 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 	}
 	DevfileSearchForDockerfile = devfile.SearchForDockerfile
 
-	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo)
+	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo, false)
 	if err != nil {
 		t.Error("generateInitialPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
@@ -580,7 +580,7 @@ func TestGenerateInitialPipelineRunForComponentPipelineFromAnnotation(t *testing
 		browseRepositoryAtShaLink: "https://githost.com/user/repo?rev=" + commitSha,
 	}
 
-	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo)
+	pipelineRun, err := generatePipelineRunForComponent(component, pipelineRef, additionalParams, pRunGitInfo, true)
 	if err != nil {
 		t.Error("generateInitialPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
@@ -727,7 +727,7 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	branchName := "custom-branch"
 	ResetTestGitProviderClient()
 
-	pipelineRun, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, true, branchName, testGitProviderClient)
+	pipelineRun, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, true, branchName, testGitProviderClient, false)
 	if err != nil {
 		t.Error("generatePaCPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
@@ -863,7 +863,7 @@ func TestGeneratePaCPipelineRunForComponentPipelineFromAnnotation(t *testing.T) 
 	branchName := "custom-branch"
 	ResetTestGitProviderClient()
 
-	pipelineRun, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, true, branchName, testGitProviderClient)
+	pipelineRun, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, true, branchName, testGitProviderClient, true)
 	if err != nil {
 		t.Error("generatePaCPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
@@ -984,7 +984,7 @@ func TestGeneratePaCPipelineRunForComponent_ShouldStopOnDevfileError(t *testing.
 	}
 	ResetTestGitProviderClient()
 
-	_, err := generatePaCPipelineRunForComponent(component, nil, nil, true, "main", testGitProviderClient)
+	_, err := generatePaCPipelineRunForComponent(component, nil, nil, true, "main", testGitProviderClient, false)
 	DevfileSearchForDockerfile = devfile.SearchForDockerfile
 	if err == nil {
 		t.Errorf("generatePaCPipelineRunForComponent(): expected error")
@@ -998,7 +998,7 @@ func TestGeneratePaCPipelineRunForComponent_ShouldStopOnDevfileError(t *testing.
 }
 
 func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSet(t *testing.T) {
-	_, err := generatePaCPipelineRunForComponent(nil, nil, nil, true, "", nil)
+	_, err := generatePaCPipelineRunForComponent(nil, nil, nil, true, "", nil, false)
 	if err == nil {
 		t.Errorf("generatePaCPipelineRunForComponent(): expected error")
 	}

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -83,16 +83,6 @@ type componentConfig struct {
 	annotations      map[string]string
 }
 
-type pipelineEntry struct {
-	Name   string `yaml:"name"`
-	Bundle string `yaml:"bundle"`
-}
-
-type pipelineConfig struct {
-	DefaultPipelineName string          `yaml:"default-pipeline-name"`
-	Pipelines           []pipelineEntry `yaml:"pipelines"`
-}
-
 func isOwnedBy(resource []metav1.OwnerReference, component appstudiov1alpha1.Component) bool {
 	if len(resource) == 0 {
 		return false
@@ -742,10 +732,10 @@ func createBuildPipelineConfigMap(configMapKey types.NamespacedName, pipelineBun
 	configMapData := map[string]string{}
 	buildPipelineData := pipelineConfig{
 		DefaultPipelineName: pipelineName,
-		Pipelines:           []pipelineEntry{{Name: pipelineName, Bundle: pipelineBundle}},
+		Pipelines:           []BuildPipeline{{Name: pipelineName, Bundle: pipelineBundle}},
 	}
 	yamlData, _ := yaml.Marshal(&buildPipelineData)
-	configMapData["config.yaml"] = string(yamlData)
+	configMapData[buildPipelineConfigName] = string(yamlData)
 
 	buildPipelineConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: configMapKey.Name, Namespace: configMapKey.Namespace},

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -164,6 +164,14 @@ const (
 	EUnsupportedPipelineRef BOErrorId = 302
 	// EMissingParamsForBundleResolver The pipelineRef selected for a component is missing parameters required for the bundle resolver.
 	EMissingParamsForBundleResolver BOErrorId = 303
+	// EWrongPipelineAnnotation Value of 'build.appstudio.openshift.io/pipeline' component annotation has wrong or missing values
+	EWrongPipelineAnnotation BOErrorId = 304
+	// EBuildPipelineConfigNotDefined build-pipeline-config configMap not found
+	EBuildPipelineConfigNotDefined BOErrorId = 305
+	// EBuildPipelineConfigNotValid build-pipeline-config configMap is not valid yaml
+	EBuildPipelineConfigNotValid BOErrorId = 306
+	// EBuildPipelineInvalid  pipeline in 'build.appstudio.openshift.io/pipeline' doesn't exist in build-pipeline-config configMap
+	EBuildPipelineInvalid BOErrorId = 307
 
 	// EPipelineRetrievalFailed Failed to retrieve a Tekton Pipeline.
 	EPipelineRetrievalFailed BOErrorId = 400
@@ -211,6 +219,10 @@ var boErrorMessages = map[BOErrorId]string{
 	EBuildPipelineSelectorNotDefined: "Build pipeline selector is not defined yet.",
 	EUnsupportedPipelineRef:          "The pipelineRef for this component (based on pipeline selectors) is not supported.",
 	EMissingParamsForBundleResolver:  "The pipelineRef for this component is missing required parameters ('name' and/or 'bundle').",
+	EWrongPipelineAnnotation:         "'build.appstudio.openshift.io/pipeline' component annotation has wrong or missing values",
+	EBuildPipelineConfigNotDefined:   "build-pipeline-config ConfigMap not found",
+	EBuildPipelineConfigNotValid:     "build-pipeline-config ConfigMap data in config.yaml is not valid yaml",
+	EBuildPipelineInvalid:            "pipeline referenced in 'build.appstudio.openshift.io/pipeline' annotation doesn't exist in build-pipeline-config ConfigMap",
 
 	EPipelineRetrievalFailed:  "Failed to retrieve the pipeline selected for this component.",
 	EPipelineConversionFailed: "Failed to convert the selected pipeline to the supported Tekton API version.",


### PR DESCRIPTION
in the new build.appstudio.openshift.io/pipeline annotation, bundle value can be 'latest', and in that case build service will get build-pipeline-config and get latest bundle from there

[STONEBLD-2448](https://issues.redhat.com//browse/STONEBLD-2448)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable