### PR TITLE
Update the base image to ubi:9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 # Use ubi-minimal as minimal base image to package the manager binary
 # For more details and updates, refer to
 # https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 


### PR DESCRIPTION
Konflux reports CVEs in the base image. They should be addressed in the
new version.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
