### PR TITLE
Revert some gitlab permanent error checks introduced in PR #315 for simple build

### DIFF
--- a/controllers/component_build_controller_simple_build.go
+++ b/controllers/component_build_controller_simple_build.go
@@ -131,12 +131,6 @@ func (r *ComponentBuildReconciler) getBuildGitInfo(ctx context.Context, componen
 		return nil, err
 	}
 
-	// getting branch just to test credentials
-	_, err = gitClient.GetDefaultBranch(repoUrl)
-	if err != nil {
-		return nil, err
-	}
-
 	var gitSecretName string
 	isPublic, err := gitClient.IsRepositoryPublic(repoUrl)
 	if err != nil {


### PR DESCRIPTION
Reverting some checks for gitlab permanent errors introduced in https://github.com/konflux-ci/build-service/pull/315 because the changes cause e2e tests failures in https://github.com/redhat-appstudio/infra-deployments/pull/3863:
```
2024-06-21T04:24:43.950Z	ERROR	ComponentOnboarding	controllers/component_build_controller.go:359	simple build submition for the Component failed	{"controller": "component", "controllerGroup": "appstudio.redhat.com", "controllerKind": "Component", "Component": {"name":"mc-golang-nodevfile","namespace":"rhtap-demo-huox-tenant"}, "namespace": "rhtap-demo-huox-tenant", "name": "mc-golang-nodevfile", "reconcileID": "310758b7-d68d-46aa-b6ce-76450c35c9bf", "ComponentGitSource": {"url":"https://github.com/redhat-appstudio-qe/devfile-sample-go-basic-dockerfile-only-private.git","dockerfileUrl":"docker/Dockerfile"}, "error": "GET https://api.github.com/repos/redhat-appstudio-qe/devfile-sample-go-basic-dockerfile-only-private: 404 Not Found [] No scope is found from response header. Check it from GitHub settings."}
```
The root cause is that siple build relying on the secret in component spec which is not counted in the recently added extra check.
Since simple build is deprecated and is rarely use and moreover with gitlab corner cases, it's safe to not to do the checks.
