### PR TITLE
Add labels and annotations to nudge pipelineRuns

### DIFF
--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -438,7 +438,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 		}
 
 		buildResult := BuildResult{BuiltImageRepository: repo, BuiltImageTag: tag, Digest: digest, Component: updatedComponent, DistributionRepositories: distibutionRepositories, FileMatches: nudgeFiles}
-		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun.Namespace, targets, true, simpleBranchName, &buildResult, gitRepoAtShaLink)
+		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun, targets, true, simpleBranchName, &buildResult, gitRepoAtShaLink)
 	} else {
 		log.Info("no targets found to update")
 	}

--- a/internal/controller/renovate_util_test.go
+++ b/internal/controller/renovate_util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022-2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestExtractCommitHash(t *testing.T) {
+	tests := []struct {
+		name      string
+		commitUrl string
+		want      string
+	}{
+		{
+			name:      "should extract commit hash from commit url",
+			commitUrl: "https://forge.com/project/repository/-/tree/4b00cdb6ceb84d3953d8987e3e06f967a6d86e76",
+			want:      "4b00cdb6ceb84d3953d8987e3e06f967a6d86e76",
+		},
+		{
+			name:      "should return empty if commit url is invalid",
+			commitUrl: "https://forge.com/project/repository",
+			want:      "",
+		},
+		{
+			name:      "should avoid erroring if the commit url has no slashes",
+			commitUrl: "forge.com",
+			want:      "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := extractCommitHash(test.commitUrl)
+			assert.Equal(t, got, test.want)
+		})
+	}
+}


### PR DESCRIPTION
This is intented as a way to easily identify these pipelineRuns in the cluster. Since most values could potentially break the 63 character limitation that exists in CR labels, they were instead turned into annotations.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable