### PR TITLE
metrics: use token from metrics-reader secret directly

### DIFF
--- a/config/monitoring/prometheus/monitor.yaml
+++ b/config/monitoring/prometheus/monitor.yaml
@@ -12,7 +12,10 @@ spec:
     - path: /metrics
       port: https
       scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
       tlsConfig:
         insecureSkipVerify: true
   selector:


### PR DESCRIPTION
Prometheus isn't allowing filesystem access for service monitor resources, so reference the token from the metrics-reader secret directly.  The bearerTokenFile and bearerTokenSecret fields are deprecated, so use the authorization field instead.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable