### PR TITLE
Ignore Renovate's exit code

### DIFF
--- a/pkg/renovate/job.go
+++ b/pkg/renovate/job.go
@@ -84,7 +84,7 @@ func (j *JobCoordinator) Execute(ctx context.Context, tasks []*Task) error {
 
 		log.Info(fmt.Sprintf("Creating renovate config map entry with length %d and value %s", len(config), config))
 		renovateCmd = append(renovateCmd,
-			fmt.Sprintf("RENOVATE_TOKEN=$TOKEN_%s RENOVATE_CONFIG_FILE=/configs/%s.json renovate", taskId, taskId),
+			fmt.Sprintf("RENOVATE_TOKEN=$TOKEN_%s RENOVATE_CONFIG_FILE=/configs/%s.json renovate || true", taskId, taskId),
 		)
 	}
 	if len(renovateCmd) == 0 {


### PR DESCRIPTION
Override Renovatge's exit code to avoid Job failure if provided git credentials are incorrect.
Context https://issues.redhat.com/browse/STONEBLD-2428 
<img width="1715" alt="Знімок екрана 2024-06-07 о 10 53 43" src="https://github.com/konflux-ci/build-service/assets/1614429/348f0d40-f5b4-4704-8bb6-72550c8a36c4">
1. with changes and valid token
2. with changes and invalid token
3. (4)with main and invalid token
