### PR TITLE
enable tag push events by default for webhook in gitlab

### DIFF
--- a/.tekton/build-service-pull-request.yaml
+++ b/.tekton/build-service-pull-request.yaml
@@ -140,7 +140,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:ec962d0be18f36ca7d331c99bf243800f569fc0a2ea6f8c8c3d3a574b71c44dc
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:4072de81ade0a75ad1eaa5449a7ff02bba84757064549a81b48c28fab3aeca59
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/build-service-push.yaml
+++ b/.tekton/build-service-push.yaml
@@ -137,7 +137,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:ec962d0be18f36ca7d331c99bf243800f569fc0a2ea6f8c8c3d3a574b71c44dc
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:4072de81ade0a75ad1eaa5449a7ff02bba84757064549a81b48c28fab3aeca59
         - name: kind
           value: task
         resolver: bundles

--- a/pkg/git/gitlab/gitlab_helper.go
+++ b/pkg/git/gitlab/gitlab_helper.go
@@ -414,6 +414,7 @@ func getPaCWebhookOpts(webhookTargetUrl, webhookSecret string) *gitlab.AddProjec
 	mergeRequestsEvents := true
 	pushEvents := true
 	noteEvents := true
+	tagEvents := true
 
 	return &gitlab.AddProjectHookOptions{
 		URL:                   &webhookTargetUrl,
@@ -422,6 +423,7 @@ func getPaCWebhookOpts(webhookTargetUrl, webhookSecret string) *gitlab.AddProjec
 		MergeRequestsEvents:   &mergeRequestsEvents,
 		PushEvents:            &pushEvents,
 		NoteEvents:            &noteEvents,
+		TagPushEvents:         &tagEvents,
 	}
 }
 


### PR DESCRIPTION
[STONEBLD-3998](https://issues.redhat.com//browse/STONEBLD-3998)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable