### PR TITLE
fix: format generated commits

### DIFF
--- a/pkg/git/github/github_helper.go
+++ b/pkg/git/github/github_helper.go
@@ -238,7 +238,7 @@ func (g *GithubClient) addCommitToBranch(owner, repository, authorName, authorEm
 		return err
 	}
 	if signedOff {
-		commitMessage = fmt.Sprintf("%s\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
+		commitMessage = fmt.Sprintf("%s\n\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
 	}
 
 	// Create the commit using the tree.
@@ -271,7 +271,7 @@ func (g *GithubClient) addDeleteCommitToBranch(owner, repository, authorName, au
 		return err
 	}
 	if signedOff {
-		commitMessage = fmt.Sprintf("%s\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
+		commitMessage = fmt.Sprintf("%s\n\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
 	}
 
 	// Create the commit using the tree.

--- a/pkg/git/gitlab/gitlab_helper.go
+++ b/pkg/git/gitlab/gitlab_helper.go
@@ -270,7 +270,7 @@ func (g *GitlabClient) commitFilesIntoBranch(projectPath, branchName, commitMess
 		actions = append(actions, action)
 	}
 	if signedOff {
-		commitMessage = fmt.Sprintf("%s\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
+		commitMessage = fmt.Sprintf("%s\n\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
 	}
 
 	opts := &gitlab.CreateCommitOptions{
@@ -298,7 +298,7 @@ func (g *GitlabClient) addDeleteCommitToBranch(projectPath, branchName, authorNa
 		})
 	}
 	if signedOff {
-		commitMessage = fmt.Sprintf("%s\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
+		commitMessage = fmt.Sprintf("%s\n\nSigned-off-by: %s <%s>", commitMessage, authorName, authorEmail)
 	}
 
 	opts := &gitlab.CreateCommitOptions{


### PR DESCRIPTION
When commits are signed off, they are not being formatted correctly. A new line is missing between the title and the sign-off.

**Before:**
Commit title
Signed off part

**After the change:**
Commit title

Signed off part