### PR TITLE
Allow to omit PaC config proposal PR creation

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -44,10 +44,11 @@ import (
 )
 
 const (
-	BuildRequestAnnotationName                 = "build.appstudio.openshift.io/request"
-	BuildRequestTriggerPaCBuildAnnotationValue = "trigger-pac-build"
-	BuildRequestConfigurePaCAnnotationValue    = "configure-pac"
-	BuildRequestUnconfigurePaCAnnotationValue  = "unconfigure-pac"
+	BuildRequestAnnotationName                  = "build.appstudio.openshift.io/request"
+	BuildRequestTriggerPaCBuildAnnotationValue  = "trigger-pac-build"
+	BuildRequestConfigurePaCAnnotationValue     = "configure-pac"
+	BuildRequestConfigurePaCNoMrAnnotationValue = "configure-pac-no-mr"
+	BuildRequestUnconfigurePaCAnnotationValue   = "unconfigure-pac"
 
 	BuildStatusAnnotationName = "build.appstudio.openshift.io/status"
 
@@ -63,8 +64,6 @@ const (
 	gitRepoAtShaAnnotationName    = "build.appstudio.openshift.io/repo"
 	gitTargetBranchAnnotationName = "build.appstudio.redhat.com/target_branch"
 
-	ImageRepoAnnotationName         = "image.redhat.com/image"
-	ImageRepoGenerateAnnotationName = "image.redhat.com/generate"
 	buildPipelineServiceAccountName = "appstudio-pipeline"
 
 	defaultBuildPipelineAnnotation     = "build.appstudio.openshift.io/pipeline"
@@ -324,7 +323,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			bometrics.PushPipelineRebuildTriggerTimeMetric.Observe(time.Since(bometrics.ComponentTimesForMetrics[componentIdForMetrics].StartTimestamp).Seconds())
 		}
 
-	case BuildRequestConfigurePaCAnnotationValue:
+	case BuildRequestConfigurePaCAnnotationValue, BuildRequestConfigurePaCNoMrAnnotationValue:
 		updateMetricsTimes(componentIdForMetrics, requestedAction, reconcileStartTime)
 		// initial build upon component creation (doesn't have either build status)
 		initialBuild := func() bool {

--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -498,6 +498,12 @@ func (r *ComponentBuildReconciler) ConfigureRepositoryForPaC(ctx context.Context
 		}
 	}
 
+	// It might seem that there is more optimal way of doing this.
+	// However, this use case is not often used, so making logic above more complicated does not worth it.
+	if component.Annotations[BuildRequestAnnotationName] == BuildRequestConfigurePaCNoMrAnnotationValue {
+		// User requested not to create a proposal PR.
+		return "", nil
+	}
 	return gitClient.EnsurePaCMergeRequest(repoUrl, mrData)
 }
 


### PR DESCRIPTION
For some gitops scenarios it miight be useful to omit PaC proposal PRs creation if pipeline configs are created automatically on user's side. In order to have such behavior, instead of requesting `configure-pac` action, one need to request `configure-pac-no-mr`.

Example:
```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: Component
metadata:
  name: my-component
  namespace: my-tenant
  annotations:
    build.appstudio.openshift.io/request: configure-pac-no-mr
spec:
  ...
```