### PR TITLE
Dependency update controller should consider non-existing component as

### DIFF
--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -178,6 +178,12 @@ func (r *ComponentDependencyUpdateReconciler) Reconcile(ctx context.Context, req
 			patch := client.MergeFrom(pipelineRun.DeepCopy())
 			return r.removePipelineFinalizer(ctx, pipelineRun, patch)
 		}
+
+		// When component doesn't exist handle it as permanent error
+		if errors.IsNotFound(err) {
+			log.Error(err, "component doesn't exist")
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
permanent error, and don't retry on it

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable