### PR TITLE
new annotation on nudged component "build.appstudio.openshift.io/buil…

### DIFF
--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -65,6 +65,7 @@ const (
 	NudgeFinalizer               = "build.appstudio.openshift.io/build-nudge-finalizer"
 	FailureCountAnnotationName   = "build.appstudio.openshift.io/build-nudge-failures"
 	NudgeFilesAnnotationName     = "build.appstudio.openshift.io/build-nudge-files"
+	NudgeSimpleBranchName        = "build.appstudio.openshift.io/build-nudge-simple-branch"
 
 	ComponentNudgedEventType      = "ComponentNudged"
 	ComponentNudgeFailedEventType = "ComponentNudgeFailed"
@@ -416,8 +417,13 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 	gitRepoAtShaLink := pipelineRun.Annotations[gitRepoAtShaAnnotationName]
 	if len(targets) > 0 {
 		log.Info("will create renovate job")
+		simpleBranchName := false
+		if updatedComponent.Annotations != nil && updatedComponent.Annotations[NudgeSimpleBranchName] == "true" {
+			simpleBranchName = true
+		}
+
 		buildResult := BuildResult{BuiltImageRepository: repo, BuiltImageTag: tag, Digest: digest, Component: updatedComponent, DistributionRepositories: distibutionRepositories, FileMatches: nudgeFiles}
-		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun.Namespace, targets, true, &buildResult, gitRepoAtShaLink)
+		nudgeErr = r.ComponentDependenciesUpdater.CreateRenovaterPipeline(ctx, pipelineRun.Namespace, targets, true, simpleBranchName, &buildResult, gitRepoAtShaLink)
 	} else {
 		log.Info("no targets found to update")
 	}

--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -816,7 +816,7 @@ var _ = Describe("Component nudge controller", func() {
 			failures = 1
 			// mock function to produce error
 
-			GenerateRenovateConfigForNudge = func(target updateTarget, buildResult *BuildResult, gitRepoAtShaAnnotation string) (RenovateConfig, error) {
+			GenerateRenovateConfigForNudge = func(target updateTarget, buildResult *BuildResult, gitRepoAtShaAnnotation string, simpleBranchName bool) (RenovateConfig, error) {
 				if failures == 0 {
 					log.Info("components nudged")
 					return RenovateConfig{}, nil
@@ -863,7 +863,7 @@ var _ = Describe("Component nudge controller", func() {
 		It("Test retries exceeded", func() {
 			failures = 10
 			// mock function to produce error
-			GenerateRenovateConfigForNudge = func(target updateTarget, buildResult *BuildResult, gitRepoAtShaAnnotation string) (RenovateConfig, error) {
+			GenerateRenovateConfigForNudge = func(target updateTarget, buildResult *BuildResult, gitRepoAtShaAnnotation string, simpleBranchName bool) (RenovateConfig, error) {
 				if failures == 0 {
 					log.Info("components nudged")
 					return RenovateConfig{}, nil
@@ -971,7 +971,7 @@ var _ = Describe("Component nudge controller", func() {
 				ImageRepositoryUsername:        imageRepositoryUsername,
 			}
 
-			resultConfig, err := generateRenovateConfigForNudge(renovateTarget, &buildResult, imageBuiltFrom)
+			resultConfig, err := generateRenovateConfigForNudge(renovateTarget, &buildResult, imageBuiltFrom, false)
 			Expect(err).Should(Succeed())
 			Expect(resultConfig.GitProvider).Should(Equal(gitProvider))
 			Expect(resultConfig.Username).Should(Equal(gitUsername))
@@ -1015,7 +1015,7 @@ var _ = Describe("Component nudge controller", func() {
 				ImageRepositoryUsername:        imageRepositoryUsername,
 			}
 
-			resultConfig2, err := generateRenovateConfigForNudge(renovateTarget2, &buildResult, imageBuiltFrom)
+			resultConfig2, err := generateRenovateConfigForNudge(renovateTarget2, &buildResult, imageBuiltFrom, false)
 			Expect(err).Should(Succeed())
 			Expect(resultConfig2.CustomManagers[0].FileMatch).Should(Equal(fileMatchesList2))
 		})


### PR DESCRIPTION
…d-nudge-simple-branch"

when annotation is set with "true" nudged component branch won't have nudged component name in it

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable