### PR TITLE
feat: enable hermetic builds

### DIFF
--- a/.tekton/build-service-pull-request.yaml
+++ b/.tekton/build-service-pull-request.yaml
@@ -29,6 +29,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/build-service-push.yaml
+++ b/.tekton/build-service-push.yaml
@@ -26,6 +26,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
There has been a request to enable hermetic build, to increase security.
Hermetic build happens without an access to the internet and that's why we need to prefetch dependencies.
We use Go modules at the moment.