### PR TITLE
Add support for canceling in-progress pipeline runs

### DIFF
--- a/controllers/component_build_controller_pipeline.go
+++ b/controllers/component_build_controller_pipeline.go
@@ -295,6 +295,7 @@ func generatePaCPipelineRunForComponent(
 	repoUrl := component.Spec.Source.GitSource.URL
 
 	annotations := map[string]string{
+		"pipelinesascode.tekton.dev/cancel-in-progress": "false",
 		"pipelinesascode.tekton.dev/max-keep-runs": "3",
 		"build.appstudio.redhat.com/target_branch": "{{target_branch}}",
 		pacCelExpressionAnnotationName:             pipelineCelExpression,
@@ -312,6 +313,7 @@ func generatePaCPipelineRunForComponent(
 	var pipelineName string
 	var proposedImage string
 	if onPull {
+		annotations["pipelinesascode.tekton.dev/cancel-in-progress"] = "true"
 		annotations["build.appstudio.redhat.com/pull_request_number"] = "{{pull_request_number}}"
 		pipelineName = component.Name + pipelineRunOnPRSuffix
 		proposedImage = imageRepo + ":on-pr-{{revision}}"

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -263,6 +263,9 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	if pipelineRun.Annotations["pipelinesascode.tekton.dev/max-keep-runs"] != "3" {
 		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/max-keep-runs annotation value")
 	}
+	if pipelineRun.Annotations["pipelinesascode.tekton.dev/cancel-in-progress"] != "true" {
+		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/cancel-in-progress annotation value")
+	}
 	if pipelineRun.Annotations["build.appstudio.redhat.com/target_branch"] != "{{target_branch}}" {
 		t.Error("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/target_branch annotation value")
 	}


### PR DESCRIPTION
With PAC v0.32.0, support was added to cancel in-progress pipeline runs, see:
https://pipelinesascode.com/docs/guide/running/#cancelling-in-progress-pipelineruns. Even if this version of PAC is not deployed, by starting to add the annotation, users can take advantage of the functionality when it is deployed.

ref: https://github.com/openshift-pipelines/pipelines-as-code/releases/tag/v0.32.0

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable