### PR TITLE
Don't list all installations when creating newGithubClientByApp and

### DIFF
--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -266,6 +266,7 @@ func (u ComponentDependenciesUpdater) GetUpdateTargetsGithubApp(ctx context.Cont
 	// Load GitHub App and get GitHub Installations
 	githubAppIdStr := string(pacSecret.Data[PipelinesAsCodeGithubAppIdKey])
 	privateKey := pacSecret.Data[PipelinesAsCodeGithubPrivateKey]
+	pacConfig := map[string][]byte{PipelinesAsCodeGithubPrivateKey: []byte(privateKey), PipelinesAsCodeGithubAppIdKey: []byte(githubAppIdStr)}
 
 	// Match installed repositories with Components and get custom branch if defined
 	targetsToUpdate := []updateTarget{}
@@ -292,16 +293,15 @@ func (u ComponentDependenciesUpdater) GetUpdateTargetsGithubApp(ctx context.Cont
 		url := getGitRepoUrl(component)
 		log.Info("getting app installation for component repository", "ComponentName", component.Name, "ComponentNamespace", component.Namespace, "RepositoryUrl", url)
 		githubAppInstallation, slugTmp, err := github.GetAppInstallationsForRepository(githubAppIdStr, privateKey, url)
-		if slug == "" {
-			slug = slugTmp
-		}
 		if err != nil {
 			log.Error(err, "Failed to get GitHub app installation for component", "ComponentName", component.Name, "ComponentNamespace", component.Namespace)
 			continue
 		}
+		if slug == "" {
+			slug = slugTmp
+		}
 
 		if appBotId == 0 {
-			pacConfig := map[string][]byte{PipelinesAsCodeGithubPrivateKey: []byte(privateKey), PipelinesAsCodeGithubAppIdKey: []byte(githubAppIdStr)}
 			gitClient, err := gitproviderfactory.CreateGitClient(gitproviderfactory.GitClientConfig{
 				PacSecretData: pacConfig,
 				GitProvider:   gitProvider,

--- a/pkg/git/github/github_client.go
+++ b/pkg/git/github/github_client.go
@@ -49,6 +49,8 @@ type GithubClient struct {
 
 	appId            int64
 	appPrivateKeyPem []byte
+	appName          string
+	appSlug          string
 }
 
 // EnsurePaCMergeRequest creates or updates existing Pipelines as Code configuration proposal merge request

--- a/pkg/git/gitproviderfactory/gitproviderfactory.go
+++ b/pkg/git/gitproviderfactory/gitproviderfactory.go
@@ -89,15 +89,6 @@ func createGitClient(gitClientConfig GitClientConfig) (gitprovider.GitProviderCl
 			return nil, err
 		}
 
-		// Check if the application is installed into target repository
-		appInstalled, err := githubClient.IsAppInstalledIntoRepository(gitClientConfig.RepoUrl)
-		if err != nil {
-			return nil, err
-		}
-		if !appInstalled {
-			return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppNotInstalled,
-				fmt.Errorf("failed to create git client: GitHub Application is not installed into the repository"))
-		}
 		return githubClient, nil
 
 	case "gitlab":


### PR DESCRIPTION
just find specific installation for a repository and owner

also removed IsAppInstalledIntoRepository, since that check is now in newGithubClientByApp

also store github app name & slug in GithubClient

[STONEBLD-3905](https://issues.redhat.com//browse/STONEBLD-3905)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable