### PR TITLE
additional git url validations

### DIFF
--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -292,7 +292,7 @@ func generatePaCPipelineRunForComponent(
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cel expression for pipeline: %w", err)
 	}
-	repoUrl := component.Spec.Source.GitSource.URL
+	repoUrl := getGitRepoUrl(*component)
 
 	annotations := map[string]string{
 		"pipelinesascode.tekton.dev/cancel-in-progress": "false",
@@ -447,6 +447,7 @@ func generateCelExpressionForPipeline(component *appstudiov1alpha1.Component, gi
 	eventCondition := fmt.Sprintf(`event == "%s"`, eventType)
 
 	targetBranchCondition := fmt.Sprintf(`target_branch == "%s"`, targetBranch)
+	repoUrl := getGitRepoUrl(*component)
 
 	// Set path changed event filtering only for Components that are stored within a directory of the git repository.
 	// Also, we have to rebuild everything on push events, so applying the filter only to pull request pipeline.
@@ -466,7 +467,6 @@ func generateCelExpressionForPipeline(component *appstudiov1alpha1.Component, gi
 			if !strings.Contains(dockerfile, "://") {
 				// dockerfile could be relative to the context directory or repository root.
 				// To avoid unessesary builds, it's required to pass absolute path to the Dockerfile.
-				repoUrl := component.Spec.Source.GitSource.URL
 				branch := component.Spec.Source.GitSource.Revision
 				dockerfilePath := contextDir + dockerfile
 				isDockerfileInContextDir, err := gitClient.IsFileExist(repoUrl, branch, dockerfilePath)

--- a/internal/controller/component_build_controller_secrets.go
+++ b/internal/controller/component_build_controller_secrets.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
-	"strings"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -92,7 +91,8 @@ func (r *ComponentBuildReconciler) ensureIncomingSecret(ctx context.Context, com
 func (r *ComponentBuildReconciler) lookupPaCSecret(ctx context.Context, component *appstudiov1alpha1.Component, gitProvider string) (*corev1.Secret, error) {
 	log := ctrllog.FromContext(ctx)
 
-	scmComponent, err := git.NewScmComponent(gitProvider, component.Spec.Source.GitSource.URL, component.Spec.Source.GitSource.Revision, component.Name, component.Namespace)
+	repoUrl := getGitRepoUrl(*component)
+	scmComponent, err := git.NewScmComponent(gitProvider, repoUrl, component.Spec.Source.GitSource.Revision, component.Name, component.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, comp
 }
 
 func getWebhookSecretKeyForComponent(component appstudiov1alpha1.Component) string {
-	gitRepoUrl := strings.TrimSuffix(component.Spec.Source.GitSource.URL, ".git")
+	gitRepoUrl := getGitRepoUrl(component)
 
 	notAllowedCharRegex, _ := regexp.Compile("[^-._a-zA-Z0-9]{1}")
 	return notAllowedCharRegex.ReplaceAllString(gitRepoUrl, "_")

--- a/internal/controller/component_build_controller_unit_test.go
+++ b/internal/controller/component_build_controller_unit_test.go
@@ -1375,6 +1375,56 @@ func TestGetGitProvider(t *testing.T) {
 			componentRepoUrl: "https://github.com/user",
 			expectError:      true,
 		},
+		{
+			name:             "should return error if git source URL path doesn't have 2 parts namespace(owner)/repo",
+			componentRepoUrl: "https://github.com/user",
+			expectError:      true,
+		},
+		{
+			name:             "should return error if git source URL path has more than 2 parts namespace(owner)/repo",
+			componentRepoUrl: "https://github.com/user/repository/tree",
+			expectError:      true,
+		},
+		{
+			name:             "should return error if git source URL path has more than 2 parts namespace(owner)/repo",
+			componentRepoUrl: "https://github.com/user/repository/tree/branch/file",
+			expectError:      true,
+		},
+		{
+			name:             "should detect gitlab provider even if path has more than 2 parts",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository/additional",
+			want:             "gitlab",
+		},
+		{
+			name:             "should detect gitlab provider even if path has more than 2 parts",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository/additional/other",
+			want:             "gitlab",
+		},
+		{
+			name:             "should detect gitlab provider url ends with '.git'",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository.git",
+			want:             "gitlab",
+		},
+		{
+			name:             "should detect gitlab provider url ends with '.git' and slash",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository.git/",
+			want:             "gitlab",
+		},
+		{
+			name:             "should return error if gitlab url contains '-'",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository/additional/other/-/tree/main/file",
+			expectError:      true,
+		},
+		{
+			name:             "should return error if gitlab url contains '-'",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository/additional/other/-/commit/shacommit",
+			expectError:      true,
+		},
+		{
+			name:             "should return error if gitlab url contains '-'",
+			componentRepoUrl: "https://gitlab.com/user/test-component-repository/additional/other/-/blob/main/blobfile",
+			expectError:      true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -100,6 +100,8 @@ const (
 	EUnknownGitProvider BOErrorId = 60
 	// Insecure HTTP can't be used for git repository URL
 	EHttpUsedForRepository BOErrorId = 61
+	// Wrong git source url used, can't be path to tree/blob etc
+	EWrongGitSourceUrl BOErrorId = 62
 
 	// Happens when configured in cluster Pipelines as Code application is not installed in Component source repository.
 	// User must install the application to fix this error.
@@ -189,6 +191,7 @@ var boErrorMessages = map[BOErrorId]string{
 
 	EUnknownGitProvider:    "unknown git provider of the source repository",
 	EHttpUsedForRepository: "http used for git repository, use secure connection",
+	EWrongGitSourceUrl:     "wrong git source url used, can't be path to tree/blob etc",
 
 	EGitHubAppNotInstalled:         "GitHub Application is not installed in user repository",
 	EGitHubAppMalformedPrivateKey:  "malformed GitHub Application private key",


### PR DESCRIPTION
allow trailing '/' in git url and strip it in the code

for github allow only 2 parts in the path:
    https://github.com/owner/reponame
when creating repo in github and repo name contains '/' github converts it to '-'

for gitlab don't allow '-' in the path because that is used for
    commits/tree/blob etc
but allow more than 2 parts in the path as gitlab allows that

[STONEBLD-3181](https://issues.redhat.com//browse/STONEBLD-3181)
[STONEBLD-3215](https://issues.redhat.com//browse/STONEBLD-3215)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable