### PR TITLE
feat: split e2e into github/gitlab pipelines with pre-pull and optimizations

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -249,7 +249,7 @@ spec:
           - name: revision
             value: prep
           - name: pathInRepo
-            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.2/pull-request-comment.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -247,7 +247,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: main
+            value: prep
           - name: pathInRepo
             value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -122,86 +122,18 @@ spec:
     - name: pre-pull-images
       runAfter:
         - deploy-konflux
-      taskSpec:
-        volumes:
-          - name: cluster-secret
-            secret:
-              optional: true
-              secretName: kfg-$(context.pipelineRun.name)
-        steps:
-          - name: create-job
-            image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
-            env:
-              - name: KUBECONFIG
-                value: /tmp/kubeconfig
-            volumeMounts:
-              - name: cluster-secret
-                mountPath: /tmp/kubeconfig
-                subPath: kubeconfig
-            script: |
-              #!/usr/bin/env bash
-              set -uo pipefail
-              trap 'echo "[WARN] Pre-pull failed but continuing (non-blocking)"; exit 0' ERR
-
-              echo "==> Resolving step images from build pipeline bundles..."
-
-              BUILD_BUNDLE=$(kubectl get configmap build-pipeline-config -n build-service \
-                -o jsonpath='{.data.config\.yaml}' 2>/dev/null \
-                | yq e '.pipelines[] | select(.name == "docker-build-oci-ta") | .bundle' -)
-
-              if [ -z "$BUILD_BUNDLE" ]; then
-                echo "[WARN] Could not resolve build pipeline bundle, skipping"
-                exit 0
-              fi
-              echo "  Pipeline: $(echo $BUILD_BUNDLE | sed 's|.*/||')"
-
-              TASK_BUNDLES=$(tkn bundle list "$BUILD_BUNDLE" -o yaml 2>/dev/null \
-                | grep 'value:.*quay.io/konflux-ci/tekton-catalog/task' \
-                | sed 's/.*value: //')
-              echo "  $(echo "$TASK_BUNDLES" | wc -l | tr -d ' ') task bundles, resolving in parallel..."
-
-              STEP_IMAGES=$(echo "$TASK_BUNDLES" \
-                | xargs -P10 -I{} sh -c 'tkn bundle list "{}" -o yaml 2>/dev/null | grep "^\s*image:" | sed "s/.*image: //"' \
-                | sed 's/@sha256:[a-f0-9]*//' | sort -u \
-                | grep ':' | grep -v 'redhat-services-prod')
-
-              EXTRA_IMAGES="
-              quay.io/konflux-ci/mintmaker-renovate-image:latest
-              quay.io/redhat-appstudio/konflux-test:latest
-              registry.access.redhat.com/ubi9/ubi:latest"
-
-              ALL_IMAGES=$(echo -e "$STEP_IMAGES\n$EXTRA_IMAGES" | sed 's/^ *//' | sort -u | grep -v '^$')
-              COUNT=$(echo "$ALL_IMAGES" | wc -l | tr -d ' ')
-              echo "  $COUNT images to pre-pull"
-
-              CONTAINERS=""
-              IDX=0
-              while IFS= read -r img; do
-                CONTAINERS="${CONTAINERS}
-                      - name: pull-${IDX}
-                        image: ${img}
-                        command: ['echo']"
-                IDX=$((IDX + 1))
-              done <<< "$ALL_IMAGES"
-
-              cat <<JOBEOF | kubectl apply -f -
-              apiVersion: batch/v1
-              kind: Job
-              metadata:
-                name: pre-pull-images
-                namespace: default
-              spec:
-                backoffLimit: 0
-                activeDeadlineSeconds: 600
-                ttlSecondsAfterFinished: 60
-                template:
-                  spec:
-                    nodeName: kind-mapt-control-plane
-                    restartPolicy: Never
-                    containers:${CONTAINERS}
-              JOBEOF
-
-              echo "==> Pre-pull Job created with $IDX containers"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: prep
+          - name: pathInRepo
+            value: tasks/pre-pull-images/0.1/pre-pull-images.yaml
+      params:
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -47,9 +47,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/tekton-integration-catalog.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: protect-control-plane
+            value: main
           - name: pathInRepo
             value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
       params:
@@ -91,9 +91,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/tekton-integration-catalog.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: protect-control-plane
+            value: main
           - name: pathInRepo
             value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -249,7 +249,7 @@ spec:
           - name: revision
             value: prep
           - name: pathInRepo
-            value: tasks/pull-request-comment/0.2/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -2,40 +2,24 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: konflux-e2e-tests
+  name: konflux-e2e-tests-github
 spec:
   description: |-
-    This pipeline automates the process of running end-to-end tests for Konflux
-    using a Kind cluster running on AWS cluster. The pipeline provisions
-    the Kind cluster, installs Konflux using the konflux-ci repository scripts, runs the tests, collects artifacts,
-    and finally deprovisions the Kind cluster.
+    This pipeline runs GitHub provider e2e tests for Konflux build-service.
+    It provisions a Kind cluster on AWS, installs Konflux, and runs the GitHub
+    test suite. Finally it collects artifacts and deprovisions the cluster.
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test.'
       default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
       type: string
-    - name: test-name
-      description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: ''
-    - name: ocp-version
-      description: 'The OpenShift version to use for the ephemeral cluster deployment.'
-      type: string
     - name: konflux-test-infra-secret
       description: The name of secret where testing infrastructures credentials are stored.
-      type: string
-    - name: replicas
-      description: 'The number of replicas for the cluster nodes.'
-      type: string
-    - name: machine-type
-      description: 'The type of machine to use for the cluster nodes.'
+      default: "konflux-test-infra"
       type: string
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/build-service'
       description: The OCI container used to store all test artifacts.
-    - name: component-image
-      default: 'none'
-      description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
-        in another Konflux component repo. Will pass the component built image from the snapshot.'
     - name: artifact-browser-url
       description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
       default: ""
@@ -63,20 +47,20 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+            value: https://github.com/flacatus/tekton-integration-catalog.git
           - name: revision
-            value: main
+            value: protect-control-plane
           - name: pathInRepo
             value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
       params:
         - name: secret-aws-credentials
-          value: mapt-kind-secret
+          value: konflux-mapt-us-east-1
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
         - name: id
           value: $(context.pipelineRun.name)
         - name: tags
-          value: 'owner=konflux-devprod@redhat.com,project=Konflux,created-by=integration-pipeline,component=build-service'
+          value: 'owner=konflux-devprod@redhat.com,project=Konflux,created-by=integration-pipeline,component=build-service,provider=github'
         - name: debug
           value: 'false'
         - name: ownerKind
@@ -87,7 +71,7 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: oci-ref
           value: $(params.oci-container-repo):$(context.pipelineRun.name)
-        - name: credentials-secret-name
+        - name: oci-credentials
           value: $(params.konflux-test-infra-secret)
         - name: extra-port-mappings
           value: >-
@@ -98,6 +82,8 @@ spec:
           value: 64
         - name: spot
           value: 'false'
+        - name: harden-control-plane
+          value: 'true'
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster
@@ -105,9 +91,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog
+            value: https://github.com/flacatus/tekton-integration-catalog.git
           - name: revision
-            value: main
+            value: protect-control-plane
           - name: pathInRepo
             value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
       params:
@@ -131,6 +117,91 @@ spec:
           value: $(tasks.test-metadata.results.instrumented-container-tag)
         - name: build-credentials
           value: "konflux-e2e-secrets"
+        - name: harden-kyverno
+          value: "true"
+    - name: pre-pull-images
+      runAfter:
+        - deploy-konflux
+      taskSpec:
+        volumes:
+          - name: cluster-secret
+            secret:
+              optional: true
+              secretName: kfg-$(context.pipelineRun.name)
+        steps:
+          - name: create-job
+            image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+            env:
+              - name: KUBECONFIG
+                value: /tmp/kubeconfig
+            volumeMounts:
+              - name: cluster-secret
+                mountPath: /tmp/kubeconfig
+                subPath: kubeconfig
+            script: |
+              #!/usr/bin/env bash
+              set -uo pipefail
+              trap 'echo "[WARN] Pre-pull failed but continuing (non-blocking)"; exit 0' ERR
+
+              echo "==> Resolving step images from build pipeline bundles..."
+
+              BUILD_BUNDLE=$(kubectl get configmap build-pipeline-config -n build-service \
+                -o jsonpath='{.data.config\.yaml}' 2>/dev/null \
+                | yq e '.pipelines[] | select(.name == "docker-build-oci-ta") | .bundle' -)
+
+              if [ -z "$BUILD_BUNDLE" ]; then
+                echo "[WARN] Could not resolve build pipeline bundle, skipping"
+                exit 0
+              fi
+              echo "  Pipeline: $(echo $BUILD_BUNDLE | sed 's|.*/||')"
+
+              TASK_BUNDLES=$(tkn bundle list "$BUILD_BUNDLE" -o yaml 2>/dev/null \
+                | grep 'value:.*quay.io/konflux-ci/tekton-catalog/task' \
+                | sed 's/.*value: //')
+              echo "  $(echo "$TASK_BUNDLES" | wc -l | tr -d ' ') task bundles, resolving in parallel..."
+
+              STEP_IMAGES=$(echo "$TASK_BUNDLES" \
+                | xargs -P10 -I{} sh -c 'tkn bundle list "{}" -o yaml 2>/dev/null | grep "^\s*image:" | sed "s/.*image: //"' \
+                | sed 's/@sha256:[a-f0-9]*//' | sort -u \
+                | grep ':' | grep -v 'redhat-services-prod')
+
+              EXTRA_IMAGES="
+              quay.io/konflux-ci/mintmaker-renovate-image:latest
+              quay.io/redhat-appstudio/konflux-test:latest
+              registry.access.redhat.com/ubi9/ubi:latest"
+
+              ALL_IMAGES=$(echo -e "$STEP_IMAGES\n$EXTRA_IMAGES" | sed 's/^ *//' | sort -u | grep -v '^$')
+              COUNT=$(echo "$ALL_IMAGES" | wc -l | tr -d ' ')
+              echo "  $COUNT images to pre-pull"
+
+              CONTAINERS=""
+              IDX=0
+              while IFS= read -r img; do
+                CONTAINERS="${CONTAINERS}
+                      - name: pull-${IDX}
+                        image: ${img}
+                        command: ['echo']"
+                IDX=$((IDX + 1))
+              done <<< "$ALL_IMAGES"
+
+              cat <<JOBEOF | kubectl apply -f -
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: pre-pull-images
+                namespace: default
+              spec:
+                backoffLimit: 0
+                activeDeadlineSeconds: 600
+                ttlSecondsAfterFinished: 60
+                template:
+                  spec:
+                    nodeName: kind-mapt-control-plane
+                    restartPolicy: Never
+                    containers:${CONTAINERS}
+              JOBEOF
+
+              echo "==> Pre-pull Job created with $IDX containers"
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:
@@ -163,6 +234,10 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: test-environment
           value: "upstream"
+        - name: ginkgo-procs
+          value: "6"
+        - name: e2e-extra-label-filter
+          value: "github"
   finally:
     - name: collect-and-upload-coverage
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-github.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-github.yaml
@@ -128,12 +128,14 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: prep
+            value: main
           - name: pathInRepo
             value: tasks/pre-pull-images/0.1/pre-pull-images.yaml
       params:
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
+        - name: pipeline-name
+          value: "docker-build"
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:
@@ -247,7 +249,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: prep
+            value: main
           - name: pathInRepo
             value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -249,7 +249,7 @@ spec:
           - name: revision
             value: prep
           - name: pathInRepo
-            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.2/pull-request-comment.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -1,0 +1,347 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: konflux-e2e-tests-gitlab
+spec:
+  description: |-
+    This pipeline runs GitLab provider e2e tests for Konflux build-service.
+    It provisions a Kind cluster on AWS, installs Konflux, and runs the GitLab
+    test suite. Finally it collects artifacts and deprovisions the cluster.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: konflux-test-infra-secret
+      description: The name of secret where testing infrastructures credentials are stored.
+      default: "konflux-test-infra"
+      type: string
+    - name: oci-container-repo
+      default: 'quay.io/konflux-test-storage/konflux-team/build-service'
+      description: The OCI container used to store all test artifacts.
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
+  tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test-metadata/0.4/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+    - name: provision-kind-cluster
+      runAfter:
+        - test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/flacatus/tekton-integration-catalog.git
+          - name: revision
+            value: protect-control-plane
+          - name: pathInRepo
+            value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+      params:
+        - name: secret-aws-credentials
+          value: konflux-mapt-us-east-1
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: tags
+          value: 'owner=konflux-devprod@redhat.com,project=Konflux,created-by=integration-pipeline,component=build-service,provider=gitlab'
+        - name: debug
+          value: 'false'
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+        - name: oci-ref
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: $(params.konflux-test-infra-secret)
+        - name: extra-port-mappings
+          value: >-
+            '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
+        - name: cpus
+          value: 32
+        - name: memory
+          value: 64
+        - name: spot
+          value: 'false'
+        - name: harden-control-plane
+          value: 'true'
+    - name: deploy-konflux
+      runAfter:
+        - provision-kind-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/flacatus/tekton-integration-catalog.git
+          - name: revision
+            value: protect-control-plane
+          - name: pathInRepo
+            value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+      params:
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: component-name
+          value: build-service
+        - name: component-pr-owner
+          value: $(tasks.test-metadata.results.pull-request-author)
+        - name: component-pr-sha
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: component-pr-source-branch
+          value: $(tasks.test-metadata.results.source-repo-branch)
+        - name: oci-ref
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: $(params.konflux-test-infra-secret)
+        - name: component-image-repository
+          value: $(tasks.test-metadata.results.instrumented-container-repo)
+        - name: component-image-tag
+          value: $(tasks.test-metadata.results.instrumented-container-tag)
+        - name: build-credentials
+          value: "konflux-e2e-secrets"
+        - name: harden-kyverno
+          value: "true"
+    - name: pre-pull-images
+      runAfter:
+        - deploy-konflux
+      taskSpec:
+        volumes:
+          - name: cluster-secret
+            secret:
+              optional: true
+              secretName: kfg-$(context.pipelineRun.name)
+        steps:
+          - name: create-job
+            image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+            env:
+              - name: KUBECONFIG
+                value: /tmp/kubeconfig
+            volumeMounts:
+              - name: cluster-secret
+                mountPath: /tmp/kubeconfig
+                subPath: kubeconfig
+            script: |
+              #!/usr/bin/env bash
+              set -uo pipefail
+              trap 'echo "[WARN] Pre-pull failed but continuing (non-blocking)"; exit 0' ERR
+
+              echo "==> Resolving step images from build pipeline bundles..."
+
+              BUILD_BUNDLE=$(kubectl get configmap build-pipeline-config -n build-service \
+                -o jsonpath='{.data.config\.yaml}' 2>/dev/null \
+                | yq e '.pipelines[] | select(.name == "docker-build-oci-ta") | .bundle' -)
+
+              if [ -z "$BUILD_BUNDLE" ]; then
+                echo "[WARN] Could not resolve build pipeline bundle, skipping"
+                exit 0
+              fi
+              echo "  Pipeline: $(echo $BUILD_BUNDLE | sed 's|.*/||')"
+
+              TASK_BUNDLES=$(tkn bundle list "$BUILD_BUNDLE" -o yaml 2>/dev/null \
+                | grep 'value:.*quay.io/konflux-ci/tekton-catalog/task' \
+                | sed 's/.*value: //')
+              echo "  $(echo "$TASK_BUNDLES" | wc -l | tr -d ' ') task bundles, resolving in parallel..."
+
+              STEP_IMAGES=$(echo "$TASK_BUNDLES" \
+                | xargs -P10 -I{} sh -c 'tkn bundle list "{}" -o yaml 2>/dev/null | grep "^\s*image:" | sed "s/.*image: //"' \
+                | sed 's/@sha256:[a-f0-9]*//' | sort -u \
+                | grep ':' | grep -v 'redhat-services-prod')
+
+              EXTRA_IMAGES="
+              quay.io/konflux-ci/mintmaker-renovate-image:latest
+              quay.io/redhat-appstudio/konflux-test:latest
+              registry.access.redhat.com/ubi9/ubi:latest"
+
+              ALL_IMAGES=$(echo -e "$STEP_IMAGES\n$EXTRA_IMAGES" | sed 's/^ *//' | sort -u | grep -v '^$')
+              COUNT=$(echo "$ALL_IMAGES" | wc -l | tr -d ' ')
+              echo "  $COUNT images to pre-pull"
+
+              CONTAINERS=""
+              IDX=0
+              while IFS= read -r img; do
+                CONTAINERS="${CONTAINERS}
+                      - name: pull-${IDX}
+                        image: ${img}
+                        command: ['echo']"
+                IDX=$((IDX + 1))
+              done <<< "$ALL_IMAGES"
+
+              cat <<JOBEOF | kubectl apply -f -
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: pre-pull-images
+                namespace: default
+              spec:
+                backoffLimit: 0
+                activeDeadlineSeconds: 600
+                ttlSecondsAfterFinished: 60
+                template:
+                  spec:
+                    nodeName: kind-mapt-control-plane
+                    restartPolicy: Never
+                    containers:${CONTAINERS}
+              JOBEOF
+
+              echo "==> Pre-pull Job created with $IDX containers"
+    - name: konflux-e2e-tests
+      timeout: 2h
+      runAfter:
+        - deploy-konflux
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/flacatus/e2e-tests.git
+          - name: revision
+            value: pending-retrigger-test
+          - name: pathInRepo
+            value: integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
+      params:
+        - name: test-name
+          value: $(context.pipelineRun.name)
+        - name: git-repo
+          value: $(tasks.test-metadata.results.git-repo)
+        - name: git-url
+          value: $(tasks.test-metadata.results.git-url)
+        - name: git-revision
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: oras-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: job-spec
+          value: $(tasks.test-metadata.results.job-spec)
+        - name: component-image
+          value: $(tasks.test-metadata.results.container-image)
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: test-environment
+          value: "upstream"
+        - name: ginkgo-procs
+          value: "6"
+        - name: e2e-extra-label-filter
+          value: "gitlab"
+  finally:
+    - name: collect-and-upload-coverage
+      params:
+        - name: instrumented-images
+          value: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: test-name
+          value: e2e-tests
+        - name: oci-container
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)-coverport"
+        - name: codecov-flags
+          value: e2e-tests
+        - name: credentials-secret-name
+          value: "build-service-coverport-secrets"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
+      when:
+        - input: $(tasks.konflux-e2e-tests.status)
+          operator: in
+          values:
+            - Succeeded
+            - Failed
+    - name: store-pipeline-status
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/store-pipeline-status/0.1/store-pipeline-status.yaml
+      params:
+        - name: oci-ref
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: credentials-secret-name
+          value: "$(params.konflux-test-infra-secret)"
+        - name: pipelinerun-name
+          value: $(context.pipelineRun.name)
+        - name: pipeline-aggregate-status
+          value: $(tasks.status)
+    - name: deprovision-kind-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+      params:
+        - name: secret-aws-credentials
+          value: mapt-kind-secret
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: cluster-access-secret
+          value: kfg-$(context.pipelineRun.name)
+        - name: oci-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: konflux-test-infra
+    - name: pull-request-status-message
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
+      params:
+        - name: test-name
+          value: $(context.pipelineRun.name)
+        - name: oci-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: pipeline-aggregate-status
+          value: $(tasks.status)
+        - name: pull-request-author
+          value: $(tasks.test-metadata.results.pull-request-author)
+        - name: pull-request-number
+          value: $(tasks.test-metadata.results.pull-request-number)
+        - name: git-repo
+          value: $(tasks.test-metadata.results.git-repo)
+        - name: git-org
+          value: $(tasks.test-metadata.results.git-org)
+        - name: git-revision
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: junit-report-name
+          value: e2e-report.xml
+        - name: e2e-log-name
+          value: e2e-tests.log
+        - name: cluster-provision-log-name
+          value: kind-aws-provision.log
+        - name: enable-test-results-analysis
+          value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -126,9 +126,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/tekton-integration-catalog.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: protect-control-plane
+            value: prep
           - name: pathInRepo
             value: tasks/pre-pull-images/0.1/pre-pull-images.yaml
       params:
@@ -247,7 +247,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: main
+            value: prep
           - name: pathInRepo
             value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -249,7 +249,7 @@ spec:
           - name: revision
             value: prep
           - name: pathInRepo
-            value: tasks/pull-request-comment/0.2/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -47,9 +47,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/tekton-integration-catalog.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: protect-control-plane
+            value: main
           - name: pathInRepo
             value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
       params:
@@ -91,9 +91,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/tekton-integration-catalog.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: protect-control-plane
+            value: main
           - name: pathInRepo
             value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
       params:
@@ -210,9 +210,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/flacatus/e2e-tests.git
+            value: https://github.com/konflux-ci/e2e-tests.git
           - name: revision
-            value: pending-retrigger-test
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
       params:

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -122,86 +122,18 @@ spec:
     - name: pre-pull-images
       runAfter:
         - deploy-konflux
-      taskSpec:
-        volumes:
-          - name: cluster-secret
-            secret:
-              optional: true
-              secretName: kfg-$(context.pipelineRun.name)
-        steps:
-          - name: create-job
-            image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
-            env:
-              - name: KUBECONFIG
-                value: /tmp/kubeconfig
-            volumeMounts:
-              - name: cluster-secret
-                mountPath: /tmp/kubeconfig
-                subPath: kubeconfig
-            script: |
-              #!/usr/bin/env bash
-              set -uo pipefail
-              trap 'echo "[WARN] Pre-pull failed but continuing (non-blocking)"; exit 0' ERR
-
-              echo "==> Resolving step images from build pipeline bundles..."
-
-              BUILD_BUNDLE=$(kubectl get configmap build-pipeline-config -n build-service \
-                -o jsonpath='{.data.config\.yaml}' 2>/dev/null \
-                | yq e '.pipelines[] | select(.name == "docker-build-oci-ta") | .bundle' -)
-
-              if [ -z "$BUILD_BUNDLE" ]; then
-                echo "[WARN] Could not resolve build pipeline bundle, skipping"
-                exit 0
-              fi
-              echo "  Pipeline: $(echo $BUILD_BUNDLE | sed 's|.*/||')"
-
-              TASK_BUNDLES=$(tkn bundle list "$BUILD_BUNDLE" -o yaml 2>/dev/null \
-                | grep 'value:.*quay.io/konflux-ci/tekton-catalog/task' \
-                | sed 's/.*value: //')
-              echo "  $(echo "$TASK_BUNDLES" | wc -l | tr -d ' ') task bundles, resolving in parallel..."
-
-              STEP_IMAGES=$(echo "$TASK_BUNDLES" \
-                | xargs -P10 -I{} sh -c 'tkn bundle list "{}" -o yaml 2>/dev/null | grep "^\s*image:" | sed "s/.*image: //"' \
-                | sed 's/@sha256:[a-f0-9]*//' | sort -u \
-                | grep ':' | grep -v 'redhat-services-prod')
-
-              EXTRA_IMAGES="
-              quay.io/konflux-ci/mintmaker-renovate-image:latest
-              quay.io/redhat-appstudio/konflux-test:latest
-              registry.access.redhat.com/ubi9/ubi:latest"
-
-              ALL_IMAGES=$(echo -e "$STEP_IMAGES\n$EXTRA_IMAGES" | sed 's/^ *//' | sort -u | grep -v '^$')
-              COUNT=$(echo "$ALL_IMAGES" | wc -l | tr -d ' ')
-              echo "  $COUNT images to pre-pull"
-
-              CONTAINERS=""
-              IDX=0
-              while IFS= read -r img; do
-                CONTAINERS="${CONTAINERS}
-                      - name: pull-${IDX}
-                        image: ${img}
-                        command: ['echo']"
-                IDX=$((IDX + 1))
-              done <<< "$ALL_IMAGES"
-
-              cat <<JOBEOF | kubectl apply -f -
-              apiVersion: batch/v1
-              kind: Job
-              metadata:
-                name: pre-pull-images
-                namespace: default
-              spec:
-                backoffLimit: 0
-                activeDeadlineSeconds: 600
-                ttlSecondsAfterFinished: 60
-                template:
-                  spec:
-                    nodeName: kind-mapt-control-plane
-                    restartPolicy: Never
-                    containers:${CONTAINERS}
-              JOBEOF
-
-              echo "==> Pre-pull Job created with $IDX containers"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/flacatus/tekton-integration-catalog.git
+          - name: revision
+            value: protect-control-plane
+          - name: pathInRepo
+            value: tasks/pre-pull-images/0.1/pre-pull-images.yaml
+      params:
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:

--- a/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-gitlab.yaml
@@ -128,12 +128,14 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: prep
+            value: main
           - name: pathInRepo
             value: tasks/pre-pull-images/0.1/pre-pull-images.yaml
       params:
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
+        - name: pipeline-name
+          value: "docker-build"
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:
@@ -247,7 +249,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
-            value: prep
+            value: main
           - name: pathInRepo
             value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:


### PR DESCRIPTION
- Separate pipelines for github and gitlab provider tests
- Add pre-pull Job to cache test workload images during deploy
- Use kind-aws-provision v0.3 with control plane hardening
- Point deploy task to fork with cluster-config fix and kyverno hardening
- Set ginkgo procs to 6 per pipeline
- Remove unused pipeline params

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable