### PR TITLE
Fix empty secret name in build pipeline Service Account

### DIFF
--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -187,6 +187,10 @@ func (r *ComponentBuildReconciler) ensureNudgingPullSecrets(ctx context.Context,
 			continue
 		}
 		pullSecretName := imageRepository.Status.Credentials.PullSecretName
+		if pullSecretName == "" {
+			// Skip Image Repositories that are under provision or haven't been provisioned successfully.
+			continue
+		}
 		if !isSaSecretLinked(buildPipelineServiceAccount, pullSecretName, false) {
 			buildPipelineServiceAccount.Secrets = append(buildPipelineServiceAccount.Secrets,
 				corev1.ObjectReference{Name: pullSecretName, Namespace: buildPipelineServiceAccount.Namespace})


### PR DESCRIPTION
Do not add empty pull secret into build pipeline Service Account. That could happen when Image Repository provision failed or not yet finished for a Component that nudges current one.