### PR TITLE
incoming webhook trigger doesn't work with gitlab,

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -189,7 +189,7 @@ func validatePaCConfiguration(gitProvider string, pacSecret corev1.Secret) error
 			}
 			return nil
 		}
-		return fmt.Errorf(fmt.Sprintf("There is no applications for %s", gitProvider))
+		return fmt.Errorf("There is no applications for %s", gitProvider)
 	}
 
 	switch pacSecret.Type {

--- a/controllers/component_build_controller_pac_repository.go
+++ b/controllers/component_build_controller_pac_repository.go
@@ -225,6 +225,15 @@ func generatePACRepository(component appstudiov1alpha1.Component, config *corev1
 		gitProviderConfig.URL = url
 	}
 
+	if gitProviderConfig != nil {
+		repositoryGitProvider := gitProvider
+		// https://pipelinesascode.com/docs/guide/incoming_webhook/#incoming-webhook-url
+		if repositoryGitProvider == "bitbucket" {
+			repositoryGitProvider = "bitbucket-cloud"
+		}
+		gitProviderConfig.Type = repositoryGitProvider
+	}
+
 	repository := &pacv1alpha1.Repository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Repository",

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -1008,6 +1008,7 @@ func TestGeneratePACRepository(t *testing.T) {
 					Name: pipelinesAsCodeWebhooksSecretName,
 					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.com/user/test-component-repository", nil)),
 				},
+				Type: "github",
 			},
 		},
 		{
@@ -1025,7 +1026,8 @@ func TestGeneratePACRepository(t *testing.T) {
 					Name: pipelinesAsCodeWebhooksSecretName,
 					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository/", nil)),
 				},
-				URL: "https://gitlab.com",
+				URL:  "https://gitlab.com",
+				Type: "gitlab",
 			},
 		},
 		{
@@ -1045,7 +1047,8 @@ func TestGeneratePACRepository(t *testing.T) {
 					Name: pipelinesAsCodeWebhooksSecretName,
 					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository", nil)),
 				},
-				URL: "https://gitlab.com",
+				URL:  "https://gitlab.com",
+				Type: "gitlab",
 			},
 		},
 		{
@@ -1066,7 +1069,8 @@ func TestGeneratePACRepository(t *testing.T) {
 					Name: pipelinesAsCodeWebhooksSecretName,
 					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil)),
 				},
-				URL: "https://gitlab.self-hosted.com",
+				URL:  "https://gitlab.self-hosted.com",
+				Type: "gitlab",
 			},
 		},
 		{
@@ -1088,7 +1092,8 @@ func TestGeneratePACRepository(t *testing.T) {
 					Name: pipelinesAsCodeWebhooksSecretName,
 					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil)),
 				},
-				URL: "https://gitlab.self-hosted-proxy.com",
+				URL:  "https://gitlab.self-hosted-proxy.com",
+				Type: "gitlab",
 			},
 		},
 		{
@@ -1103,7 +1108,8 @@ func TestGeneratePACRepository(t *testing.T) {
 				PipelinesAsCodeGithubPrivateKey: []byte("private-key"),
 			},
 			expectedGitProviderConfig: &pacv1alpha1.GitProvider{
-				URL: "https://github.self-hosted.com",
+				URL:  "https://github.self-hosted.com",
+				Type: "github",
 			},
 		},
 	}


### PR DESCRIPTION
Repository CR, needs spec->git_provider->type specified for anything what isn't github app

[STONEBLD-2681](https://issues.redhat.com//browse/STONEBLD-2681)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable