### PR TITLE
chore: Adjusting OWNERS file and fix Github Action CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,12 +27,13 @@ jobs:
 
       # https://github.com/securego/gosec/blob/12be14859bc7d4b956b71bef0b443694aa519d8a/README.md#integrating-with-code-scanning
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+      # pin gosec to use v2.21.0 temporarily, once upstream issue https://github.com/securego/gosec/issues/1214 is fixed, revert it to use master
+        uses: securego/gosec@v2.21.0
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif ./...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/OWNERS
+++ b/OWNERS
@@ -3,12 +3,12 @@
 approvers:
 - mmorhun
 - psturc
-- Michkov
+- tisutisu
 
 reviewers:
 - mmorhun
 - psturc
-- Michkov
+- tisutisu
 
 # 'Build team' members that are not members of openshift github org (could be added in a future):
 # - brunoapimentel


### PR DESCRIPTION
- Removing `Michov` (he already left Redhat). Adding myself to the OWNERS file, so that I can help with review/approve PRs in case someone is in PTO.
- upload-sarif GA is failing with error `Error: Unable to upload "results.sarif" as it is not valid SARIF:` for which a upstream issue https://github.com/securego/gosec/issues/1214 is open, using gosec version of 2.21 temporarily, till it is fixed in upstream
- seeing a warning like `Warning: CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/` , so updated workflow to use v3 of upload-sarif action

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable