### PR TITLE
Use custom renovate config maps for additional renovate options

### DIFF
--- a/controllers/component_build_controller_pipeline.go
+++ b/controllers/component_build_controller_pipeline.go
@@ -296,11 +296,11 @@ func generatePaCPipelineRunForComponent(
 
 	annotations := map[string]string{
 		"pipelinesascode.tekton.dev/cancel-in-progress": "false",
-		"pipelinesascode.tekton.dev/max-keep-runs": "3",
-		"build.appstudio.redhat.com/target_branch": "{{target_branch}}",
-		pacCelExpressionAnnotationName:             pipelineCelExpression,
-		gitCommitShaAnnotationName:                 "{{revision}}",
-		gitRepoAtShaAnnotationName:                 gitClient.GetBrowseRepositoryAtShaLink(repoUrl, "{{revision}}"),
+		"pipelinesascode.tekton.dev/max-keep-runs":      "3",
+		"build.appstudio.redhat.com/target_branch":      "{{target_branch}}",
+		pacCelExpressionAnnotationName:                  pipelineCelExpression,
+		gitCommitShaAnnotationName:                      "{{revision}}",
+		gitRepoAtShaAnnotationName:                      gitClient.GetBrowseRepositoryAtShaLink(repoUrl, "{{revision}}"),
 	}
 	labels := map[string]string{
 		ApplicationNameLabelName:                component.Spec.Application,

--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -417,10 +417,11 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 		targets = append(targets, newTargets...)
 	}
 
+	gitRepoAtShaLink := pipelineRun.Annotations[gitRepoAtShaAnnotationName]
 	if len(targets) > 0 {
 		log.Info("will create renovate job")
 		buildResult := BuildResult{BuiltImageRepository: repo, BuiltImageTag: tag, Digest: digest, Component: updatedComponent, DistributionRepositories: distibutionRepositories, FileMatches: nudgeFiles}
-		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun.Namespace, targets, true, &buildResult)
+		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun.Namespace, targets, true, &buildResult, gitRepoAtShaLink)
 	} else {
 		log.Info("no targets found to update")
 	}

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -527,6 +527,18 @@ func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationNa
 	}, timeout, interval).Should(BeTrue())
 }
 
+func waitComponentAnnotationExists(componentKey types.NamespacedName, annotationName string) {
+	Eventually(func() bool {
+		component := getComponent(componentKey)
+		annotations := component.GetAnnotations()
+		if annotations == nil {
+			return false
+		}
+		_, exists := annotations[annotationName]
+		return exists
+	}, timeout, interval).Should(BeTrue())
+}
+
 func createRoute(routeKey types.NamespacedName, host string) {
 	route := routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
@@ -590,6 +602,32 @@ func createCAConfigMap(configMapKey types.NamespacedName) {
 	if err := k8sClient.Create(ctx, &caConfigMap); err != nil && !k8sErrors.IsAlreadyExists(err) {
 		Fail(err.Error())
 	}
+}
+
+func createCustomRenovateConfigMap(configMapKey types.NamespacedName, configMapData map[string]string) {
+	customConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapKey.Name, Namespace: configMapKey.Namespace},
+		Data:       configMapData,
+	}
+	if err := k8sClient.Create(ctx, &customConfigMap); err != nil && !k8sErrors.IsAlreadyExists(err) {
+		Fail(err.Error())
+	}
+}
+
+func deleteConfigMap(configMapKey types.NamespacedName) {
+	configMap := corev1.ConfigMap{}
+	if err := k8sClient.Get(ctx, configMapKey, &configMap); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return
+		}
+		Fail(err.Error())
+	}
+	if err := k8sClient.Delete(ctx, &configMap); err != nil && !k8sErrors.IsNotFound(err) {
+		Fail(err.Error())
+	}
+	Eventually(func() bool {
+		return k8sErrors.IsNotFound(k8sClient.Get(ctx, configMapKey, &configMap))
+	}, timeout, interval).Should(BeTrue())
 }
 
 func waitServiceAccount(serviceAccountKey types.NamespacedName) corev1.ServiceAccount {


### PR DESCRIPTION
namespace one will be used if there isn't component's annotation with specific config map

[KONFLUX-4372](https://issues.redhat.com//browse/KONFLUX-4372)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable