### PR TITLE
if platformAutomerge isn't specified explicitly set it to True, as is

### DIFF
--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -412,6 +412,9 @@ func (u ComponentDependenciesUpdater) ReadCustomRenovateConfigMap(ctx context.Co
 		} else {
 			customRenovateOptions.PlatformAutomerge = platformAutomergeValue
 		}
+	} else {
+		// renovate default is True
+		customRenovateOptions.PlatformAutomerge = true
 	}
 
 	ignoreTestsOption, ignoreTestsExists := customRenovateConfigMap.Data[RenovateConfigMapIgnoreTestsKey]


### PR DESCRIPTION
default for renovate

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable