### PR TITLE
feat: use ci-helper-app (test results analyzer)

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -48,7 +48,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -58,7 +58,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -68,35 +68,19 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-    - name: create-oci-container
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/create-oci-artifact/0.1/create-oci-artifact.yaml
-      params:
-        - name: oci-container-repo
-          value: $(params.oci-container-repo)
-        - name: oci-container-tag
-          value: $(context.pipelineRun.name)
     - name: provision-rosa
       runAfter:
         - rosa-hcp-metadata
         - test-metadata
-        - create-oci-container
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
       params:
         - name: cluster-name
           value: $(tasks.rosa-hcp-metadata.results.cluster-name)
@@ -110,6 +94,8 @@ spec:
           value: $(params.konflux-test-infra-secret)
         - name: cloud-credential-key
           value: $(params.cloud-credential-key)
+        - name: oci-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:
@@ -133,7 +119,7 @@ spec:
         - name: git-revision
           value: $(tasks.test-metadata.results.git-revision)
         - name: oras-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: job-spec
           value: $(tasks.test-metadata.results.job-spec)
         - name: ocp-login-command
@@ -146,18 +132,18 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)
         - name: ocp-login-command
           value: $(tasks.provision-rosa.results.ocp-login-command)
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: pull-request-author
           value: $(tasks.test-metadata.results.pull-request-author)
         - name: git-revision
@@ -181,14 +167,14 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
             value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
       params:
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: quality-dashboard-api
           value: $(params.quality-dashboard-api)
         - name: pipeline-aggregate-status
@@ -202,7 +188,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -211,7 +197,7 @@ spec:
         - name: test-name
           value: $(context.pipelineRun.name)
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: pipeline-aggregate-status
           value: $(tasks.status)
         - name: pull-request-author
@@ -224,3 +210,11 @@ spec:
           value: $(tasks.test-metadata.results.git-org)
         - name: git-revision
           value: $(tasks.test-metadata.results.git-revision)
+        - name: junit-report-name
+          value: e2e-report.xml
+        - name: e2e-log-name
+          value: e2e-tests.log
+        - name: cluster-provision-log-name
+          value: cluster-provision.log
+        - name: enable-test-results-analysis
+          value: "true"


### PR DESCRIPTION
### Description
* `create-oci-container task`, that was used for creation of OCI artifact in ref for storing test results was removed, because the creation of artifact is now handled automatically by [secure-push-oci StepAction](https://github.com/konflux-ci/tekton-integration-catalog/blob/f2e422b0b0d22925ddc6b2cab4748923b8e8ff6d/stepactions/secure-push-oci/0.1/secure-push-oci.yaml), which is now used in [0.2 version of rosa-(de)provision-hcp tasks](https://github.com/konflux-ci/tekton-integration-catalog/blob/e592f3ece893498116d896cbde0ba90761a6a94a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml#L187) and [e2e-test task](https://github.com/konflux-ci/e2e-tests/blob/9a6c4554c393b526a24c3b137a59faae436afc61/integration-tests/tasks/konflux-e2e-tests-task.yaml#L151)
* [test results analyzer](https://github.com/konflux-ci/tekton-integration-catalog/blob/e592f3ece893498116d896cbde0ba90761a6a94a/common/tasks/pull-request-comment/0.1/pull-request-comment.yaml#L58-L81), that provides more information about failed CI runs, was enabled - due to that [new params were added to the pull-request-comment task](https://github.com/konflux-ci/build-service/pull/387/files#diff-642a5657e437b7abe9d81849a1ec198ee32c73420ab078e75ed87f9c4158af1aR213-R220)


### JIRA
https://issues.redhat.com/browse/KFLUXDP-42