### PR TITLE
move ensureIncomingSecret call after checking that repository actually

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -216,11 +216,6 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(ctx context.Context, componen
 	log := ctrllog.FromContext(ctx).WithName("TriggerPaCBuild")
 	ctx = ctrllog.IntoContext(ctx, log)
 
-	incomingSecret, reconcileRequired, err := r.ensureIncomingSecret(ctx, component)
-	if err != nil {
-		return false, err
-	}
-
 	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return false, err
@@ -228,6 +223,11 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(ctx context.Context, componen
 
 	if repository == nil {
 		return false, fmt.Errorf("PaC repository not found for component %s", component.Name)
+	}
+
+	incomingSecret, reconcileRequired, err := r.ensureIncomingSecret(ctx, component)
+	if err != nil {
+		return false, err
 	}
 
 	repoUrl := component.Spec.Source.GitSource.URL


### PR DESCRIPTION
exists, because if it doesn't it would fail with panic in ensureIncomingSecret

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable