### PR TITLE
feat: onboard to CoverPort

### DIFF
--- a/.github/workflows/codecov-main.yaml
+++ b/.github/workflows/codecov-main.yaml
@@ -14,7 +14,8 @@ jobs:
       - name: Run tests
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
           verbose: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,4 +49,7 @@ jobs:
       - name: Run tests
         run: make test
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests

--- a/.tekton/build-service-pull-request.yaml
+++ b/.tekton/build-service-pull-request.yaml
@@ -223,6 +223,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - ENABLE_COVERAGE=true
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: SOURCE_ARTIFACT

--- a/.tekton/build-service-push.yaml
+++ b/.tekton/build-service-push.yaml
@@ -196,6 +196,48 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: build-instrumented-image
+      params:
+      - name: IMAGE
+        value: $(params.output-image).instrumented
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+        - ENABLE_COVERAGE=true
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:b54509f5f695c0c89de4587a403099a26da5cdc3707037edd4b7cf4342b63edd
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
     - matrix:
         params:
         - name: PLATFORM

--- a/cmd/coverage_init.go
+++ b/cmd/coverage_init.go
@@ -1,0 +1,9 @@
+//go:build coverage
+
+package main
+
+// This file is only included when building with -tags=coverage.
+// It starts a coverage HTTP server that allows collecting coverage data
+// from the running binary during E2E tests.
+
+import _ "github.com/konflux-ci/coverport/instrumentation/go" // starts coverage server via init()

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b // indirect
 	github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409 h1:hAhhcfc/EXW9eKS827PmyYuhk+Y4KkVOsT53Uo9OzCU=
 github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b h1:NoriO1KRc+7d2/JA07JizqxP0LlA2oJdD5AuQOvEIjE=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c h1:+LtI4WT2KDDpCbVki47dLIu03NH6+Qj0d/MKNu3MZYk=
 github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c/go.mod h1:L5Lk8/63ZnyszRdKWYBS5TA8yz1T/lJok8ndgsQTivE=
 github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d h1:z7j3mglNoXvIrw5Vz/Ul+izoITRaqYURPIWrFoEyHgI=

--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -50,7 +50,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/test-metadata/0.3/test-metadata.yaml
+            value: tasks/test-metadata/0.4/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -126,9 +126,9 @@ spec:
         - name: oci-credentials
           value: $(params.konflux-test-infra-secret)
         - name: component-image-repository
-          value: $(tasks.test-metadata.results.container-repo)
+          value: $(tasks.test-metadata.results.instrumented-container-repo)
         - name: component-image-tag
-          value: $(tasks.test-metadata.results.container-tag)
+          value: $(tasks.test-metadata.results.instrumented-container-tag)
         - name: build-credentials
           value: "konflux-e2e-secrets"
     - name: konflux-e2e-tests
@@ -163,6 +163,31 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: test-environment
           value: "upstream"
+    - name: collect-and-upload-coverage
+      runAfter:
+        - konflux-e2e-tests
+      params:
+        - name: instrumented-images
+          value: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: test-name
+          value: e2e-tests
+        - name: oci-container
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: codecov-flags
+          value: e2e-tests
+        - name: credentials-secret-name
+          value: "build-service-coverport-secrets"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
   finally:
     - name: store-pipeline-status
       taskRef:


### PR DESCRIPTION
This PR onboards build-service to CoverPort.

### What is CoverPort

Open-source solution for producing and collecting of E2E test coverage data and for reporting of any kind of test data for containerized applications across Konflux components, replacing Sealights. Coverage data is collected during E2E tests, processed via Tekton tasks, uploaded to CodeCov/SonarCloud/SonarQube for visualization, and aggregated in DevLake for long-term analytics and weekly reporting.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable