### PR TITLE
don't set followTag in renovate config as it isn't meant for container

### DIFF
--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -985,7 +985,6 @@ var _ = Describe("Component nudge controller", func() {
 			Expect(resultConfig.PackageRules[1].BranchPrefix).Should(Equal("konflux/component-updates/"))
 			Expect(resultConfig.PackageRules[1].BranchTopic).Should(Equal(componentName))
 			Expect(resultConfig.PackageRules[1].CommitMessageTopic).Should(Equal(componentName))
-			Expect(resultConfig.PackageRules[1].FollowTag).Should(Equal(builtImageTag))
 			Expect(resultConfig.PackageRules[1].MatchPackageNames).Should(Equal(matchPackageNames))
 			Expect(resultConfig.PackageRules[1].CommitMessagePrefix).Should(Equal(commitMessagePrefix))
 			Expect(resultConfig.PackageRules[1].CommitMessageSuffix).Should(Equal(commitMessageSuffix))

--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -120,7 +120,6 @@ type PackageRule struct {
 	RecreateWhen         string   `json:"recreateWhen,omitempty"`
 	RebaseWhen           string   `json:"rebaseWhen,omitempty"`
 	Enabled              bool     `json:"enabled"`
-	FollowTag            string   `json:"followTag,omitempty"`
 }
 
 type RenovateConfig struct {
@@ -550,7 +549,6 @@ func generateRenovateConfigForNudge(target updateTarget, buildResult *BuildResul
 		RecreateWhen:        "always",
 		RebaseWhen:          "behind-base-branch",
 		Enabled:             true,
-		FollowTag:           buildResult.BuiltImageTag,
 		CommitBody:          fmt.Sprintf("Image created from '%s'\n\nSigned-off-by: %s", gitRepoAtShaLink, target.GitAuthor),
 		CommitMessagePrefix: target.ComponentCustomRenovateOptions.CommitMessagePrefix,
 		CommitMessageSuffix: target.ComponentCustomRenovateOptions.CommitMessageSuffix,


### PR DESCRIPTION
images

[STONEBLD-3662](https://issues.redhat.com//browse/STONEBLD-3662)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable