### PR TITLE
fix(sealights): add missing params to e2e tests

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -44,6 +44,9 @@ spec:
     - name: enable-sl-plugin
       description: "A flag to enable or disable the Sealights integration feature. When set to 'true', test results are sent to Sealights for analysis; otherwise, this feature is skipped."
       default: "true"
+    - name: enable-sealights
+      description: "A flag to enable sealights integration"
+      default: "true"
     - name: artifact-browser-url
       description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
       default: ""
@@ -147,6 +150,10 @@ spec:
           value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: oci-credentials
           value: $(params.konflux-test-infra-secret)
+        - name: component-image-repository
+          value: $(tasks.sealights-refs.results.sealights-container-repo)
+        - name: component-image-tag
+          value: $(tasks.sealights-refs.results.sealights-container-tag)
         - name: build-credentials
           value: "konflux-e2e-secrets"
     - name: konflux-e2e-tests
@@ -181,6 +188,8 @@ spec:
           value: $(tasks.sealights-refs.results.sealights-bsid)
         - name: test-stage
           value: $(params.test-stage)
+        - name: enable-sealights
+          value: $(params.enable-sealights)
         - name: enable-sl-plugin
           value: $(params.enable-sl-plugin)
         - name: cluster-access-secret-name


### PR DESCRIPTION
Missing params in e2e test tasks causes missing coverage in sealights

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable