### PR TITLE
when component is marked for removal in cleanUpNudgingPullSecrets

### DIFF
--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -233,8 +233,11 @@ func (r *ComponentBuildReconciler) cleanUpNudgingPullSecrets(ctx context.Context
 		nudgedComponentBuildPipelineServiceAccountName := getBuildPipelineServiceAccountNameByComponentName(nudgedComponentName)
 		nudgedComponentBuildPipelineServiceAccount := &corev1.ServiceAccount{}
 		if err := r.Client.Get(ctx, types.NamespacedName{Name: nudgedComponentBuildPipelineServiceAccountName, Namespace: component.Namespace}, nudgedComponentBuildPipelineServiceAccount); err != nil {
-			log.Error(err, "failed to get build pipeline Service Account for Component", "Component", nudgedComponentName, l.Action, l.ActionView)
-			return err
+			if !errors.IsNotFound(err) {
+				log.Error(err, "failed to get build pipeline Service Account for Component", "Component", nudgedComponentName, l.Action, l.ActionView)
+				return err
+			}
+			continue
 		}
 
 		pullSecretIndex := getSecretReferenceIndex(nudgedComponentBuildPipelineServiceAccount, pullSecretName, false)


### PR DESCRIPTION
we should ignore if SA for nudged component doesn't exist, as there isn't anything to cleanup, and it shouldn't fail

[KONFLUX-9472](https://issues.redhat.com//browse/KONFLUX-9472)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable