### PR TITLE
Remove SeaLights from build-service

### DIFF
--- a/.tekton/build-service-pull-request.yaml
+++ b/.tekton/build-service-pull-request.yaml
@@ -173,49 +173,18 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
-    - name: sealights-go-instrumentation
-      params:
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      - name: component
-        value: '{{ repo_name }}'
-      - name: branch
-        value: '{{ source_branch }}'
-      - name: revision
-        value: '{{ revision }}'
-      - name: repository-url
-        value: '{{ repo_url }}'
-      - name: pull-request-number
-        value: '{{ pull_request_number }}'
-      - name: target-branch
-        value: '{{ target_branch }}'
-      - name: oci-storage
-        value: $(params.output-image).sealights.git
-      - name: disable-token-save
-        value: 'true'
-      runAfter:
-      - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: sealights-go-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sealights-go-oci-ta:0.1@sha256:ce75fd9d498365a9c1e42f8340cc3e7d09a68ab312588905d169964055f092b2
-        - name: kind
-          value: task
-        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.sealights-go-instrumentation.results.SOURCE_ARTIFACT)
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - sealights-go-instrumentation
+      - clone-repository
       taskRef:
         params:
         - name: name

--- a/.tekton/build-service-push.yaml
+++ b/.tekton/build-service-push.yaml
@@ -170,31 +170,6 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
-    - name: sealights-go-instrumentation
-      params:
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      - name: component
-        value: '{{ repo_name }}'
-      - name: branch
-        value: '{{ source_branch }}'
-      - name: revision
-        value: '{{ revision }}'
-      - name: oci-storage
-        value: $(params.output-image).sealights.git
-      - name: disable-token-save
-        value: 'true'
-      runAfter:
-      - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: sealights-go-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sealights-go-oci-ta:0.1@sha256:ce75fd9d498365a9c1e42f8340cc3e7d09a68ab312588905d169964055f092b2
-        - name: kind
-          value: task
-        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
@@ -253,53 +228,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - prefetch-dependencies
-      taskRef:
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:650b0bca57c626c1e82f35cdfadf44a7792230b2b992aaa9c369d615aae6590d
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - 'true'
-    - matrix:
-        params:
-        - name: PLATFORM
-          value:
-          - $(params.build-platforms)
-      name: build-sealights-images
-      params:
-      - name: IMAGE
-        value: $(params.output-image).sealights
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.sealights-go-instrumentation.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - prefetch-dependencies
-      - sealights-go-instrumentation
       taskRef:
         params:
         - name: name

--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -17,11 +17,6 @@ spec:
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
       default: ''
-    - name: test-stage
-      default: 'build-service-e2e'
-      description: >-
-        "The name or identifier of the testing phase (e.g., "integration", "e2e") during which the results
-          are being captured. This helps distinguish the test results within Sealights for better reporting and traceability"
     - name: ocp-version
       description: 'The OpenShift version to use for the ephemeral cluster deployment.'
       type: string
@@ -41,30 +36,11 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
-    - name: enable-sl-plugin
-      description: "A flag to enable or disable the Sealights integration feature. When set to 'true', test results are sent to Sealights for analysis; otherwise, this feature is skipped."
-      default: "true"
-    - name: enable-sealights
-      description: "A flag to enable sealights integration"
-      default: "true"
     - name: artifact-browser-url
       description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
       default: ""
       type: string
   tasks:
-    - name: sealights-refs
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
     - name: test-metadata
       taskRef:
         resolver: git
@@ -74,7 +50,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.3/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -82,7 +58,6 @@ spec:
           value: $(context.pipelineRun.name)
     - name: provision-kind-cluster
       runAfter:
-        - sealights-refs
         - test-metadata
       taskRef:
         resolver: git
@@ -151,9 +126,9 @@ spec:
         - name: oci-credentials
           value: $(params.konflux-test-infra-secret)
         - name: component-image-repository
-          value: $(tasks.sealights-refs.results.sealights-container-repo)
+          value: $(tasks.test-metadata.results.container-repo)
         - name: component-image-tag
-          value: $(tasks.sealights-refs.results.sealights-container-tag)
+          value: $(tasks.test-metadata.results.container-tag)
         - name: build-credentials
           value: "konflux-e2e-secrets"
     - name: konflux-e2e-tests
@@ -183,15 +158,7 @@ spec:
         - name: job-spec
           value: $(tasks.test-metadata.results.job-spec)
         - name: component-image
-          value: $(tasks.sealights-refs.results.sealights-container-image)
-        - name: sealights-bsid
-          value: $(tasks.sealights-refs.results.sealights-bsid)
-        - name: test-stage
-          value: $(params.test-stage)
-        - name: enable-sealights
-          value: $(params.enable-sealights)
-        - name: enable-sl-plugin
-          value: $(params.enable-sl-plugin)
+          value: $(tasks.test-metadata.results.container-image)
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
         - name: test-environment


### PR DESCRIPTION
SeaLights was introduced in order to provide E2E tests code coverage. However, the license for it has not been renewed and SeaLights will thus stop working.

Get rid of it before it breaks CI