### PR TITLE
Updates for the build-definitions migration to konflux-ci

### DIFF
--- a/pkg/renovate/config.go
+++ b/pkg/renovate/config.go
@@ -87,7 +87,7 @@ func NewTektonJobConfig(platform, endpoint, username, gitAuthor string, reposito
 			SemanticCommits:      "enabled",
 			PRFooter:             "To execute skipped test pipelines write comment `/ok-to-test`",
 			PRBodyColumns:        []string{"Package", "Change", "Notes"},
-			PRBodyDefinitions:    fmt.Sprintf("{ \"Notes\": \"{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}\" }", renovatePattern),
+			PRBodyDefinitions:    fmt.Sprintf("{ \"Notes\": \"{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/konflux-ci/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}\" }", renovatePattern),
 			PRBodyTemplate:       "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
 			RecreateWhen:         "always",
 			RebaseWhen:           "behind-base-branch",

--- a/pkg/renovate/config.go
+++ b/pkg/renovate/config.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	RenovateMatchPatternEnvName = "RENOVATE_PATTERN"
-	DefaultRenovateMatchPattern = "^quay.io/redhat-appstudio-tekton-catalog/"
+	DefaultRenovateMatchPattern = "^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/"
 )
 
 var (


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
