### PR TITLE
Make gitlab errors permanent

### DIFF
--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -1644,7 +1644,9 @@ var _ = Describe("Component build controller", func() {
 			Expect(isRemovePaCPullRequestInvoked).To(BeFalse())
 			// Clean up for the component should not recreate pipeline service account
 			deleteComponent(resourceCleanupKey)
-			Expect(isRemovePaCPullRequestInvoked).To(BeTrue())
+			// Wait for method to be actually called, because we remove finalizer immediately,
+			// so removal of PR might not be called yet while component is already gone
+			Eventually(func() bool { return isRemovePaCPullRequestInvoked }, timeout, interval).Should(BeTrue())
 
 			pipelineServiceAccountKey := types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: resourceCleanupKey.Namespace}
 			pipelineServiceAccount := &corev1.ServiceAccount{}

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -144,6 +144,8 @@ const (
 	EGitLabTokenBlockedAccount BOErrorId = 92
 	// EGitLabSecretTypeNotSupported the secret type with GitLab credentials is not supported.
 	EGitLabSecretTypeNotSupported BOErrorId = 93
+	// EGitLabBranchDoesntExist GitLab branch doesn't exist
+	EGitLabBranchDoesntExist BOErrorId = 94
 
 	// Value of 'image.redhat.com/image' component annotation is not a valid json or the json has invalid structure.
 	EFailedToParseImageAnnotation BOErrorId = 200
@@ -211,6 +213,7 @@ var boErrorMessages = map[BOErrorId]string{
 	EGitLabTokenUnauthorized:      "Access token is unrecognizable by remote GitLab service",
 	EGitLabTokenBlockedAccount:    "Access token has blocked account",
 	EGitLabSecretTypeNotSupported: "The secret type with GitLab credentials is not supported",
+	EGitLabBranchDoesntExist:      "GitLab branch does not exist",
 
 	EFailedToParseImageAnnotation:        "Failed to parse image.redhat.com/image annotation value",
 	EComponentGitSecretMissing:           "Secret with git credential not found",

--- a/pkg/git/github/github_helper.go
+++ b/pkg/git/github/github_helper.go
@@ -397,6 +397,9 @@ func (g *GithubClient) getAppUserID(userName string) (int64, error) {
 
 // CheckGitUrlError returns more specific git error
 func CheckGitUrlError(err error) error {
+	if _, isBoError := err.(*boerrors.BuildOpError); isBoError {
+		return err
+	}
 	if strings.Contains(err.Error(), "404 Not Found") || strings.Contains(err.Error(), "no such host") {
 		return boerrors.NewBuildOpError(boerrors.ENotExistGitSourceUrl, fmt.Errorf("git source URL host is invalid or repository doesn't exist"))
 	}


### PR DESCRIPTION
when gitlab branch doesn't exist

when token is expired or revoked

when branch can't be created

when commit can't be created in branch

[STONEBLD-3456](https://issues.redhat.com//browse/STONEBLD-3456)
[STONEBLD-3457](https://issues.redhat.com//browse/STONEBLD-3457)
[STONEBLD-3458](https://issues.redhat.com//browse/STONEBLD-3458)
[STONEBLD-3459](https://issues.redhat.com//browse/STONEBLD-3459)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable