### PR TITLE
Disable renovate updates for golang dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,22 @@
       "automerge": true
     },
     {
+      "description": "Go minor updates",
       "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
-      "matchDepTypes": ["golang"],
-      "enabled": false
+      "matchUpdateTypes": ["minor"],
+      "groupName": "go minor dependencies"
+    },
+    {
+      "description": "Go patch updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "go patch dependencies"
+    },
+    {
+      "description": "Go digest updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "groupName": "go digest dependencies"
     }
   ]
 }


### PR DESCRIPTION
We have a lot of PRs from renovate that bumps some golang deps.
It causes noise for no gain:
- Security related issues are reported by Konflux CI
- Quite often upating a depencency involves other updates, since some deps must be in sync.
- If everything just works, why would we need a newer version? I'd prefer stability.