### PR TITLE
Fix nil dereference in gitlab.getDefaultBranch

### DIFF
--- a/pkg/git/gitlab/gitlab_helper.go
+++ b/pkg/git/gitlab/gitlab_helper.go
@@ -168,7 +168,10 @@ func (g *GitlabClient) deleteBranch(projectPath, branch string) (bool, error) {
 func (g *GitlabClient) getDefaultBranch(projectPath string) (string, error) {
 	projectInfo, resp, err := g.client.Projects.GetProject(projectPath, nil)
 	if err != nil {
-		return "", refineGitHostingServiceError(resp.Response, err)
+		if resp != nil {
+			err = refineGitHostingServiceError(resp.Response, err)
+		}
+		return "", err
 	}
 	if projectInfo == nil {
 		return "", fmt.Errorf("project info is empty in GitLab API response")


### PR DESCRIPTION
The GetProject() call can return a nil response for various reasons. Don't try to dereference a nil response.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable