### PR TITLE
change branch prefix on a new onboarding component

### DIFF
--- a/internal/controller/component_build_controller_pac.go
+++ b/internal/controller/component_build_controller_pac.go
@@ -60,7 +60,7 @@ const (
 	pacIncomingSecretNameSuffix    = "-incoming"
 	pacIncomingSecretKey           = "incoming-secret"
 
-	pacMergeRequestSourceBranchPrefix = "appstudio-"
+	pacMergeRequestSourceBranchPrefix = "konflux-"
 
 	appstudioWorkspaceNameLabel      = "appstudio.redhat.com/workspace_name"
 	pacCustomParamAppstudioWorkspace = "appstudio_workspace"


### PR DESCRIPTION
This should reduce user confusion and increase consistency with MintMaker branches.

Possible problems:
- If a Component has a PaC provision PR opened, instead of updating old one, a new PR will be created.
- If a Component has a PaC provision PR opened and user requests Component removal /unprovision, old branch will not be removed nor PR closed.

Solution:
An announcement needs to be made to users. When they see duplication the **old one** must be closed.