### PR TITLE
Fix appstudio-pipeline Service Account Secrets sync for newly created Components

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,7 @@ rules:
   resources:
   - components/status
   - imagerepositories
+  - imagerepositories/status
   - releaseplanadmissions
   verbs:
   - get

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -144,6 +144,7 @@ func updateMetricsTimes(componentIdForMetrics string, requestedAction string, re
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseplanadmissions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=create
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -604,6 +604,11 @@ func isComponentImageRepositorySecret(secretName string, imageRepositories []img
 					return true
 				}
 			}
+			// Handle the situation when both the Component and the Image Repository were created at the same time
+			// and Image Controller operator hasn't yet set the owner reference.
+			if imageRepository.Labels[ApplicationNameLabelName] != "" && imageRepository.Labels[ComponentNameLabelName] != "" {
+				return true
+			}
 			return false
 		}
 	}


### PR DESCRIPTION
Handle the situation when both the Component and the Image Repository were created at the same time and Image Controller operator hasn't yet set the owner reference for the Image Repository. Even in such case, the push secret should not be treated as common and should not be synced to other Components build pipeline Service Account.