### PR TITLE
component will create namespace pull secret if it doesn't exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 
 // If you update dependencies below you must also update internal/controller/suite_test.go
 require (
-	github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409
+	github.com/konflux-ci/application-api v0.0.0-20251126155256-d24742e8b026
 	github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c
 	github.com/konflux-ci/release-service v0.0.0-20240610124538-758a1d48d002
 	github.com/openshift-pipelines/pipelines-as-code v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
-github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409 h1:hAhhcfc/EXW9eKS827PmyYuhk+Y4KkVOsT53Uo9OzCU=
-github.com/konflux-ci/application-api v0.0.0-20240812090716-e7eb2ecfb409/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/application-api v0.0.0-20251126155256-d24742e8b026 h1:Y6oKDSxmDY7JiNsrPm0ZRUcW+9cv20B71DuitI3sl28=
+github.com/konflux-ci/application-api v0.0.0-20251126155256-d24742e8b026/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b h1:NoriO1KRc+7d2/JA07JizqxP0LlA2oJdD5AuQOvEIjE=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c h1:+LtI4WT2KDDpCbVki47dLIu03NH6+Qj0d/MKNu3MZYk=

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -69,6 +69,12 @@ const (
 	buildPipelineConfigName            = "config.yaml"
 
 	waitForContainerImageMessage = "waiting for spec.containerImage to be set by ImageRepository with annotation image-controller.appstudio.redhat.com/update-component-image"
+
+	// when true, will enforce namespace pull secret creation
+	// when false, doesn't check namespace pull secret existence anymore
+	ensureNamespacePullSecretAnnotation = "build.appstudio.openshift.io/ensure-namespace-pull-secret"
+	integrationServiceAccountName       = "konflux-integration-runner"
+	namespacePullSecretName             = "components-namespace-pull"
 )
 
 type BuildStatus struct {
@@ -183,6 +189,38 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// because Image Controller operator expects the Service Account to exist to link push secret to it.
 		if err := r.EnsureBuildPipelineServiceAccount(ctx, &component); err != nil {
 			return ctrl.Result{}, err
+		}
+
+		ensureNamespacePullSecret, ensureNamespacePullSecretExists := component.Annotations[ensureNamespacePullSecretAnnotation]
+
+		// ensure namespace pull secret forced by annotation, useful for migration
+		if ensureNamespacePullSecretExists && ensureNamespacePullSecret == "true" {
+			if err := r.checkNamespacePullSecretAndSetAnnotation(ctx, req.NamespacedName, &component); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// ensure namespace pull secret also after component has already finalizer
+		if controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizer) {
+			// don't check namespace pull secret if ensureNamespacePullSecretAnnotation is set to false already
+			// this will prevent getting Secret multiple times after finalizer is set
+			if !ensureNamespacePullSecretExists || ensureNamespacePullSecret != "false" {
+				if err := r.checkNamespacePullSecretAndSetAnnotation(ctx, req.NamespacedName, &component); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{}, nil
+			}
+
+			// add namespace pull secret to integration SA
+			if err := r.updateSaWithNamespacePullSecret(ctx, integrationServiceAccountName, component.Namespace, true); err != nil {
+				return ctrl.Result{}, err
+			}
+
+			// add namespace pull secret to component SA
+			if err := r.updateSaWithNamespacePullSecret(ctx, getBuildPipelineServiceAccountName(component.Name), component.Namespace, false); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -356,7 +356,7 @@ func generatePaCPipelineRunForComponent(
 			Params:       params,
 			Workspaces:   pipelineRunWorkspaces,
 			TaskRunTemplate: tektonapi.PipelineTaskRunTemplate{
-				ServiceAccountName: getBuildPipelineServiceAccountName(component),
+				ServiceAccountName: getBuildPipelineServiceAccountName(component.Name),
 			},
 		},
 	}

--- a/internal/controller/component_build_controller_secrets.go
+++ b/internal/controller/component_build_controller_secrets.go
@@ -20,14 +20,17 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -36,6 +39,16 @@ import (
 	"github.com/konflux-ci/build-service/pkg/git"
 	l "github.com/konflux-ci/build-service/pkg/logs"
 )
+
+const InternalSecretLabelName = "appstudio.redhat.com/internal"
+
+// dockerConfigJson represents the structure of a .dockerconfigjson secret
+type dockerConfigJson struct {
+	Auths map[string]dockerConfigAuth `json:"auths"`
+}
+type dockerConfigAuth struct {
+	Auth string `json:"auth"`
+}
 
 // ensureIncomingSecret is ensuring that incoming secret for PaC trigger exists
 // if secret doesn't exists it will create it and also add repository as owner
@@ -186,6 +199,129 @@ func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, comp
 	}
 
 	return webhookSecretString, nil
+}
+
+// checkNamespacePullSecretAndSetAnnotation ensures that namespace pull secret exists and adds annotation
+func (r *ComponentBuildReconciler) checkNamespacePullSecretAndSetAnnotation(ctx context.Context, namespace types.NamespacedName, component *appstudiov1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	if err := r.ensureNamespacePullSecret(ctx, component.Namespace); err != nil {
+		return err
+	}
+
+	checkType := "implicit"
+	ensureNamespacePullSecret, ensureNamespacePullSecretExists := component.Annotations[ensureNamespacePullSecretAnnotation]
+	if ensureNamespacePullSecretExists && ensureNamespacePullSecret == "true" {
+		checkType = "explicit"
+	}
+
+	if component.Annotations == nil {
+		component.Annotations = make(map[string]string)
+	}
+	component.Annotations[ensureNamespacePullSecretAnnotation] = "false"
+	if err := r.Client.Update(ctx, component); err != nil {
+		log.Error(err, fmt.Sprintf("failed to update component after %s ensuring namespace pull secret", checkType))
+		return err
+	}
+	log.Info(fmt.Sprintf("updated component after %s ensuring namespace pull secret", checkType))
+	r.WaitForCacheUpdate(ctx, namespace, component)
+
+	return nil
+}
+
+// ensureNamespacePullSecret ensures that namespace pull secret exists
+func (r *ComponentBuildReconciler) ensureNamespacePullSecret(ctx context.Context, namespace string) error {
+	log := ctrllog.FromContext(ctx)
+
+	namespacePullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: namespacePullSecretName, Namespace: namespace}, namespacePullSecret); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to get namespace pull secret", "secretName", namespacePullSecretName)
+			return err
+		}
+
+		secretList := &corev1.SecretList{}
+		if err := r.Client.List(ctx, secretList, &client.ListOptions{Namespace: namespace}); err != nil {
+			log.Error(err, "failed to list secrets", l.Action, l.ActionView)
+			return err
+		}
+
+		combinedAuths := dockerConfigJson{Auths: map[string]dockerConfigAuth{}}
+
+		// add to the namespace pull secret only pull secrets from ImageRepositories
+		for _, secret := range secretList.Items {
+			shouldProcess := false
+
+			// Only process secrets of type kubernetes.io/dockerconfigjson
+			if secret.Type != corev1.SecretTypeDockerConfigJson {
+				continue
+			}
+
+			// Secret missing .dockerconfigjson key
+			dockerConfigDataBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
+			if !ok {
+				continue
+			}
+
+			// Only process pull secret from ImageRepository
+			if !strings.HasSuffix(secret.Name, "-image-pull") {
+				continue
+			}
+
+			// Only process pull secret owned by ImageRepository
+			for _, owner := range secret.OwnerReferences {
+				if owner.Kind == "ImageRepository" {
+					shouldProcess = true
+					break
+				}
+			}
+
+			if !shouldProcess {
+				continue
+			}
+
+			var dcj dockerConfigJson
+			if err := json.Unmarshal(dockerConfigDataBytes, &dcj); err != nil {
+				log.Error(err, "failed to unmarshal .dockerconfigjson data from secret", "secretName", secret.Name)
+				continue
+			}
+
+			for registry, authEntry := range dcj.Auths {
+				combinedAuths.Auths[registry] = authEntry
+			}
+		}
+
+		// Marshal combined auths back into .dockerconfigjson format
+		combinedDockerConfig := dockerConfigJson{Auths: combinedAuths.Auths}
+		marshaledData, err := json.Marshal(combinedDockerConfig)
+		if err != nil {
+			log.Error(err, "failed to marshal combined docker config json")
+			return err
+		}
+
+		// Create namespace pull secret
+		namespacePullSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespacePullSecretName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					InternalSecretLabelName: "true",
+				},
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: marshaledData,
+			},
+		}
+
+		if err := r.Client.Create(ctx, namespacePullSecret); err != nil {
+			log.Error(err, "failed to create namespace pull secret", "secretName", namespacePullSecret, l.Action, l.ActionAdd)
+			return err
+		}
+		log.Info("Namespace pull secret created", "secretName", namespacePullSecretName)
+	}
+
+	return nil
 }
 
 func getWebhookSecretKeyForComponent(component appstudiov1alpha1.Component) string {

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -47,10 +47,7 @@ const (
 
 // getBuildPipelineServiceAccountName returns name of dedicated Service Account
 // that should be used for build pipelines of the given Component.
-func getBuildPipelineServiceAccountName(component *appstudiov1alpha1.Component) string {
-	return getBuildPipelineServiceAccountNameByComponentName(component.GetName())
-}
-func getBuildPipelineServiceAccountNameByComponentName(componentName string) string {
+func getBuildPipelineServiceAccountName(componentName string) string {
 	return "build-pipeline-" + componentName
 }
 
@@ -62,7 +59,7 @@ func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context
 	ctx = ctrllog.IntoContext(ctx, log)
 
 	// Verify build pipeline Service Account
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	buildPipelinesServiceAccount := &corev1.ServiceAccount{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, buildPipelinesServiceAccount); err != nil {
 		if !errors.IsNotFound(err) {
@@ -89,6 +86,7 @@ func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context
 			log.Error(err, fmt.Sprintf("failed to create Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionAdd)
 			return err
 		}
+		log.Info("Component SA created", "saName", buildPipelineServiceAccountName)
 	}
 
 	if err := r.ensureNudgingPullSecrets(ctx, component); err != nil {
@@ -135,7 +133,7 @@ func (r *ComponentBuildReconciler) linkCommonSecretsToBuildPipelineServiceAccoun
 // has pull secrets for image repositories of Components that nudge current Component linked.
 // Note, they must be linked into Secrets section (not imagePullSecrets).
 func (r *ComponentBuildReconciler) ensureNudgingPullSecrets(ctx context.Context, component *appstudiov1alpha1.Component) error {
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	log := ctrllog.FromContext(ctx).WithValues("ServiceAccountName", buildPipelineServiceAccountName)
 
 	allComponentsInNamespaceList := &appstudiov1alpha1.ComponentList{}
@@ -222,7 +220,7 @@ func (r *ComponentBuildReconciler) cleanUpNudgingPullSecrets(ctx context.Context
 	pullSecretName := imageRepository.Status.Credentials.PullSecretName
 
 	for _, nudgedComponentName := range component.Spec.BuildNudgesRef {
-		nudgedComponentBuildPipelineServiceAccountName := getBuildPipelineServiceAccountNameByComponentName(nudgedComponentName)
+		nudgedComponentBuildPipelineServiceAccountName := getBuildPipelineServiceAccountName(nudgedComponentName)
 		nudgedComponentBuildPipelineServiceAccount := &corev1.ServiceAccount{}
 		if err := r.Client.Get(ctx, types.NamespacedName{Name: nudgedComponentBuildPipelineServiceAccountName, Namespace: component.Namespace}, nudgedComponentBuildPipelineServiceAccount); err != nil {
 			if !errors.IsNotFound(err) {
@@ -282,7 +280,7 @@ func (r *ComponentBuildReconciler) getComponentImageRepository(ctx context.Conte
 func (r *ComponentBuildReconciler) ensureBuildPipelineServiceAccountBinding(ctx context.Context, component *appstudiov1alpha1.Component) error {
 	log := ctrllog.FromContext(ctx)
 
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 
 	// Verify Role Binding for build pipeline Service Account
 	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
@@ -373,7 +371,7 @@ func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx 
 
 	subjectsNumberBefore := len(buildPipelinesRoleBinding.Subjects)
 
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	subjectIndex := getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName)
 	if subjectIndex != -1 {
 		if len(buildPipelinesRoleBinding.Subjects) == 1 {
@@ -459,4 +457,46 @@ func getSecretReferenceIndex(serviceAccount *corev1.ServiceAccount, secretName s
 
 func isSaSecretLinked(serviceAccount *corev1.ServiceAccount, secretName string, isPull bool) bool {
 	return getSecretReferenceIndex(serviceAccount, secretName, isPull) != -1
+}
+
+// updateSaWithNamespacePullSecret updates a ServiceAccount to include
+// the namespace pull secret as an imagePullSecret and as a Secret depending on bothSections param
+func (r *ComponentBuildReconciler) updateSaWithNamespacePullSecret(ctx context.Context, saName, namespace string, bothSections bool) error {
+	log := ctrllog.FromContext(ctx)
+
+	// fetch SA
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: saName, Namespace: namespace}, serviceAccount); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("ServiceAccount not found", "serviceAccountName", saName, "namespace", namespace)
+			return nil
+		}
+		log.Error(err, "failed to read ServiceAccount", "serviceAccountName", saName, "namespace", namespace, l.Action, l.ActionView)
+		return err
+	}
+
+	// Check and update Secrets
+	shouldUpdateServiceAccount := false
+	if !isSaSecretLinked(serviceAccount, namespacePullSecretName, false) {
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: namespacePullSecretName})
+		shouldUpdateServiceAccount = true
+	}
+
+	// Check and update imagePullSecrets
+	if bothSections {
+		if !isSaSecretLinked(serviceAccount, namespacePullSecretName, true) {
+			serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: namespacePullSecretName})
+			shouldUpdateServiceAccount = true
+		}
+	}
+
+	if shouldUpdateServiceAccount {
+		if err := r.Client.Update(ctx, serviceAccount); err != nil {
+			log.Error(err, "failed to update Service Account with namespace pull secret", "serviceAccountName", saName, "namespace", namespace, l.Action, l.ActionUpdate)
+			return err
+		}
+		log.Info("Service Account updated successfully with namespace pull secret.", "serviceAccountName", saName, "namespace", namespace, "secretName", namespacePullSecretName)
+	}
+
+	return nil
 }

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -121,10 +122,12 @@ var _ = Describe("Component build controller", func() {
 
 	Context("Test build pipeline Service Account", func() {
 		var (
-			namespace           = "sa-test"
-			component1Key       = types.NamespacedName{Name: "component-sa-1", Namespace: namespace}
-			component2Key       = types.NamespacedName{Name: "component-sa-2", Namespace: namespace}
-			buildRoleBindingKey = types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: namespace}
+			namespace              = "sa-test"
+			component1Key          = types.NamespacedName{Name: "component-sa-1", Namespace: namespace}
+			component2Key          = types.NamespacedName{Name: "component-sa-2", Namespace: namespace}
+			buildRoleBindingKey    = types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: namespace}
+			namespacePullSecretKey = types.NamespacedName{Name: namespacePullSecretName, Namespace: namespace}
+			integrationSaKey       = types.NamespacedName{Name: integrationServiceAccountName, Namespace: namespace}
 		)
 
 		_ = BeforeEach(func() {
@@ -138,6 +141,7 @@ var _ = Describe("Component build controller", func() {
 			}
 			createSecret(pacSecretKey, pacSecretData)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
+			createServiceAccount(integrationSaKey)
 
 			ResetTestGitProviderClient()
 		})
@@ -149,6 +153,106 @@ var _ = Describe("Component build controller", func() {
 			deleteRoleBinding(buildRoleBindingKey)
 			deleteServiceAccount(getComponentServiceAccountKey(component1Key))
 			deleteServiceAccount(getComponentServiceAccountKey(component2Key))
+			deleteServiceAccount(integrationSaKey)
+			deleteSecret(namespacePullSecretKey)
+		})
+
+		It("should create namespace pull secret and test forced creation and check linking", func() {
+			createComponent(component1Key)
+			component1SAKey := getComponentServiceAccountKey(component1Key)
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
+			namespacePullSecret := waitSecretCreated(namespacePullSecretKey)
+			component1SA := waitServiceAccount(component1SAKey)
+			integrationSA := waitServiceAccount(integrationSaKey)
+
+			// namespace pull secret is linked to component SA
+			Expect(component1SA.ImagePullSecrets).To(HaveLen(0))
+			Expect(component1SA.Secrets).To(HaveLen(1))
+			Expect(component1SA.Secrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+
+			// namespace pull secret is linked to integration SA
+			Expect(integrationSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(integrationSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+			Expect(integrationSA.Secrets).To(HaveLen(1))
+			Expect(integrationSA.Secrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+
+			// namespace pull secret is created empty because there weren't any IR pull secrets
+			namespacePullSecretDockerConfigJson := string(namespacePullSecret.Data[corev1.DockerConfigJsonKey])
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(namespacePullSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(decodedSecret.Auths).To(HaveLen(0))
+
+			// pull secret with IR owner will be added to namespace pull secret
+			pullSecret1Data := generateDockerConfigJson("registry1", "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: "pull1-image-pull", Namespace: namespace}
+			// pull secret with IR owner will be added to namespace pull secret
+			pullSecret2Data := generateDockerConfigJson("registry2", "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: "pull2-image-pull", Namespace: namespace}
+			// push secret with IR owner won't be added to namespace pull secret
+			pushSecretData := generateDockerConfigJson("registry3", "user3", "pass3")
+			pushSecretKey := types.NamespacedName{Name: "push3-image-push", Namespace: namespace}
+			// user secret without owner, named like IR pull secret, won't be added to namespace pull secret
+			userSecret1Data := generateDockerConfigJson("registry4", "user4", "pass4")
+			userSecret1Key := types.NamespacedName{Name: "pull4-image-pull", Namespace: namespace}
+			// user secret without owner, won't be added to namespace pull secret
+			userSecret2Data := generateDockerConfigJson("registry5", "user5", "pass5")
+			userSecret2Key := types.NamespacedName{Name: "pull5-user", Namespace: namespace}
+
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data, true)
+			defer deleteSecret(pullSecret1Key)
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, true)
+			defer deleteSecret(pullSecret2Key)
+			createDockerConfigSecret(pushSecretKey, pushSecretData, true)
+			defer deleteSecret(pushSecretKey)
+			createDockerConfigSecret(userSecret1Key, userSecret1Data, false)
+			defer deleteSecret(userSecret1Key)
+			createDockerConfigSecret(userSecret2Key, userSecret2Data, false)
+			defer deleteSecret(userSecret2Key)
+
+			// delete namespace pull secret and force creation of it
+			deleteSecret(namespacePullSecretKey)
+			setComponentAnnotation(component1Key, ensureNamespacePullSecretAnnotation, "true")
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
+
+			namespacePullSecret = waitSecretCreated(namespacePullSecretKey)
+			// namespace pull secret is created with 2 IR pull secrets
+			namespacePullSecretDockerConfigJson = string(namespacePullSecret.Data[corev1.DockerConfigJsonKey])
+			Expect(json.Unmarshal([]byte(namespacePullSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(decodedSecret.Auths).To(HaveLen(2))
+
+			Expect(decodedSecret.Auths["registry1"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user1:pass1"))))
+			Expect(decodedSecret.Auths["registry2"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user2:pass2"))))
+		})
+
+		It("should create namespace pull secret and check linking for each component", func() {
+			createComponent(component1Key)
+			component1SAKey := getComponentServiceAccountKey(component1Key)
+			createComponent(component2Key)
+			component2SAKey := getComponentServiceAccountKey(component2Key)
+
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
+
+			waitSecretCreated(namespacePullSecretKey)
+			component1SA := waitServiceAccount(component1SAKey)
+			component2SA := waitServiceAccount(component2SAKey)
+			integrationSA := waitServiceAccount(integrationSaKey)
+
+			// namespace pull secret is linked to component SA
+			Expect(component1SA.ImagePullSecrets).To(HaveLen(0))
+			Expect(component1SA.Secrets).To(HaveLen(1))
+			Expect(component1SA.Secrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+
+			// namespace pull secret is linked to component SA
+			Expect(component2SA.ImagePullSecrets).To(HaveLen(0))
+			Expect(component2SA.Secrets).To(HaveLen(1))
+			Expect(component2SA.Secrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+
+			// namespace pull secret is linked to integration SA
+			Expect(integrationSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(integrationSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretKey.Name))
+			Expect(integrationSA.Secrets).To(HaveLen(1))
+			Expect(integrationSA.Secrets[0].Name).To(Equal(namespacePullSecretKey.Name))
 		})
 
 		It("should create build pipeline dedicated service account and role binding", func() {
@@ -338,6 +442,7 @@ var _ = Describe("Component build controller", func() {
 			waitServiceAccountInRoleBinding(buildRoleBindingKey, component1SAKey.Name)
 
 			deleteServiceAccount(component1SAKey)
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
 
 			// trigger a reconcile
 			component1 := getComponent(component1Key)
@@ -366,6 +471,8 @@ var _ = Describe("Component build controller", func() {
 			Expect(roleBinding.Subjects).To(HaveLen(2))
 
 			deleteRoleBinding(buildRoleBindingKey)
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 
 			// trigger a reconcile for component 1
 			component1 := getComponent(component1Key)
@@ -417,6 +524,7 @@ var _ = Describe("Component build controller", func() {
 			defer deleteComponent(nudgedComponentKey)
 			nudgedComponentImageRepo := createImageRepositoryForComponent(nudgedComponentKey)
 			defer deleteImageRepository(nudgedComponentKey)
+			waitComponentAnnotationValue(nudgedComponentKey, ensureNamespacePullSecretAnnotation, "false")
 
 			// Simulate Image Controller and add push secret of nudged Component to its Service Account
 			nudgedComponentSA := waitServiceAccount(nudgedComponentSAKey)
@@ -441,6 +549,16 @@ var _ = Describe("Component build controller", func() {
 			createComponentCustom(component2)
 			component2ImageRepo := createImageRepositoryForComponent(component2Key)
 			defer deleteImageRepository(component2Key)
+
+			waitComponentAnnotationValue(component1Key, ensureNamespacePullSecretAnnotation, "false")
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
+
+			// Trigger a reconcile for nudged Component.
+			// In real environment it should be done by update of BuildNudgedBy field in the nudged Component status
+			nudgedComponent := getComponent(nudgedComponentKey)
+			nudgedComponent.Annotations["build-nudged-by"] = "component2"
+			Expect(k8sClient.Update(ctx, nudgedComponent)).To(Succeed())
+
 			// Check that the pull secret of nudging Component was linked to the nudged Component build pipeline Service Account
 			waitServiceAccountLinkedSecret(nudgedComponentSAKey, component2ImageRepo.Status.Credentials.PullSecretName, false)
 			// Check that a pull secret was not linked from a not nudging Component
@@ -458,7 +576,7 @@ var _ = Describe("Component build controller", func() {
 
 			// Trigger a reconcile for nudged Component.
 			// In real environment it should be done by update of BuildNudgedBy field in the nudged Component status
-			nudgedComponent := getComponent(nudgedComponentKey)
+			nudgedComponent = getComponent(nudgedComponentKey)
 			nudgedComponent.Annotations["build-nudged-by"] = "component1"
 			Expect(k8sClient.Update(ctx, nudgedComponent)).To(Succeed())
 
@@ -1184,6 +1302,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 
 			pacSecretData = map[string]string{}
 			deleteSecret(pacSecretKey)
@@ -1207,6 +1326,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 			UndoPaCMergeRequestFunc = func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error) {
 				return "", nil
 			}
@@ -1254,6 +1374,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 
 			repository := waitPaCRepositoryCreated(resourceCleanupKey)
 			incomingSecretName := fmt.Sprintf("%s%s", repository.Name, pacIncomingSecretNameSuffix)
@@ -1264,11 +1385,10 @@ var _ = Describe("Component build controller", func() {
 			Expect(k8sClient.Update(ctx, repository)).Should(Succeed())
 
 			// create incoming secret
-			component := getComponent(resourceCleanupKey)
 			incomingSecretData := map[string]string{
 				pacIncomingSecretKey: "secret password",
 			}
-			incomingSecretResourceKey := types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}
+			incomingSecretResourceKey := types.NamespacedName{Namespace: namespace, Name: incomingSecretName}
 			createSecret(incomingSecretResourceKey, incomingSecretData)
 			defer deleteSecret(incomingSecretResourceKey)
 
@@ -1309,6 +1429,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 			expectPacBuildStatus(resourceCleanupKey, "enabled", 0, "", mergeUrl)
 
 			// provision 2nd component
@@ -1436,6 +1557,7 @@ var _ = Describe("Component build controller", func() {
 				gitURL:       SampleRepoLink + "-samerepo",
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 
 			// create second component which uses the same url
 			secondComponentKey := types.NamespacedName{Name: HASCompName + "-cleanup-second", Namespace: namespace}
@@ -1445,6 +1567,7 @@ var _ = Describe("Component build controller", func() {
 				gitURL:       SampleRepoLink + "-samerepo",
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(secondComponentKey)
+			waitComponentAnnotationValue(secondComponentKey, ensureNamespacePullSecretAnnotation, "false")
 
 			// shouldn't remove webhook because another component exists for the same repo
 			setComponentBuildRequest(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
@@ -1587,6 +1710,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 			deleteSecret(pacSecretKey)
 
 			setComponentBuildRequest(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
@@ -1607,11 +1731,12 @@ var _ = Describe("Component build controller", func() {
 				componentKey: resourceCleanupKey,
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(resourceCleanupKey)
+			waitComponentAnnotationValue(resourceCleanupKey, ensureNamespacePullSecretAnnotation, "false")
 
 			component := getComponent(resourceCleanupKey)
 			component.Spec.Source.GitSource.URL = "wrong"
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
-			waitPaCFinalizerOnComponent(resourceCleanupKey)
 
 			setComponentBuildRequest(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponentGone(resourceCleanupKey)
@@ -1917,6 +2042,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourcePacTriggerKey)
+			waitComponentAnnotationValue(resourcePacTriggerKey, ensureNamespacePullSecretAnnotation, "false")
 			expectPacBuildStatus(resourcePacTriggerKey, "enabled", 0, "", mergeUrl)
 
 			repository := waitPaCRepositoryCreated(resourcePacTriggerKey)
@@ -2039,6 +2165,7 @@ var _ = Describe("Component build controller", func() {
 			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			incomingSecretName := fmt.Sprintf("%s%s", repository.Name, pacIncomingSecretNameSuffix)
 
+			waitComponentAnnotationValue(resourcePacTriggerKey, ensureNamespacePullSecretAnnotation, "false")
 			component1 := getComponent(resourcePacTriggerKey)
 			pipelineRunName1 := component1.Name + pipelineRunOnPushSuffix
 
@@ -2078,6 +2205,7 @@ var _ = Describe("Component build controller", func() {
 			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
 			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"main"}))
 
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
@@ -2139,6 +2267,7 @@ var _ = Describe("Component build controller", func() {
 			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			incomingSecretName := fmt.Sprintf("%s%s", repository.Name, pacIncomingSecretNameSuffix)
 
+			waitComponentAnnotationValue(resourcePacTriggerKey, ensureNamespacePullSecretAnnotation, "false")
 			component1 := getComponent(resourcePacTriggerKey)
 			pipelineRunName1 := component1.Name + pipelineRunOnPushSuffix
 
@@ -2178,6 +2307,7 @@ var _ = Describe("Component build controller", func() {
 			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
 			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"main"}))
 
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
@@ -2261,6 +2391,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
 			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
@@ -2362,6 +2493,7 @@ var _ = Describe("Component build controller", func() {
 				Reply(202).JSON(map[string]string{})
 
 			// trigger push pipeline for 2nd component
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 			setComponentBuildRequest(component2Key, BuildRequestTriggerPaCBuildAnnotationValue)
 			incomingSecretResourceKey := types.NamespacedName{Namespace: component2.Namespace, Name: incomingSecretName}
 			waitSecretCreated(incomingSecretResourceKey)
@@ -2431,6 +2563,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
 			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 
+			waitComponentAnnotationValue(component2Key, ensureNamespacePullSecretAnnotation, "false")
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 

--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -565,7 +565,7 @@ func (r *ComponentDependencyUpdateReconciler) getImageRepositoryCredentials(ctx 
 
 	// get service account and gather linked secrets
 	buildPipelineServiceAccount := &corev1.ServiceAccount{}
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component)
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: namespace}, buildPipelineServiceAccount); err != nil {
 		log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", buildPipelineServiceAccountName, namespace), l.Action, l.ActionView)
 		return "", "", err

--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -175,7 +175,6 @@ var _ = Describe("Component nudge controller", func() {
 				pr := getPipelineRun("test-pipeline-1", UserNamespace)
 				return pr == nil
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
 		})
 
 		It("Test finalizer removed on pipeline completion", func() {
@@ -533,11 +532,11 @@ var _ = Describe("Component nudge controller", func() {
 				component1.Annotations[CustomRenovateConfigMapAnnotation] = componentRenovateConfigName.Name
 				err = k8sClient.Update(context.TODO(), &component1)
 				Expect(err).ToNot(HaveOccurred())
-				waitComponentAnnotationExists(operator1Key, CustomRenovateConfigMapAnnotation)
+				waitComponentAnnotationValue(operator1Key, CustomRenovateConfigMapAnnotation, componentRenovateConfigName.Name)
 				component2.Annotations[CustomRenovateConfigMapAnnotation] = componentRenovateConfigName.Name
 				err = k8sClient.Update(context.TODO(), &component2)
 				Expect(err).ToNot(HaveOccurred())
-				waitComponentAnnotationExists(operator2Key, CustomRenovateConfigMapAnnotation)
+				waitComponentAnnotationValue(operator2Key, CustomRenovateConfigMapAnnotation, componentRenovateConfigName.Name)
 			}
 
 			createBuildPipelineRun("test-pipeline-1", UserNamespace, baseComponentName, imageBuiltFrom)

--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -719,7 +719,7 @@ func (u ComponentDependenciesUpdater) CreateRenovaterPipeline(ctx context.Contex
 		}
 	}
 
-	renovatePipelineServiceAccountName := getBuildPipelineServiceAccountName(buildResult.Component)
+	renovatePipelineServiceAccountName := getBuildPipelineServiceAccountName(buildResult.Component.Name)
 	if err := u.Client.Get(ctx, types.NamespacedName{Name: renovatePipelineServiceAccountName, Namespace: namespace}, &corev1.ServiceAccount{}); err != nil {
 		log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", renovatePipelineServiceAccountName, namespace), l.Action, l.ActionView)
 		return err

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	applicationApiDepVersion := "v0.0.0-20240812090716-e7eb2ecfb409"
+	applicationApiDepVersion := "v0.0.0-20251126155256-d24742e8b026"
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "hack", "routecrd", "route.yaml"),

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -188,6 +190,16 @@ func setComponentBuildRequest(componentKey types.NamespacedName, buildRequest st
 		component.Annotations = make(map[string]string)
 	}
 	component.Annotations[BuildRequestAnnotationName] = buildRequest
+
+	Expect(k8sClient.Update(ctx, component)).To(Succeed())
+}
+
+func setComponentAnnotation(componentKey types.NamespacedName, annotationKey, annotationValue string) {
+	component := getComponent(componentKey)
+	if component.Annotations == nil {
+		component.Annotations = make(map[string]string)
+	}
+	component.Annotations[annotationKey] = annotationValue
 
 	Expect(k8sClient.Update(ctx, component)).To(Succeed())
 }
@@ -498,6 +510,50 @@ func createSCMSecret(resourceKey types.NamespacedName, data map[string]string, s
 	}, timeout, interval).Should(Succeed())
 }
 
+// createDockerConfigSecret creates SecretTypeDockerConfigJson secret
+func createDockerConfigSecret(secretKey types.NamespacedName, dockerConfigData string, setIrOwner bool) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretKey.Name,
+			Namespace: secretKey.Namespace,
+			Labels: map[string]string{
+				InternalSecretLabelName: "true",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte(dockerConfigData),
+		},
+	}
+
+	if setIrOwner {
+		secret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "ImageRepository",
+			Name:       "ir-name",
+			UID:        "ir-uid",
+		}}
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
+// generateDockerConfigJson creates the raw JSON string for .dockerconfigjson
+func generateDockerConfigJson(registry, username, password string) string {
+	auths := map[string]dockerConfigAuth{}
+
+	// when all are empty create empty auths
+	if registry != "" && username != "" && password != "" {
+		authString := fmt.Sprintf("%s:%s", username, password)
+		encodedAuth := base64.StdEncoding.EncodeToString([]byte(authString))
+		auths[registry] = dockerConfigAuth{encodedAuth}
+	}
+
+	dcj := dockerConfigJson{Auths: auths}
+	marshaled, err := json.Marshal(dcj)
+	Expect(err).To(Succeed())
+	return string(marshaled)
+}
+
 func deleteSecret(resourceKey types.NamespacedName) {
 	secret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, resourceKey, secret); err != nil {
@@ -517,12 +573,13 @@ func deleteSecret(resourceKey types.NamespacedName) {
 	}, timeout, interval).Should(BeTrue())
 }
 
-func waitSecretCreated(resourceKey types.NamespacedName) {
+func waitSecretCreated(resourceKey types.NamespacedName) *corev1.Secret {
 	secret := &corev1.Secret{}
 	Eventually(func() bool {
 		err := k8sClient.Get(ctx, resourceKey, secret)
 		return err == nil && secret.ResourceVersion != ""
 	}, timeout, interval).Should(BeTrue())
+	return secret
 }
 
 func waitSecretGone(resourceKey types.NamespacedName) {
@@ -614,15 +671,15 @@ func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationNa
 	}, timeout, interval).Should(BeTrue())
 }
 
-func waitComponentAnnotationExists(componentKey types.NamespacedName, annotationName string) {
+func waitComponentAnnotationValue(componentKey types.NamespacedName, annotationName, annotationValue string) {
 	Eventually(func() bool {
 		component := getComponent(componentKey)
 		annotations := component.GetAnnotations()
 		if annotations == nil {
 			return false
 		}
-		_, exists := annotations[annotationName]
-		return exists
+		annotation, exists := annotations[annotationName]
+		return exists && annotation == annotationValue
 	}, timeout, interval).Should(BeTrue())
 }
 
@@ -715,6 +772,17 @@ func deleteConfigMap(configMapKey types.NamespacedName) {
 	Eventually(func() bool {
 		return k8sErrors.IsNotFound(k8sClient.Get(ctx, configMapKey, &configMap))
 	}, timeout, interval).Should(BeTrue())
+}
+
+func createServiceAccount(serviceAccountKey types.NamespacedName) corev1.ServiceAccount {
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceAccountKey.Namespace,
+			Name:      serviceAccountKey.Name,
+		},
+	}
+	Expect(k8sClient.Create(ctx, &serviceAccount)).To(Succeed())
+	return waitServiceAccount(serviceAccountKey)
 }
 
 func waitServiceAccount(serviceAccountKey types.NamespacedName) corev1.ServiceAccount {


### PR DESCRIPTION
and add there all pull secrets from all imageRepositories in the namespace

new annotation build.appstudio.openshift.io/ensure-namespace-pull-secret with value 'false' indicates that secret was created

when annotation is set to 'true' it will enforce creation of the secret

namespace pull secret will be also linked to component SA and integration SA (konflux-integration-runner)

[STONEBLD-4018](https://issues.redhat.com//browse/STONEBLD-4018)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable