### PR TITLE
fix: when nudging, have Renovate be more patient with GitLab

### DIFF
--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -633,7 +633,7 @@ func (u ComponentDependenciesUpdater) CreateRenovaterPipeline(ctx context.Contex
 		// we are passing host rules via variable, because we can't resolve variable in json config
 		// also this way we can use custom provided config without any modifications
 		renovateCmds = append(renovateCmds,
-			fmt.Sprintf("RENOVATE_PR_HOURLY_LIMIT=0 RENOVATE_PR_CONCURRENT_LIMIT=0 RENOVATE_TOKEN=$TOKEN_%s RENOVATE_CONFIG_FILE=/configs/%s-%s.%s RENOVATE_HOST_RULES=%s renovate", randomStr2, target.ComponentName, randomStr1, configType, hostRules),
+			fmt.Sprintf("RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY=5000 RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS=7 RENOVATE_PR_HOURLY_LIMIT=0 RENOVATE_PR_CONCURRENT_LIMIT=0 RENOVATE_TOKEN=$TOKEN_%s RENOVATE_CONFIG_FILE=/configs/%s-%s.%s RENOVATE_HOST_RULES=%s renovate", randomStr2, target.ComponentName, randomStr1, configType, hostRules),
 		)
 	}
 	if len(renovateCmds) == 0 {


### PR DESCRIPTION
GitLab has a long-standing issue where the API refuses attempts to set "merge when pipeline succeeds" even when the MR is ready for it[1].

Renovate already does some retrying with exponential backoff[2], but the default behavior is to only wait for up to 7.5 seconds. This leads to nudging MRs very often failing to automerge, especially at times of high GitLab load.

By setting a higher base delay value and a higher number of retries we can ensure automerge works a lot more reliably.

[KONFLUX-9373](https://issues.redhat.com//browse/KONFLUX-9373)

[1] https://gitlab.com/gitlab-org/gitlab/-/issues/353984
[2] https://github.com/renovatebot/renovate/blob/88768303ee7f246da3337c5d34cace8c53f1284e/lib/modules/platform/gitlab/index.ts#L694-L714

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable