### PR TITLE
Remove ability to onboard a Component with appstudio-pipeline Service Account

### DIFF
--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -110,25 +110,9 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Con
 		return nil, nil, err
 	}
 
-	// TODO delete the conditions after migration to the new Service Account done.
-	// If a Config Map with name "use-new-sa" exist, switch to the new Service Account.
-	useOldSA := true
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: BuildServiceNamespaceName, Name: "use-new-sa"}, &corev1.ConfigMap{}); err == nil {
-		useOldSA = false
-		log.Info("using new service account in pipeline")
-	} else {
-		if !errors.IsNotFound(err) {
-			return nil, nil, err
-		}
-		log.Info("using old service account in pipeline")
-	}
-
 	pipelineRunOnPush, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, pacTargetBranch, gitClient, false)
 	if err != nil {
 		return nil, nil, err
-	}
-	if useOldSA {
-		pipelineRunOnPush.Spec.TaskRunTemplate = tektonapi.PipelineTaskRunTemplate{}
 	}
 	pipelineRunOnPushYaml, err := yaml.Marshal(pipelineRunOnPush)
 	if err != nil {
@@ -138,9 +122,6 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Con
 	pipelineRunOnPR, err := generatePaCPipelineRunForComponent(component, pipelineSpec, additionalParams, pacTargetBranch, gitClient, true)
 	if err != nil {
 		return nil, nil, err
-	}
-	if useOldSA {
-		pipelineRunOnPR.Spec.TaskRunTemplate = tektonapi.PipelineTaskRunTemplate{}
 	}
 	pipelineRunOnPRYaml, err := yaml.Marshal(pipelineRunOnPR)
 	if err != nil {

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -367,12 +367,6 @@ var _ = Describe("Component build controller", func() {
 		})
 
 		It("should create PaC PR with build pipeline service account", func() {
-			// TODO remove the config map creation after migration is done
-			useNewSaConfigMap := corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "use-new-sa", Namespace: BuildServiceNamespaceName},
-			}
-			Expect(k8sClient.Create(ctx, &useNewSaConfigMap)).To(Succeed())
-
 			isCreatePaCPullRequestInvoked := false
 			EnsurePaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (string, error) {
 				defer GinkgoRecover()


### PR DESCRIPTION
Currently Build Service has option to onboard a Component with deprecated appstudio-pipeline Service Account. It should not be a case any more since appstudio-pipeline SA is past due date. All new Components should use dedicated build pipeline Service Account.