### PR TITLE
Export some internal controller types

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import controllers "github.com/konflux-ci/build-service/internal/controller"
+
+const (
+	BuildStatusAnnotationName  = controllers.BuildStatusAnnotationName
+	BuildRequestAnnotationName = controllers.BuildRequestAnnotationName
+)
+
+type BuildStatus = controllers.BuildStatus
+type PaCBuildStatus = controllers.PaCBuildStatus
+type ErrorInfo = controllers.ErrorInfo


### PR DESCRIPTION
Temporarily export types and constants defined in internal controller package which are used in e2e tests.
The proper solution is to move them to spec and status of the Component.