### PR TITLE
if secret for git has empty string as username treat it as username

### DIFF
--- a/pkg/git/gitproviderfactory/gitproviderfactory.go
+++ b/pkg/git/gitproviderfactory/gitproviderfactory.go
@@ -50,6 +50,9 @@ func createGitClient(gitClientConfig GitClientConfig) (gitprovider.GitProviderCl
 	gitProvider := gitClientConfig.GitProvider
 	secretData := gitClientConfig.PacSecretData
 	username, usernameExists := secretData["username"]
+	if usernameExists && len(username) == 0 {
+		usernameExists = false
+	}
 	password, passwordExists := secretData["password"]
 	_, sshKeyExists := secretData["ssh-privatekey"]
 


### PR DESCRIPTION
wasn't specified, empty username fails in gitlab

[STONEBLD-3653](https://issues.redhat.com//browse/STONEBLD-3653)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable