### PR TITLE
Create dedicated build SA per Component

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -241,6 +241,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO delete the controller after migration to the new dedicated to build Service Account.
+	if err = (&controllers.AppstudioPipelineServiceAccountWatcherReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "AppstudioPipelineServiceAccountWatcher")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,24 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/internal/controller/appstudio-pipeline-sa-watcher-controller.go
+++ b/internal/controller/appstudio-pipeline-sa-watcher-controller.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	l "github.com/konflux-ci/build-service/pkg/logs"
+)
+
+// TODO delete the controller after migration to the new dedicated to build Service Account.
+// AppstudioPipelineServiceAccountWatcherReconciler watches appstudio-pippeline Service Account
+// and syncs linked secrets updates to dedicated for build pipeline Service Account.
+type AppstudioPipelineServiceAccountWatcherReconciler struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *AppstudioPipelineServiceAccountWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ServiceAccount{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return false
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				// React only if appstudio-pipeline Service Account is changed
+				sa, ok := e.ObjectNew.(*corev1.ServiceAccount)
+				if !ok {
+					return false
+				}
+				return sa.Name == buildPipelineServiceAccountName
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		})).
+		Named("AppstudioPipelineServiceAccountWatcher").
+		Complete(r)
+}
+
+func (r *AppstudioPipelineServiceAccountWatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx).WithName("appstudioPipelineSA")
+	log.Info("Synching secrets")
+
+	componentList := &appstudiov1alpha1.ComponentList{}
+	if err := r.Client.List(ctx, componentList, client.InNamespace(req.Namespace)); err != nil {
+		log.Info("failed to list Components")
+		return ctrl.Result{}, err
+	}
+
+	for _, component := range componentList.Items {
+		buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(&component)
+		buildPipelinesServiceAccount := &corev1.ServiceAccount{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: req.Namespace}, buildPipelinesServiceAccount); err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, fmt.Sprintf("failed to read build pipeline Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionView)
+				// do not break sync because of a faulty item
+			}
+			// Dedicated build pipeline Service Account hasn't been yet created.
+			// Skip for now, the sync will be performed on the Service Account creation.
+			continue
+		}
+
+		if err := LinkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx, r.Client, &component); err != nil {
+			log.Error(err, "failed to sync linked secrets for Component", "Component", component.Name, l.Action, l.ActionUpdate)
+			// do not break sync because of a faulty item
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/appstudio-pipeline-sa-watcher-controller_test.go
+++ b/internal/controller/appstudio-pipeline-sa-watcher-controller_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2022-2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("appstudio-pipeline Service Account watcher controller", func() {
+
+	var (
+		namespace              = "sa-sync"
+		component1Key          = types.NamespacedName{Name: HASCompName + "-sa-watcher-1", Namespace: namespace}
+		component2Key          = types.NamespacedName{Name: HASCompName + "-sa-watcher-2", Namespace: namespace}
+		appstudioPipelineSAKey = types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: namespace}
+		component1SAKey        = types.NamespacedName{Name: "build-pipeline-" + component1Key.Name, Namespace: namespace}
+		component2SAKey        = types.NamespacedName{Name: "build-pipeline-" + component2Key.Name, Namespace: namespace}
+
+		commonSecret1Name     = "common-secret-1"
+		commonSecret2Name     = "common-secret-2"
+		commonPullSecret1Name = "common-pull-secret-1"
+		commonPullSecret2Name = "common-pull-secret-2"
+	)
+
+	Context("Test SA secrets sync", func() {
+
+		It("prepare resources", func() {
+			createNamespace(namespace)
+
+			component1 := getComponentData(componentConfig{componentKey: component1Key})
+			component1.Spec.ContainerImage = ""
+			Expect(k8sClient.Create(ctx, component1)).To(Succeed())
+			component2 := getComponentData(componentConfig{componentKey: component2Key})
+			component2.Spec.ContainerImage = ""
+			Expect(k8sClient.Create(ctx, component2)).To(Succeed())
+
+			appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+			Expect(appstudioPipelineSA.Secrets).To(HaveLen(0))
+			Expect(appstudioPipelineSA.ImagePullSecrets).To(HaveLen(0))
+			component1SA := waitServiceAccount(component1SAKey)
+			Expect(component1SA.Secrets).To(HaveLen(0))
+			Expect(component1SA.ImagePullSecrets).To(HaveLen(0))
+			component2SA := waitServiceAccount(component1SAKey)
+			Expect(component2SA.Secrets).To(HaveLen(0))
+			Expect(component2SA.ImagePullSecrets).To(HaveLen(0))
+		})
+
+		It("should sync linked secret", func() {
+			appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+			appstudioPipelineSA.Secrets = append(appstudioPipelineSA.Secrets, corev1.ObjectReference{Name: commonSecret1Name, Namespace: namespace})
+			Expect(k8sClient.Update(ctx, &appstudioPipelineSA)).To(Succeed())
+			Eventually(func() bool {
+				appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+				return len(appstudioPipelineSA.Secrets) == 1 && appstudioPipelineSA.Secrets[0].Name == commonSecret1Name
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				component1SA := waitServiceAccount(component1SAKey)
+				return len(component1SA.Secrets) == 1 && component1SA.Secrets[0].Name == commonSecret1Name && len(component1SA.ImagePullSecrets) == 0
+			}, timeout, interval).Should(BeTrue())
+			Eventually(func() bool {
+				component2SA := waitServiceAccount(component2SAKey)
+				return len(component2SA.Secrets) == 1 && component2SA.Secrets[0].Name == commonSecret1Name && len(component2SA.ImagePullSecrets) == 0
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should sync linked pull secret", func() {
+			appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+			appstudioPipelineSA.ImagePullSecrets = append(appstudioPipelineSA.ImagePullSecrets, corev1.LocalObjectReference{Name: commonPullSecret1Name})
+			Expect(k8sClient.Update(ctx, &appstudioPipelineSA)).To(Succeed())
+			Eventually(func() bool {
+				appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+				return len(appstudioPipelineSA.ImagePullSecrets) == 1 && appstudioPipelineSA.ImagePullSecrets[0].Name == commonPullSecret1Name
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				component1SA := waitServiceAccount(component1SAKey)
+				return len(component1SA.ImagePullSecrets) == 1 && component1SA.ImagePullSecrets[0].Name == commonPullSecret1Name &&
+					len(component1SA.Secrets) == 1 && component1SA.Secrets[0].Name == commonSecret1Name
+			}, timeout, interval).Should(BeTrue())
+			Eventually(func() bool {
+				component2SA := waitServiceAccount(component2SAKey)
+				return len(component2SA.ImagePullSecrets) == 1 && component2SA.ImagePullSecrets[0].Name == commonPullSecret1Name &&
+					len(component2SA.Secrets) == 1 && component2SA.Secrets[0].Name == commonSecret1Name
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should sync both linked secrets and pull secrets", func() {
+			appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+			appstudioPipelineSA.Secrets = append(appstudioPipelineSA.Secrets, corev1.ObjectReference{Name: commonSecret2Name})
+			appstudioPipelineSA.ImagePullSecrets = append(appstudioPipelineSA.ImagePullSecrets, corev1.LocalObjectReference{Name: commonPullSecret2Name})
+			Expect(k8sClient.Update(ctx, &appstudioPipelineSA)).To(Succeed())
+			Eventually(func() bool {
+				appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+				return len(appstudioPipelineSA.Secrets) == 2 && len(appstudioPipelineSA.ImagePullSecrets) == 2
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				component1SA := waitServiceAccount(component1SAKey)
+				return len(component1SA.Secrets) == 2 &&
+					component1SA.Secrets[0].Name == commonSecret1Name && component1SA.Secrets[1].Name == commonSecret2Name &&
+					len(component1SA.ImagePullSecrets) == 2 &&
+					component1SA.ImagePullSecrets[0].Name == commonPullSecret1Name && component1SA.ImagePullSecrets[1].Name == commonPullSecret2Name
+			}, timeout, interval).Should(BeTrue())
+			Eventually(func() bool {
+				component2SA := waitServiceAccount(component2SAKey)
+				return len(component2SA.Secrets) == 2 &&
+					component2SA.Secrets[0].Name == commonSecret1Name && component2SA.Secrets[1].Name == commonSecret2Name &&
+					len(component2SA.ImagePullSecrets) == 2 &&
+					component2SA.ImagePullSecrets[0].Name == commonPullSecret1Name && component2SA.ImagePullSecrets[1].Name == commonPullSecret2Name
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should sync a few linked secret", func() {
+			commonSecret3Name := "common-secret-3"
+			commonSecret4Name := "common-secret-4"
+			appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+			appstudioPipelineSA.Secrets = append(appstudioPipelineSA.Secrets, corev1.ObjectReference{Name: commonSecret3Name})
+			appstudioPipelineSA.Secrets = append(appstudioPipelineSA.Secrets, corev1.ObjectReference{Name: commonSecret4Name})
+			Expect(k8sClient.Update(ctx, &appstudioPipelineSA)).To(Succeed())
+			Eventually(func() bool {
+				appstudioPipelineSA := waitServiceAccount(appstudioPipelineSAKey)
+				return len(appstudioPipelineSA.Secrets) == 4 && len(appstudioPipelineSA.ImagePullSecrets) == 2
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				component1SA := waitServiceAccount(component1SAKey)
+				return len(component1SA.Secrets) == 4 &&
+					component1SA.Secrets[0].Name == commonSecret1Name && component1SA.Secrets[1].Name == commonSecret2Name &&
+					component1SA.Secrets[2].Name == commonSecret3Name && component1SA.Secrets[3].Name == commonSecret4Name &&
+					len(component1SA.ImagePullSecrets) == 2 &&
+					component1SA.ImagePullSecrets[0].Name == commonPullSecret1Name && component1SA.ImagePullSecrets[1].Name == commonPullSecret2Name
+			}, timeout, interval).Should(BeTrue())
+			Eventually(func() bool {
+				component2SA := waitServiceAccount(component2SAKey)
+				return len(component2SA.Secrets) == 4 &&
+					component2SA.Secrets[0].Name == commonSecret1Name && component2SA.Secrets[1].Name == commonSecret2Name &&
+					component2SA.Secrets[2].Name == commonSecret3Name && component2SA.Secrets[3].Name == commonSecret4Name &&
+					len(component2SA.ImagePullSecrets) == 2 &&
+					component2SA.ImagePullSecrets[0].Name == commonPullSecret1Name && component2SA.ImagePullSecrets[1].Name == commonPullSecret2Name
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("clean up", func() {
+			deleteComponent(component1Key)
+			deleteComponent(component2Key)
+			deleteServiceAccount(appstudioPipelineSAKey)
+			deleteServiceAccount(component1Key)
+			deleteServiceAccount(component2Key)
+		})
+	})
+})

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -151,8 +151,9 @@ func updateMetricsTimes(componentIdForMetrics string, requestedAction string, re
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch;update;delete
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 
 func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -174,11 +175,21 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	// don't recreate SA upon component deletion
+	// Don't recreate build pipeline Service Account upon component deletion.
 	if component.ObjectMeta.DeletionTimestamp.IsZero() {
-		// Ensure pipeline service account exists
+		// Ensure deprecated pipeline service account exists for backward compatability.
 		_, err = r.ensurePipelineServiceAccount(ctx, component.Namespace)
 		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err := r.EnsureBuildPipelineServiceAccount(ctx, &component); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// TODO remove after migration to dedicated Service Account is done.
+		// It's needed to add newly linked common secrets to appstudio-pipeline into dedicated Service Account.
+		if err := r.linkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx, &component); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -236,7 +247,28 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			_, _ = r.UndoPaCProvisionForComponent(ctx, &component)
 		}
 
+		// Clean up common build pipelines Role Binding
+		if err := r.removeBuildPipelineServiceAccountBinding(ctx, &component); err != nil {
+			return ctrl.Result{}, err
+		}
+
 		return ctrl.Result{}, nil
+	}
+
+	// Migrate existing components to the new Service Accounts model.
+	// TODO remove when migration is done.
+	if component.Annotations != nil && component.Annotations[serviceAccountMigrationAnnotationName] == "true" {
+		if err := r.performServiceAccountMigration(ctx, &component); err != nil {
+			if boErr, ok := err.(*boerrors.BuildOpError); ok && boErr.IsPersistent() {
+				// Permanent error, cannot do more, stop.
+				log.Error(err, "Migration to the new Service Account permanently failed")
+				return ctrl.Result{}, nil
+			}
+			// Retry the migration
+			return ctrl.Result{}, err
+		}
+		delete(component.Annotations, serviceAccountMigrationAnnotationName)
+		return ctrl.Result{}, r.Client.Update(ctx, &component)
 	}
 
 	_, _, err = r.GetBuildPipelineFromComponentAnnotation(ctx, &component)

--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -110,9 +110,25 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Con
 		return nil, nil, err
 	}
 
+	// TODO delete the conditions after migration to the new Service Account done.
+	// If a Config Map with name "use-new-sa" exist, switch to the new Service Account.
+	useOldSA := true
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: BuildServiceNamespaceName, Name: "use-new-sa"}, &corev1.ConfigMap{}); err == nil {
+		useOldSA = false
+		log.Info("using new service account in pipeline")
+	} else {
+		if !errors.IsNotFound(err) {
+			return nil, nil, err
+		}
+		log.Info("using old service account in pipeline")
+	}
+
 	pipelineRunOnPush, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, pacTargetBranch, gitClient, false)
 	if err != nil {
 		return nil, nil, err
+	}
+	if useOldSA {
+		pipelineRunOnPush.Spec.TaskRunTemplate = tektonapi.PipelineTaskRunTemplate{}
 	}
 	pipelineRunOnPushYaml, err := yaml.Marshal(pipelineRunOnPush)
 	if err != nil {
@@ -122,6 +138,9 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Con
 	pipelineRunOnPR, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, pacTargetBranch, gitClient, true)
 	if err != nil {
 		return nil, nil, err
+	}
+	if useOldSA {
+		pipelineRunOnPR.Spec.TaskRunTemplate = tektonapi.PipelineTaskRunTemplate{}
 	}
 	pipelineRunOnPRYaml, err := yaml.Marshal(pipelineRunOnPR)
 	if err != nil {
@@ -381,6 +400,9 @@ func generatePaCPipelineRunForComponent(
 			PipelineSpec: pipelineSpec,
 			Params:       params,
 			Workspaces:   pipelineRunWorkspaces,
+			TaskRunTemplate: tektonapi.PipelineTaskRunTemplate{
+				ServiceAccountName: getBuildPipelineServiceAccountName(component),
+			},
 		},
 	}
 

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	BuildPipelineClusterRoleName = "appstudio-pipelines-runner"
-	buildPipelineRoleBindingName = BuildPipelineClusterRoleName + "-bindings"
+	buildPipelineRoleBindingName = "konflux-pipelines-runner-bindings"
 
 	commonBuildSecretLabelName = "build.appstudio.openshift.io/common-secret"
 

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -430,7 +430,7 @@ func (r *ComponentBuildReconciler) setServiceAccountInPipelineDefinition(ctx con
 	}
 
 	// getting branch in advance just to test credentials
-	defaultBranch, err := gitClient.GetDefaultBranch(repoUrl)
+	defaultBranch, err := gitClient.GetDefaultBranchWithChecks(repoUrl)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -1,0 +1,488 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/build-service/pkg/boerrors"
+	gp "github.com/konflux-ci/build-service/pkg/git/gitprovider"
+	"github.com/konflux-ci/build-service/pkg/git/gitproviderfactory"
+	l "github.com/konflux-ci/build-service/pkg/logs"
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+const (
+	BuildPipelineClusterRoleName = "appstudio-pipelines-runner"
+	buildPipelineRoleBindingName = BuildPipelineClusterRoleName + "-bindings"
+
+	commonBuildSecretLabelName = "build.appstudio.openshift.io/common-secret"
+
+	serviceAccountMigrationAnnotationName = "build.appstudio.openshift.io/sa-migration"
+)
+
+// getBuildPipelineServiceAccountName returns name of dedicated Service Account
+// that should be used for build pipelines of the given Component.
+func getBuildPipelineServiceAccountName(component *appstudiov1alpha1.Component) string {
+	return "build-pipeline-" + component.GetName()
+}
+
+// EnsureBuildPipelineServiceAccount checks if dedicated Service Account for Component build pipelines and
+// corresponding Role Binding to appstudio-pipeline-runner Cluster Role exists.
+// If a resource missing, it will be created.
+func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx).WithName("buildSA-provision")
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	// Verify build pipeline Service Account
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelinesServiceAccount := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, buildPipelinesServiceAccount); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, fmt.Sprintf("failed to read build pipeline Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionView)
+			return err
+		}
+
+		// Service Account for Component build pipelines doesn't exist.
+		// Create Service Account for the build pipeline.
+		buildPipelineSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      buildPipelineServiceAccountName,
+				Namespace: component.Namespace,
+			},
+		}
+		if err := controllerutil.SetOwnerReference(component, buildPipelineSA, r.Scheme); err != nil {
+			log.Error(err, "failed to add owner reference to build pipeline Service Account")
+			return err
+		}
+		if err := r.linkCommonSecretsToBuildPipelineServiceAccount(ctx, buildPipelineSA); err != nil {
+			return err
+		}
+		if err := r.Client.Create(ctx, buildPipelineSA); err != nil {
+			log.Error(err, fmt.Sprintf("failed to create Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionAdd)
+			return err
+		}
+	}
+
+	if err := r.ensureBuildPipelineServiceAccountBinding(ctx, component); err != nil {
+		log.Error(err, "failed to ensure role binding for build pipleine Service Account")
+		return err
+	}
+
+	return nil
+}
+
+// linkCommonSecretsToBuildPipelineServiceAccount searches for common build Secrets in Component namespace
+// marked with corresponding label and adds them into secrets section of the given Service Account.
+func (r *ComponentBuildReconciler) linkCommonSecretsToBuildPipelineServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount) error {
+	// Get all secrets with common for all Component label
+	commonSecretsList := &corev1.SecretList{}
+
+	commonBuildSecretRequirement, err := labels.NewRequirement(commonBuildSecretLabelName, selection.Equals, []string{"true"})
+	if err != nil {
+		return err
+	}
+	commonBuildSecretsSelector := labels.NewSelector().Add(*commonBuildSecretRequirement)
+	commonBuildSecretsListOptions := client.ListOptions{
+		LabelSelector: commonBuildSecretsSelector,
+		Namespace:     serviceAccount.Namespace,
+	}
+	if err := r.Client.List(ctx, commonSecretsList, &commonBuildSecretsListOptions); err != nil {
+		return err
+	}
+
+	// Add found secrets to the Service Account Secrets section
+	for _, commonSecret := range commonSecretsList.Items {
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: commonSecret.Name})
+	}
+
+	return nil
+}
+
+// ensureBuildPipelineServiceAccountBinding makes sure that a common for all build pipelines Service Accounts
+// Role Binding exists and contains a subject record for the given component.
+func (r *ComponentBuildReconciler) ensureBuildPipelineServiceAccountBinding(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+
+	// Verify Role Binding for build pipeline Service Account
+	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: component.Namespace}, buildPipelinesRoleBinding); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to read common build pipelines Role Binding", l.Action, l.ActionView)
+			return err
+		}
+
+		// This is the first Component in the namespace being onboarded.
+		// Create common Role Binding to appstudio-pipelines-runner Cluster Role for all build pipeline Service Accounts.
+		// Add only one subject for the given Component.
+		buildPipelinesRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      buildPipelineRoleBindingName,
+				Namespace: component.Namespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     BuildPipelineClusterRoleName,
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      buildPipelineServiceAccountName,
+					Namespace: component.Namespace,
+				},
+			},
+		}
+		if err := r.Client.Create(ctx, buildPipelinesRoleBinding); err != nil {
+			// errors.IsNotFound(err) will always be false because appstudio-pipelines-runner Cluster Role exists.
+			log.Error(err, "failed to create common build pipelines Role Binding", l.Action, l.ActionAdd)
+			return err
+		}
+		return nil
+	}
+
+	// Common Role Binding to appstudio-pipelines-runner Cluster Role for all build pipeline Service Accounts exists.
+	// Make sure it contains a subject record for the given Component.
+	if getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName) != -1 {
+		// Up to date, nothing to do.
+		return nil
+	}
+	// Add record for the Component build pipeline Service Account and update common Role Binding.
+	buildPipelinesRoleBinding.Subjects = append(buildPipelinesRoleBinding.Subjects, rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      buildPipelineServiceAccountName,
+		Namespace: component.Namespace,
+	})
+	if err := r.Client.Update(ctx, buildPipelinesRoleBinding); err != nil {
+		log.Error(err, "failed to add a subject to common build pipelines Role Binding", l.Action, l.ActionUpdate)
+		return err
+	}
+	log.Info("Added Service Account to common build pipelines Role Binding", "ServiceAccountName", buildPipelineServiceAccountName, l.Action, l.ActionUpdate)
+
+	return nil
+}
+
+// getRoleBindingSaSubjectIndex checks if given Role Binding grants permissions to a Service Account
+// with the provided name and returns the subject record index.
+// If there is no record for the Service Account, -1 is returned.
+func getRoleBindingSaSubjectIndex(roleBinding *rbacv1.RoleBinding, serviceAccountName string) int {
+	for i, subject := range roleBinding.Subjects {
+		if subject.Kind == "ServiceAccount" && subject.Name == serviceAccountName {
+			return i
+		}
+	}
+	return -1
+}
+
+// removeBuildPipelineServiceAccountBinding deletes subject record for build pipleine Service Account
+// of the given Component from the common build pipelines Role Binding.
+// Deletes the common Role Binding if no subjects are left.
+func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: component.Namespace}, buildPipelinesRoleBinding); err != nil {
+		if errors.IsNotFound(err) {
+			// Nothing to do
+			return nil
+		}
+		log.Error(err, "failed to read common build pipelines Role Binding", l.Action, l.ActionView)
+		return err
+	}
+
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	subjectIndex := getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName)
+	if subjectIndex != -1 {
+		if len(buildPipelinesRoleBinding.Subjects) == 1 {
+			// Clean the last subject
+			buildPipelinesRoleBinding.Subjects = nil
+		} else {
+			// Remove subject by its index
+			oldSubjects := buildPipelinesRoleBinding.Subjects
+			newSubjects := append(oldSubjects[:subjectIndex], oldSubjects[subjectIndex+1:]...)
+			buildPipelinesRoleBinding.Subjects = newSubjects
+			if err := r.Client.Update(ctx, buildPipelinesRoleBinding); err != nil {
+				log.Error(err, "failed to remove subject from common build pipelines Role Binding")
+				return err
+			}
+			log.Info("removed subject from common build pipelines Role Binding")
+			return nil
+		}
+	}
+
+	// Check if we need to keep common build pipelines Role Binding
+	if len(buildPipelinesRoleBinding.Subjects) == 0 {
+		// No subjects left, remove whole Role Binding
+		if err := r.Client.Delete(ctx, buildPipelinesRoleBinding); err != nil {
+			log.Error(err, "failed to delete common build pipelines Role Binding", l.Action, l.ActionDelete)
+			return err
+		}
+		log.Info("deleted common build pipelines Role Binding")
+	}
+
+	return nil
+}
+
+//
+// Migration from appstudio-pipeline Service Account to dedicated to build Service Account
+//
+
+func (r *ComponentBuildReconciler) performServiceAccountMigration(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx).WithName("buildSA-migration")
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	if err := r.linkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx, component); err != nil {
+		log.Error(err, "failed to link common secret to new Service Account")
+		return err
+	}
+
+	if err := r.setServiceAccountInPipelineDefinition(ctx, component); err != nil {
+		log.Error(err, "failed to create migration PR")
+		return err
+	}
+
+	return nil
+}
+
+func (r *ComponentBuildReconciler) linkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	return LinkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx, r.Client, component)
+}
+
+// LinkCommonSecretsToNewServiceAccount links all secrets from appstudio-pipeline Service Account
+// except image repository secrets to the new dedicated to build Service Account.
+func LinkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx context.Context, c client.Client, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	appstudioPipelineServiceAccount := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, appstudioPipelineServiceAccount); err != nil {
+		if errors.IsNotFound(err) {
+			// Ignore not found error, assume the migration for the linked secrets has been done.
+			log.Info("skipping linked secret migration")
+			return nil
+		}
+		return err
+	}
+
+	componentBuildServiceAccount := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, types.NamespacedName{Name: getBuildPipelineServiceAccountName(component), Namespace: component.Namespace}, componentBuildServiceAccount); err != nil {
+		log.Error(err, "failed to get component build Service Account")
+		return err
+	}
+
+	isComponentServiceAccountEdited := migrateLinkedSecrets(appstudioPipelineServiceAccount, componentBuildServiceAccount)
+	if isComponentServiceAccountEdited {
+		if err := c.Update(ctx, componentBuildServiceAccount); err != nil {
+			log.Error(err, "failed to update build Service Account after attempt of secrets migration")
+			return err
+		}
+		log.Info("Migrated common secrets to the new Service Account")
+	}
+
+	return nil
+}
+
+func migrateLinkedSecrets(appstudioPipelineServiceAccount, componentBuildServiceAccount *corev1.ServiceAccount) bool {
+	isEdited := false
+
+	// secrets
+	for _, secretObject := range appstudioPipelineServiceAccount.Secrets {
+		secretName := secretObject.Name
+		if !isImageRepositorySecret(secretName) && !isSaSecretLinked(componentBuildServiceAccount, secretName, false) {
+			componentBuildServiceAccount.Secrets = append(componentBuildServiceAccount.Secrets, corev1.ObjectReference{Name: secretName})
+			isEdited = true
+		}
+	}
+
+	// pull secrets
+	for _, pullSecretObject := range appstudioPipelineServiceAccount.ImagePullSecrets {
+		pullSecretName := pullSecretObject.Name
+		if !isImageRepositorySecret(pullSecretName) && !isSaSecretLinked(componentBuildServiceAccount, pullSecretName, true) {
+			componentBuildServiceAccount.ImagePullSecrets = append(componentBuildServiceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: pullSecretName})
+			isEdited = true
+		}
+	}
+
+	return isEdited
+}
+
+func isImageRepositorySecret(secretName string) bool {
+	return strings.HasPrefix(secretName, "imagerepository") || strings.HasSuffix(secretName, "image-push")
+}
+
+func isSaSecretLinked(serviceAccount *corev1.ServiceAccount, secretName string, isPull bool) bool {
+	if isPull {
+		for _, pullSecretObject := range serviceAccount.ImagePullSecrets {
+			if pullSecretObject.Name == secretName {
+				return true
+			}
+		}
+	} else {
+		for _, secretObject := range serviceAccount.Secrets {
+			if secretObject.Name == secretName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const saMigrationMergeRequestDescription = `
+## Build pipeline Service Account migration
+
+This PR chnages Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
+`
+
+// Need to create a PR that adds to every pipeline definition:
+func (r *ComponentBuildReconciler) setServiceAccountInPipelineDefinition(ctx context.Context, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	gitProvider, err := getGitProvider(*component)
+	if err != nil {
+		// There is no point to continue if git provider is not known.
+		return err
+	}
+
+	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider)
+	if err != nil {
+		log.Error(err, "error getting git provider credentials secret", l.Action, l.ActionView)
+		// Cannot continue without accessing git provider credentials.
+		return boerrors.NewBuildOpError(boerrors.EPaCSecretNotFound, err)
+	}
+
+	repoUrl := getGitRepoUrl(*component)
+
+	gitClient, err := gitproviderfactory.CreateGitClient(gitproviderfactory.GitClientConfig{
+		PacSecretData:             pacSecret.Data,
+		GitProvider:               gitProvider,
+		RepoUrl:                   repoUrl,
+		IsAppInstallationExpected: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	// getting branch in advance just to test credentials
+	defaultBranch, err := gitClient.GetDefaultBranch(repoUrl)
+	if err != nil {
+		return err
+	}
+	baseBranch := component.Spec.Source.GitSource.Revision
+	if baseBranch == "" {
+		baseBranch = defaultBranch
+	}
+
+	pushPipelinePath := getPipelineRunDefinitionFilePath(component, false)
+	pullPipelinePath := getPipelineRunDefinitionFilePath(component, true)
+
+	pushPipelineDefinitionFound := true
+	var pushPipelineContent []byte
+	pushPipelineContent, err = gitClient.DownloadFileContent(repoUrl, baseBranch, pushPipelinePath)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		pushPipelineDefinitionFound = false
+	}
+	pullPipelineDefinitionFound := true
+	var pullPipelineContent []byte
+	pullPipelineContent, err = gitClient.DownloadFileContent(repoUrl, baseBranch, pullPipelinePath)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		pullPipelineDefinitionFound = false
+	}
+	if !pushPipelineDefinitionFound && !pullPipelineDefinitionFound {
+		// No pipeline definitions found
+		log.Info("No pipeline definitions found to migrate")
+		return nil
+	}
+
+	pipelineRunServiceAccountName := getBuildPipelineServiceAccountName(component)
+
+	if pushPipelineDefinitionFound {
+		pushPipelineContent, err = addServiceAccountToPipelineRun(pushPipelineContent, pipelineRunServiceAccountName)
+		if err != nil {
+			log.Error(err, "failed to add Service Account to push pipeline definition")
+			return err
+		}
+	}
+	if pullPipelineDefinitionFound {
+		pullPipelineContent, err = addServiceAccountToPipelineRun(pullPipelineContent, pipelineRunServiceAccountName)
+		if err != nil {
+			log.Error(err, "failed to add Service Account to pull pipeline definition")
+			return err
+		}
+	}
+
+	mrData := &gp.MergeRequestData{
+		CommitMessage:  "Konflux build pipeline service account migration for " + component.Name,
+		SignedOff:      true,
+		BranchName:     fmt.Sprintf("%s%s", "konflux-sa-migration-", component.Name),
+		BaseBranchName: baseBranch,
+		Title:          "Konflux build pipeline service account migration",
+		Text:           saMigrationMergeRequestDescription,
+		AuthorName:     "konflux",
+		AuthorEmail:    "konflux@no-reply.konflux-ci.dev",
+		Files:          []gp.RepositoryFile{},
+	}
+	if pushPipelineDefinitionFound {
+		mrData.Files = append(mrData.Files, gp.RepositoryFile{FullPath: pushPipelinePath, Content: pushPipelineContent})
+	}
+	if pullPipelineDefinitionFound {
+		mrData.Files = append(mrData.Files, gp.RepositoryFile{FullPath: pullPipelinePath, Content: pullPipelineContent})
+	}
+
+	var webUrl string
+	webUrl, err = gitClient.EnsurePaCMergeRequest(repoUrl, mrData)
+	if err != nil {
+		log.Error(err, "failed to create migration PR")
+		return err
+	}
+
+	log.Info("Migration PR: " + webUrl)
+	return nil
+}
+
+// addServiceAccountToPipelineRun specifies given service account to use in the pipeline.
+func addServiceAccountToPipelineRun(pipelineRunBytes []byte, serviceAccountName string) ([]byte, error) {
+	buildPipelineData := &tektonapi.PipelineRun{}
+	if err := yaml.Unmarshal(pipelineRunBytes, buildPipelineData); err != nil {
+		return nil, err
+	}
+
+	buildPipelineData.Spec.TaskRunTemplate.ServiceAccountName = serviceAccountName
+
+	return yaml.Marshal(buildPipelineData)
+}

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -317,7 +317,7 @@ func (r *ComponentBuildReconciler) linkCommonAppstudioPipelineSecretsToNewServic
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, appstudioPipelineServiceAccount); err != nil {
 		if errors.IsNotFound(err) {
 			// Ignore not found error, assume the migration for the linked secrets has been done.
-			log.Info("skipping linked secret migration")
+			log.Info("skipping linked secret migration due to missing appstudio-pipeline Service Account")
 			return nil
 		}
 		return err
@@ -325,7 +325,7 @@ func (r *ComponentBuildReconciler) linkCommonAppstudioPipelineSecretsToNewServic
 	return LinkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx, r.Client, component, appstudioPipelineServiceAccount)
 }
 
-// LinkCommonSecretsToNewServiceAccount links all secrets from appstudio-pipeline Service Account
+// LinkCommonAppstudioPipelineSecretsToNewServiceAccount links all secrets from appstudio-pipeline Service Account
 // except image repository secrets to the new dedicated to build Service Account.
 func LinkCommonAppstudioPipelineSecretsToNewServiceAccount(ctx context.Context, c client.Client, component *appstudiov1alpha1.Component, appstudioPipelineServiceAccount *corev1.ServiceAccount) error {
 	log := ctrllog.FromContext(ctx)
@@ -396,7 +396,7 @@ func isSaSecretLinked(serviceAccount *corev1.ServiceAccount, secretName string, 
 const saMigrationMergeRequestDescription = `
 ## Build pipeline Service Account migration
 
-This PR chnages Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
+This PR changes Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
 Please merge the Service Account update to avoid broken builds when deprected "appstudio-pipeline" Service Account is removed.
 `
 

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -107,11 +107,14 @@ var _ = Describe("Component build controller", func() {
 
 	Context("Test build pipeline Service Account", func() {
 		var (
-			component1Key = types.NamespacedName{Name: "component-sa-1", Namespace: HASAppNamespace}
-			component2Key = types.NamespacedName{Name: "component-sa-2", Namespace: HASAppNamespace}
+			namespace           = "sa-test"
+			component1Key       = types.NamespacedName{Name: "component-sa-1", Namespace: namespace}
+			component2Key       = types.NamespacedName{Name: "component-sa-2", Namespace: namespace}
+			buildRoleBindingKey = types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: namespace}
 		)
 
 		_ = BeforeEach(func() {
+			createNamespace(namespace)
 			ResetTestGitProviderClient()
 		})
 

--- a/internal/controller/component_build_controller_unit_test.go
+++ b/internal/controller/component_build_controller_unit_test.go
@@ -339,6 +339,10 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 		}
 		t.Errorf("generatePaCPipelineRunForComponent(): unexpected pipeline workspaces %v", workspace)
 	}
+
+	if pipelineRun.Spec.TaskRunTemplate.ServiceAccountName != "build-pipeline-"+component.Name {
+		t.Error("generatePaCPipelineRunForComponent(): build pipeline service account is incorrect")
+	}
 }
 
 func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSet(t *testing.T) {

--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -376,6 +376,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 		}
 	}
 
+	// Filter components to have only components that are nudged (should be rebuilt) after current component build.
 	for i := range components.Items {
 		comp := components.Items[i]
 		if slices.Contains(updatedComponent.Spec.BuildNudgesRef, comp.Name) {
@@ -383,10 +384,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 		}
 	}
 
-	updatedOutputImage := updatedComponent.Spec.ContainerImage
-	imageRepositoryHost := strings.Split(updatedOutputImage, "/")[0]
-
-	imageRepositoryUsername, imageRepositoryPassword, err := r.getImageRepositoryCredentials(ctx, pipelineRun.Namespace, updatedOutputImage)
+	imageRepositoryUsername, imageRepositoryPassword, err := r.getImageRepositoryCredentials(ctx, updatedComponent)
 	if err != nil {
 		// when we can't find credential for repository, remove pipeline finalizer and return error
 		_, errRemoveFinalizer := r.removePipelineFinalizer(ctx, pipelineRun, patch)
@@ -396,6 +394,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 
 		return ctrl.Result{}, err
 	}
+	imageRepositoryHost := strings.Split(updatedComponent.Spec.ContainerImage, "/")[0]
 
 	var nudgeErr error
 	var targets []updateTarget
@@ -537,24 +536,28 @@ func (r *ComponentDependencyUpdateReconciler) removePipelineFinalizer(ctx contex
 
 // getImageRepositoryCredentials returns username and password for image repository
 // it is searching all dockerconfigjson type secrets which are linked to the service account
-func (r *ComponentDependencyUpdateReconciler) getImageRepositoryCredentials(ctx context.Context, namespace, updatedOutputImage string) (string, string, error) {
+func (r *ComponentDependencyUpdateReconciler) getImageRepositoryCredentials(ctx context.Context, component *applicationapi.Component) (string, string, error) {
 	log := ctrllog.FromContext(ctx)
 
+	updatedOutputImage := component.Spec.ContainerImage
+	namespace := component.Namespace
+
 	// get service account and gather linked secrets
-	pipelinesServiceAccount := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: namespace}, pipelinesServiceAccount)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccount := &corev1.ServiceAccount{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: namespace}, buildPipelineServiceAccount)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", buildPipelineServiceAccountName, namespace), l.Action, l.ActionView)
 		return "", "", err
 	}
 
 	linkedSecretNames := []string{}
-	for _, secret := range pipelinesServiceAccount.Secrets {
+	for _, secret := range buildPipelineServiceAccount.Secrets {
 		linkedSecretNames = append(linkedSecretNames, secret.Name)
 	}
 
 	if len(linkedSecretNames) == 0 {
-		err = fmt.Errorf("No secrets linked to service account %s in namespace %s", buildPipelineServiceAccountName, namespace)
+		err = fmt.Errorf("no secrets linked to service account %s in namespace %s", buildPipelineServiceAccountName, namespace)
 		log.Error(err, "no linked secrets")
 		return "", "", err
 	}
@@ -680,7 +683,7 @@ func GetMatchedCredentialForImageRepository(ctx context.Context, outputImage str
 	}
 
 	log.Info("no credentials found for repo", "repo", repoPath)
-	return "", "", fmt.Errorf("No credentials found for repository %s ", repoPath)
+	return "", "", fmt.Errorf("no credentials found for repository %s ", repoPath)
 }
 
 func IsBuildPushPipelineRun(object client.Object) bool {

--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -554,7 +554,9 @@ func (r *ComponentDependencyUpdateReconciler) getImageRepositoryCredentials(ctx 
 			return "", "", err
 		}
 		// Fall back to deprecated appstudio-pipline Service Account
-		buildPipelineServiceAccountName = sharedBuildPipelineServiceAccountName
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: sharedBuildPipelineServiceAccountName, Namespace: namespace}, buildPipelineServiceAccount); err != nil {
+			return "", "", err
+		}
 	}
 
 	linkedSecretNames := []string{}

--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -54,18 +54,21 @@ var failures = 0
 
 var _ = Describe("Component nudge controller", func() {
 
+	var (
+		baseComponentKey = types.NamespacedName{Namespace: UserNamespace, Name: BaseComponent}
+	)
+
 	delayTime = 0
 	BeforeEach(func() {
 		createNamespace(UserNamespace)
-		baseComponentName := types.NamespacedName{Namespace: UserNamespace, Name: BaseComponent}
 		createCustomComponentWithoutBuildRequest(componentConfig{
-			componentKey:   baseComponentName,
+			componentKey:   baseComponentKey,
 			containerImage: "quay.io/organization/repo:tag",
 		})
 		createComponent(types.NamespacedName{Namespace: UserNamespace, Name: Operator1})
 		createComponent(types.NamespacedName{Namespace: UserNamespace, Name: Operator2})
 		baseComponent := applicationapi.Component{}
-		err := k8sClient.Get(context.TODO(), baseComponentName, &baseComponent)
+		err := k8sClient.Get(context.TODO(), baseComponentKey, &baseComponent)
 		Expect(err).ToNot(HaveOccurred())
 		baseComponent.Spec.BuildNudgesRef = []string{Operator1, Operator2}
 		err = k8sClient.Update(context.TODO(), &baseComponent)
@@ -95,7 +98,7 @@ var _ = Describe("Component nudge controller", func() {
 		caConfigMapKey := types.NamespacedName{Name: "trusted-ca", Namespace: BuildServiceNamespaceName}
 		createCAConfigMap(caConfigMapKey)
 
-		serviceAccountKey := types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: UserNamespace}
+		serviceAccountKey := getComponentServiceAccountKey(baseComponentKey)
 		sa := waitServiceAccount(serviceAccountKey)
 		sa.Secrets = []v1.ObjectReference{{Name: "dockerconfigjsonsecret"}}
 		Expect(k8sClient.Update(ctx, &sa)).To(Succeed())
@@ -263,7 +266,7 @@ var _ = Describe("Component nudge controller", func() {
 			deleteSecret(imageRepoSecretKey)
 			createSCMSecret(imageRepoSecretKey, imageRepoSecretData, v1.SecretTypeDockerConfigJson, map[string]string{})
 
-			serviceAccountKey := types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: UserNamespace}
+			serviceAccountKey := getComponentServiceAccountKey(baseComponentKey)
 			sa := waitServiceAccount(serviceAccountKey)
 			sa.Secrets = []v1.ObjectReference{{Name: "dockerconfigjsonsecret"}}
 			Expect(k8sClient.Update(ctx, &sa)).To(Succeed())
@@ -328,7 +331,7 @@ var _ = Describe("Component nudge controller", func() {
 			imageRepoSecretKey = types.NamespacedName{Name: "dockerconfigjsonsecret3", Namespace: UserNamespace}
 			createSCMSecret(imageRepoSecretKey, imageRepoSecretData, v1.SecretTypeDockerConfigJson, map[string]string{})
 
-			serviceAccountKey := types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: UserNamespace}
+			serviceAccountKey := getComponentServiceAccountKey(baseComponentKey)
 			sa := waitServiceAccount(serviceAccountKey)
 			sa.Secrets = []v1.ObjectReference{{Name: "dockerconfigjsonsecret"}, {Name: "dockerconfigjsonsecret2"}}
 			Expect(k8sClient.Update(ctx, &sa)).To(Succeed())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -130,7 +130,6 @@ var _ = BeforeSuite(func() {
 			Namespace: "default",
 		},
 	}
-
 	Expect(k8sClient.Create(context.Background(), &svcAccount)).Should(Succeed())
 
 	clientOpts := client.Options{
@@ -170,6 +169,13 @@ var _ = BeforeSuite(func() {
 		Scheme:                       k8sManager.GetScheme(),
 		EventRecorder:                k8sManager.GetEventRecorderFor("ComponentDependencyUpdateReconciler"),
 		ComponentDependenciesUpdater: *NewComponentDependenciesUpdater(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("ComponentDependencyUpdateReconciler")),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// TODO delete the controller after migration to the new dedicated to build Service Account.
+	err = (&AppstudioPipelineServiceAccountWatcherReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/suite_util_gitprovider_test.go
+++ b/internal/controller/suite_util_gitprovider_test.go
@@ -37,6 +37,7 @@ var (
 	DeleteBranchFunc                 func(repoUrl string, branchName string) (bool, error)
 	GetBranchShaFunc                 func(repoUrl string, branchName string) (string, error)
 	GetBrowseRepositoryAtShaLinkFunc func(repoUrl string, sha string) string
+	DownloadFileContentFunc          func(repoUrl, branchName, filePath string) ([]byte, error)
 	IsFileExistFunc                  func(repoUrl, branchName, filePath string) (bool, error)
 	IsRepositoryPublicFunc           func(repoUrl string) (bool, error)
 	GetConfiguredGitAppNameFunc      func() (string, string, error)
@@ -74,6 +75,9 @@ func ResetTestGitProviderClient() {
 	}
 	GetBrowseRepositoryAtShaLinkFunc = func(repoUrl string, sha string) string {
 		return DefaultBrowseRepository + sha
+	}
+	DownloadFileContentFunc = func(repoUrl, branchName, filePath string) ([]byte, error) {
+		return []byte{0}, nil
 	}
 	IsFileExistFunc = func(repoUrl, branchName, filePath string) (bool, error) {
 		return true, nil
@@ -119,6 +123,9 @@ func (*TestGitProviderClient) GetBranchSha(repoUrl string, branchName string) (s
 }
 func (*TestGitProviderClient) GetBrowseRepositoryAtShaLink(repoUrl string, sha string) string {
 	return GetBrowseRepositoryAtShaLinkFunc(repoUrl, sha)
+}
+func (*TestGitProviderClient) DownloadFileContent(repoUrl, branchName, filePath string) ([]byte, error) {
+	return DownloadFileContentFunc(repoUrl, branchName, filePath)
 }
 func (*TestGitProviderClient) IsFileExist(repoUrl, branchName, filePath string) (bool, error) {
 	return IsFileExistFunc(repoUrl, branchName, filePath)

--- a/pkg/git/github/github_client.go
+++ b/pkg/git/github/github_client.go
@@ -355,6 +355,20 @@ func (g *GithubClient) IsFileExist(repoUrl, branchName, filePath string) (bool, 
 	return len(files) > 0, nil
 }
 
+func (g *GithubClient) DownloadFileContent(repoUrl, branchName, filePath string) ([]byte, error) {
+	owner, repository := getOwnerAndRepoFromUrl(repoUrl)
+
+	if branchName == "" {
+		var err error
+		branchName, err = g.getDefaultBranch(owner, repository)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return g.downloadFileContent(owner, repository, branchName, filePath)
+}
+
 // IsRepositoryPublic returns true if the repository could be accessed without authentication
 func (g *GithubClient) IsRepositoryPublic(repoUrl string) (bool, error) {
 	owner, repository := getOwnerAndRepoFromUrl(repoUrl)

--- a/pkg/git/gitlab/gitlab_client.go
+++ b/pkg/git/gitlab/gitlab_client.go
@@ -280,8 +280,20 @@ func (g *GitlabClient) GetBranchSha(repoUrl, branchName string) (string, error) 
 }
 
 func (g *GitlabClient) DownloadFileContent(repoUrl, branchName, filePath string) ([]byte, error) {
-	// TODO
-	return nil, nil
+	projectPath, err := getProjectPathFromRepoUrl(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if branchName == "" {
+		var err error
+		branchName, err = g.getDefaultBranch(projectPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return g.downloadFileContent(projectPath, branchName, filePath)
 }
 
 // IsFileExist check whether given file exists in the given branch of the reposiotry.

--- a/pkg/git/gitlab/gitlab_client.go
+++ b/pkg/git/gitlab/gitlab_client.go
@@ -279,6 +279,11 @@ func (g *GitlabClient) GetBranchSha(repoUrl, branchName string) (string, error) 
 	return sha, nil
 }
 
+func (g *GitlabClient) DownloadFileContent(repoUrl, branchName, filePath string) ([]byte, error) {
+	// TODO
+	return nil, nil
+}
+
 // IsFileExist check whether given file exists in the given branch of the reposiotry.
 // If branch is empty string, default branch is used.
 func (g *GitlabClient) IsFileExist(repoUrl, branchName, filePath string) (bool, error) {

--- a/pkg/git/gitprovider/gitprovider.go
+++ b/pkg/git/gitprovider/gitprovider.go
@@ -49,6 +49,9 @@ type GitProviderClient interface {
 	// GetBranchSha returns SHA of top commit in the given branch
 	GetBranchSha(repoUrl, branchName string) (string, error)
 
+	// DownloadFileContent retrieves file content by full path in the git repository.
+	DownloadFileContent(repoUrl, branchName, filePath string) ([]byte, error)
+
 	// IsFileExist check whether given file exists in the given branch of the reposiotry
 	IsFileExist(repoUrl, branchName, filePath string) (bool, error)
 


### PR DESCRIPTION
- Create a dedicated Service Account for each Component named `build-pipeline-<component-name>` to run build pipelines with.
- Create migration code that would create a PR into user's git repository that specify explicitly Service Account to use for the build pipeline. The migration will be performed per Component if `build.appstudio.openshift.io/sa-migration: 'true'` annotation is added to the Component.
- Build Service will continue creation of old style PaC provision PRs, until `use-new-sa` Config Map is created in `build-service` namespace. Then the new Service Account would be used by default.
- Introduce a new temporal controller that syncs linked secrets from deprecated `appstudio-pipeline` Service Account to the dedicated Component build Service Account. This is needed for UI until new functionality with dedictaed Service Accounts implemented.