### PR TITLE
fix generating on-cel-expression in an 'on push' PipelineRun file

### DIFF
--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -484,8 +484,12 @@ func generateCelExpressionForPipeline(component *appstudiov1alpha1.Component, gi
 			}
 		}
 
-		pullPipelineFileName := component.Name + "-" + pipelineRunOnPRFilename
-		pathChangedSuffix = fmt.Sprintf(` && ( "%s***".pathChanged() || ".tekton/%s".pathChanged() %s)`, contextDir, pullPipelineFileName, dockerfilePathChangedSuffix)
+		pipelineFileName := component.Name + "-" + pipelineRunOnPushFilename
+		if onPull {
+			pipelineFileName = component.Name + "-" + pipelineRunOnPRFilename
+		}
+
+		pathChangedSuffix = fmt.Sprintf(` && ( "%s***".pathChanged() || ".tekton/%s".pathChanged() %s)`, contextDir, pipelineFileName, dockerfilePathChangedSuffix)
 	}
 
 	return fmt.Sprintf("%s && %s%s", eventCondition, targetBranchCondition, pathChangedSuffix), nil

--- a/internal/controller/component_build_controller_unit_test.go
+++ b/internal/controller/component_build_controller_unit_test.go
@@ -384,7 +384,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 			}(),
 			targetBranch: "my-branch",
 			wantOnPull:   `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
-			wantOnPush:   `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
+			wantOnPush:   `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-push.yaml".pathChanged() )`,
 		},
 		{
 			name: "should generate cel expression for component with context directory and its dockerfile in context directory",
@@ -398,7 +398,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 				return true, nil
 			},
 			wantOnPull: `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
-			wantOnPush: `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
+			wantOnPush: `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-push.yaml".pathChanged() )`,
 		},
 		{
 			name: "should generate cel expression for component with context directory and its dockerfile outside context directory",
@@ -412,7 +412,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 				return false, nil
 			},
 			wantOnPull: `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() || "docker-root-dir/Dockerfile".pathChanged() )`,
-			wantOnPush: `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() || "docker-root-dir/Dockerfile".pathChanged() )`,
+			wantOnPush: `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-push.yaml".pathChanged() || "docker-root-dir/Dockerfile".pathChanged() )`,
 		},
 		{
 			name: "should generate cel expression for component with context directory and its dockerfile outside git repository",
@@ -423,7 +423,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 			}(),
 			targetBranch: "my-branch",
 			wantOnPull:   `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
-			wantOnPush:   `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-pull-request.yaml".pathChanged() )`,
+			wantOnPush:   `event == "push" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || ".tekton/component-name-push.yaml".pathChanged() )`,
 		},
 		{
 			name: "should fail to generate cel expression for component if isFileExist fails",


### PR DESCRIPTION
Currently, generated on-cel-expression would contain a path to a <component-name>-pull-request.yaml file in an 'on push' PipelineRun, which is not correct.
We need to determine between on-push and on-pull-request and adjust the filename in the on-cel-expression accordingly.

Changed the tests to contain correct naming.
Before the change it was the same as on pull request, but there should be a difference between 'on push' and 'on pull' filenames in the on-cel-expression.