### PR TITLE
Allow sync of image repository secrets from appstudio-pipeline SA for common image repositories

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,7 @@ import (
 	pacwebhook "github.com/konflux-ci/build-service/pkg/pacwebhook"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	imagerepositoryapi "github.com/konflux-ci/image-controller/api/v1alpha1"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -131,6 +132,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err := releaseapi.AddToScheme(scheme); err != nil {
+		setupLog.Error(err, "unable to add pipelinesascode api to the scheme")
+		os.Exit(1)
+	}
+	if err := imagerepositoryapi.AddToScheme(scheme); err != nil {
 		setupLog.Error(err, "unable to add pipelinesascode api to the scheme")
 		os.Exit(1)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,7 @@ rules:
   - appstudio.redhat.com
   resources:
   - components/status
+  - imagerepositories
   - releaseplanadmissions
   verbs:
   - get

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 require (
 	github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409
 	github.com/konflux-ci/release-service v0.0.0-20240610124538-758a1d48d002
+	github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c
 	github.com/openshift-pipelines/pipelines-as-code v0.28.2
 	github.com/tektoncd/pipeline v0.63.0
 )

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409 h1:hAhhcfc/EXW9eKS827PmyYuhk+Y4KkVOsT53Uo9OzCU=
 github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c h1:+LtI4WT2KDDpCbVki47dLIu03NH6+Qj0d/MKNu3MZYk=
+github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c/go.mod h1:L5Lk8/63ZnyszRdKWYBS5TA8yz1T/lJok8ndgsQTivE=
 github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d h1:z7j3mglNoXvIrw5Vz/Ul+izoITRaqYURPIWrFoEyHgI=
 github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d/go.mod h1:AcChx7FjpYSIkDvQgaUKyauuF0PXm3ivB5MqZSC9Eis=
 github.com/konflux-ci/release-service v0.0.0-20240610124538-758a1d48d002 h1:BHUMLu2XlyxfsdIzI9ru3SGUYtBrFOQIl6zmMNnJYes=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	imagerepositoryapi "github.com/konflux-ci/image-controller/api/v1alpha1"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -87,6 +88,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "tektoncd", "pipeline@v0.63.0", "config", "300-crds"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "openshift-pipelines", "pipelines-as-code@v0.28.2", "config"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "konflux-ci", "release-service@v0.0.0-20240610124538-758a1d48d002", "config", "crd", "bases"),
+			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "konflux-ci", "image-controller@v0.0.0-20250424143112-69ec692d353c", "config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}
@@ -109,6 +111,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = releaseapi.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = imagerepositoryapi.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
Allows sync of ImageRepository secrets from `appstudio-pipeline` Service Account to dedicated build pipelines Service Accounts if ImageRepository is not related to (owned by) any Component. That allows handling of cases when many Components use single image repository created manually.