### PR TITLE
when POST fails, buils-service starts another reconcile, but PaC

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -299,7 +299,8 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(ctx context.Context, componen
 	resp, err := HttpClient.Post(triggerURL, "application/json", bytes.NewBuffer(bytesParam))
 
 	if err != nil {
-		return false, err
+		log.Error(err, "error from incoming webhook trigger POST")
+		return false, nil
 	}
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {


### PR DESCRIPTION
actually triggers new build, resulting in endless pipelines

temporary workaround for KFLUXBUGS-1858

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable