### PR TITLE
create temporary config map with CA certificate based on one in

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -579,6 +579,19 @@ func createBuildPipelineConfigMap(configMapKey types.NamespacedName, pipelineBun
 	}
 }
 
+func createCAConfigMap(configMapKey types.NamespacedName) {
+	configMapData := map[string]string{CaConfigMapKey: "someCAcertdata"}
+
+	caConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapKey.Name, Namespace: configMapKey.Namespace, Labels: map[string]string{CaConfigMapLabel: "true"}},
+		Data:       configMapData,
+	}
+
+	if err := k8sClient.Create(ctx, &caConfigMap); err != nil && !k8sErrors.IsAlreadyExists(err) {
+		Fail(err.Error())
+	}
+}
+
 func waitServiceAccount(serviceAccountKey types.NamespacedName) corev1.ServiceAccount {
 	serviceAccount := corev1.ServiceAccount{}
 	Eventually(func() bool {


### PR DESCRIPTION
build-service namespace if it exists, so renovate pod can mount it and use it against gitlab.cee.redhat.com

[KFLUXBUGS-1744](https://issues.redhat.com//browse/KFLUXBUGS-1744)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable