### PR TITLE
fix: move from common/tasks to tasks

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -74,7 +74,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)


### PR DESCRIPTION
Making changes to the pipelines as per the announcement `[ACTION REQUIRED] Deprecation of duplicate tasks in tekton-integration-catalog` on 24th Sept