### PR TITLE
handle wrong pac token for gitlab as permanent errors

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -274,13 +274,16 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(ctx context.Context, componen
 		return false, err
 	}
 
+	// getting branch in advance just to test credentials
+	defaultBranch, err := gitClient.GetDefaultBranch(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
 	// get target branch for incoming hook
 	targetBranch := component.Spec.Source.GitSource.Revision
 	if targetBranch == "" {
-		targetBranch, err = gitClient.GetDefaultBranch(repoUrl)
-		if err != nil {
-			return false, err
-		}
+		targetBranch = defaultBranch
 	}
 
 	incomingUpdated := updateIncoming(repository, incomingSecret.Name, pacIncomingSecretKey, targetBranch)
@@ -959,12 +962,15 @@ func (r *ComponentBuildReconciler) ConfigureRepositoryForPaC(ctx context.Context
 		return "", err
 	}
 
+	// getting branch in advance just to test credentials
+	defaultBranch, err := gitClient.GetDefaultBranch(repoUrl)
+	if err != nil {
+		return "", err
+	}
+
 	baseBranch := component.Spec.Source.GitSource.Revision
 	if baseBranch == "" {
-		baseBranch, err = gitClient.GetDefaultBranch(repoUrl)
-		if err != nil {
-			return "", err
-		}
+		baseBranch = defaultBranch
 	}
 
 	pipelineRunOnPushYaml, pipelineRunOnPRYaml, err := r.generatePaCPipelineRunConfigs(ctx, component, gitClient, baseBranch)
@@ -1034,6 +1040,12 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPaC(ctx context.Conte
 		return "", "", "", err
 	}
 
+	// getting branch in advance just to test credentials
+	defaultBranch, err := gitClient.GetDefaultBranch(repoUrl)
+	if err != nil {
+		return "", "", "", err
+	}
+
 	isAppUsed := IsPaCApplicationConfigured(gitProvider, pacConfig)
 	if !isAppUsed {
 		if webhookTargetUrl != "" {
@@ -1052,10 +1064,7 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPaC(ctx context.Conte
 	sourceBranch := generateMergeRequestSourceBranch(component)
 	baseBranch = component.Spec.Source.GitSource.Revision
 	if baseBranch == "" {
-		baseBranch, err = gitClient.GetDefaultBranch(repoUrl)
-		if err != nil {
-			return "", "", "", nil
-		}
+		baseBranch = defaultBranch
 	}
 
 	mrData := &gp.MergeRequestData{

--- a/controllers/component_build_controller_simple_build.go
+++ b/controllers/component_build_controller_simple_build.go
@@ -131,6 +131,12 @@ func (r *ComponentBuildReconciler) getBuildGitInfo(ctx context.Context, componen
 		return nil, err
 	}
 
+	// getting branch just to test credentials
+	_, err = gitClient.GetDefaultBranch(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
 	var gitSecretName string
 	isPublic, err := gitClient.IsRepositoryPublic(repoUrl)
 	if err != nil {

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -136,8 +136,8 @@ const (
 	EGitLabTokenUnauthorized BOErrorId = 90
 	// EGitLabTokenInsufficientScope the access token does not have sufficient scope and 403 is responded.
 	EGitLabTokenInsufficientScope BOErrorId = 91
-	// EGitLabSecretInvalid the secret with GitLab credentials is invalid.
-	EGitLabSecretInvalid BOErrorId = 92
+	// EGitLabTokenBlockedAccount  access token has blocked account
+	EGitLabTokenBlockedAccount BOErrorId = 92
 	// EGitLabSecretTypeNotSupported the secret type with GitLab credentials is not supported.
 	EGitLabSecretTypeNotSupported BOErrorId = 93
 
@@ -203,6 +203,8 @@ var boErrorMessages = map[BOErrorId]string{
 
 	EGitLabTokenInsufficientScope: "GitLab access token does not have enough scope",
 	EGitLabTokenUnauthorized:      "Access token is unrecognizable by remote GitLab service",
+	EGitLabTokenBlockedAccount:    "Access token has blocked account",
+	EGitLabSecretTypeNotSupported: "The secret type with GitLab credentials is not supported",
 
 	EFailedToParseImageAnnotation:        "Failed to parse image.redhat.com/image annotation value",
 	EComponentGitSecretMissing:           "Secret with git credential not found",


### PR DESCRIPTION
when secret has just password and not username error looks like: GET https://gitlab.com/api/v4/projects/namespace/project: 401 {message: 401 Unauthorized}

when secret has both password and username error looks like: oauth2: "invalid_grant" "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."

also handle blocked account which error looks like: message: 403 Forbidden - Your account has been blocked.

[STONEBLD-2463](https://issues.redhat.com//browse/STONEBLD-2463)
[STONEBLD-2464](https://issues.redhat.com//browse/STONEBLD-2464)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable