### PR TITLE
fix: repo annotation for GitLab subgroups

### DIFF
--- a/pkg/git/gitlab/gitlab_client.go
+++ b/pkg/git/gitlab/gitlab_client.go
@@ -318,13 +318,7 @@ func (g *GitlabClient) IsRepositoryPublic(repoUrl string) (bool, error) {
 // GetBrowseRepositoryAtShaLink returns web URL of repository state at given SHA
 func (g *GitlabClient) GetBrowseRepositoryAtShaLink(repoUrl, sha string) string {
 	repoUrl = strings.TrimSuffix(repoUrl, ".git")
-	gitSourceUrlParts := strings.Split(repoUrl, "/")
-	gitProviderHost := "https://" + gitSourceUrlParts[2]
-	gitlabNamespace := gitSourceUrlParts[3]
-	gitlabProjectName := gitSourceUrlParts[4]
-	projectPath := gitlabNamespace + "/" + gitlabProjectName
-
-	return fmt.Sprintf("%s/%s/-/tree/%s", gitProviderHost, projectPath, sha)
+	return fmt.Sprintf("%s/-/tree/%s", repoUrl, sha)
 }
 
 func (g *GitlabClient) GetConfiguredGitAppName() (string, string, error) {

--- a/pkg/git/gitlab/gitlab_client_test.go
+++ b/pkg/git/gitlab/gitlab_client_test.go
@@ -1,0 +1,50 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetBrowseRepositoryAtShaLink(t *testing.T) {
+	baseUrl := "https://gitlab.cee.foo.com"
+
+	// "{{revision}}" is used in the pipeline generation
+	revisionArgument := "{{revision}}"
+
+	expectedEnding := fmt.Sprintf("-/tree/%s", revisionArgument)
+	testCases := []struct {
+		TestName string
+		RepoUrl  string
+		SHA      string
+		Result   string
+	}{
+		{
+			TestName: "Basic repository",
+			RepoUrl:  fmt.Sprintf("%s/group/repo", baseUrl),
+			Result:   fmt.Sprintf("%s/group/repo/%s", baseUrl, expectedEnding),
+		},
+		{
+			TestName: "Repository in a subgroup",
+			RepoUrl:  fmt.Sprintf("%s/group/subgroup/repo", baseUrl),
+			Result:   fmt.Sprintf("%s/group/subgroup/repo/%s", baseUrl, expectedEnding),
+		},
+		{
+			TestName: "Repository ending with '.git'",
+			RepoUrl:  fmt.Sprintf("%s/group/subgroup/repo.git", baseUrl),
+			Result:   fmt.Sprintf("%s/group/subgroup/repo/%s", baseUrl, expectedEnding),
+		},
+	}
+
+	glClient, err := NewGitlabClient("", baseUrl)
+	if err != nil {
+		t.Fatal("Failed to create Gitlab client")
+	}
+	for _, tc := range testCases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			result := glClient.GetBrowseRepositoryAtShaLink(tc.RepoUrl, revisionArgument)
+			if result != tc.Result {
+				t.Errorf("got %s, want %s", result, tc.Result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[KFLUXBUGS-1552](https://issues.redhat.com/browse/KFLUXBUGS-1552)
- generation of `build.appstudio.openshift.io/repo` annotation ignores subgroups in GitLab URLs, e.g.
`gitlab.com/group/subgroup/reponame`
- include unit tests