### PR TITLE
Ignore PaC 504 error

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -298,9 +298,9 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(ctx context.Context, componen
 	}
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		// ignore 503 for now, until PAC fixes issue https://issues.redhat.com/browse/SRVKP-4352
+		// ignore 503 and 504 for now, until PAC fixes issue https://issues.redhat.com/browse/SRVKP-4352
 		log.Info(fmt.Sprintf("PaC incoming endpoint %s returned HTTP %d", triggerURL, resp.StatusCode))
-		if resp.StatusCode == 503 {
+		if resp.StatusCode == 503 || resp.StatusCode == 504 {
 			return false, nil
 		}
 		return false, fmt.Errorf("PaC incoming endpoint returned HTTP %d", resp.StatusCode)


### PR DESCRIPTION
workaround for https://issues.redhat.com/browse/SRVKP-4352

With the 503 PaC error fixed, long running requests are hitting another timeout, this time on the OCP route (default 30s), resulting 504 error. Both timeouts are covered in
https://github.com/openshift-pipelines/pipelines-as-code/pull/1747, yet this allows safer transition to the fixed version. Once running the fixed version and no errors recorded, we'll stop ignoring those errors.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable