### PR TITLE
test: collect coverage even if tests fail

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -163,9 +163,8 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: test-environment
           value: "upstream"
+  finally:
     - name: collect-and-upload-coverage
-      runAfter:
-        - konflux-e2e-tests
       params:
         - name: instrumented-images
           value: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
@@ -174,7 +173,7 @@ spec:
         - name: test-name
           value: e2e-tests
         - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)-coverport"
         - name: codecov-flags
           value: e2e-tests
         - name: credentials-secret-name
@@ -188,7 +187,12 @@ spec:
             value: main
           - name: pathInRepo
             value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
-  finally:
+      when:
+        - input: $(tasks.konflux-e2e-tests.status)
+          operator: in
+          values:
+            - Succeeded
+            - Failed
     - name: store-pipeline-status
       taskRef:
         resolver: git


### PR DESCRIPTION
If we collect the e2e test coverage data **only when all e2e tests pass**, we're losing data for jobs that are failing due to flakey tests (e.g. periodic jobs)

Adding the "collect-and-upload-coverage" task to the finally block should prevent losing the coverage data.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable