### PR TITLE
Improve the heuristic for guessing the git provider

### DIFF
--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -1267,6 +1267,16 @@ func TestGetGitProvider(t *testing.T) {
 			want:             "github",
 		},
 		{
+			name:             "should detect non-standard github provider via http url",
+			componentRepoUrl: "https://cooler.github.my-company.com/user/test-component-repository",
+			want:             "github",
+		},
+		{
+			name:             "should detect non-standard github provider via git url",
+			componentRepoUrl: "git@cooler.github.my-company.com:user/test-component-repository",
+			want:             "github",
+		},
+		{
 			name:             "should detect gitlab provider via http url",
 			componentRepoUrl: "https://gitlab.com/user/test-component-repository",
 			want:             "gitlab",
@@ -1277,6 +1287,16 @@ func TestGetGitProvider(t *testing.T) {
 			want:             "gitlab",
 		},
 		{
+			name:             "should detect non-standard gitlab provider via http url",
+			componentRepoUrl: "https://cooler.gitlab.my-company.com/user/test-component-repository",
+			want:             "gitlab",
+		},
+		{
+			name:             "should detect non-standard gitlab provider via git url",
+			componentRepoUrl: "git@cooler.gitlab.my-company.com:user/test-component-repository",
+			want:             "gitlab",
+		},
+		{
 			name:             "should detect bitbucket provider via http url",
 			componentRepoUrl: "https://bitbucket.org/user/test-component-repository",
 			want:             "bitbucket",
@@ -1284,6 +1304,16 @@ func TestGetGitProvider(t *testing.T) {
 		{
 			name:             "should detect bitbucket provider via git url",
 			componentRepoUrl: "git@bitbucket.org:user/test-component-repository",
+			want:             "bitbucket",
+		},
+		{
+			name:             "should detect non-standard bitbucket provider via http url",
+			componentRepoUrl: "https://cooler.bitbucket.my-company.com/user/test-component-repository",
+			want:             "bitbucket",
+		},
+		{
+			name:             "should detect non-standard bitbucket provider via git url",
+			componentRepoUrl: "git@cooler.bitbucket.my-company.com:user/test-component-repository",
 			want:             "bitbucket",
 		},
 		{

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -1335,6 +1335,12 @@ func TestGetGitProvider(t *testing.T) {
 			want:                           "bitbucket",
 		},
 		{
+			name:                           "should prefer the annotation over the url",
+			componentRepoUrl:               "https://not.github.my-company.com/user/test-component-repository",
+			componentGitProviderAnnotation: "gitlab",
+			want:                           "gitlab",
+		},
+		{
 			name:             "should fail to detect git provider for self-hosted instance if annotation is not set",
 			componentRepoUrl: "https://mydomain.com/user/test-component-repository",
 			expectError:      true,


### PR DESCRIPTION
[KFLUXBUGS-1559](https://issues.redhat.com//browse/KFLUXBUGS-1559)

Previously, the function guessed the provider based on a specific
segment in the hostname in the repo url.

For a host like cooler.gitlab.my-company.com, the returned provider
would be (depending on whether the repo url is git@ -style or not):

    git@cooler.gitlab.my-company.com:org/repo
        ^^^^^^

    https://cooler.gitlab.my-company.com/org/repo.git
                          ^^^^^^^^^^

Fix the heuristic and make it much looser - now it just searches the
hostname for substrings corresponding to the known git providers.

Note: in the highly unusual case where a hostname contains substrings
corresponding to more than one provider, the precedence is github >
gitlab > bitbucket. (Making the precedence deterministic is the reason
why allowedGitProviders had to change from a map to a slice).

### Checklist:
 - Update readme and documentation - TODO (internal documentation only)