### PR TITLE
nudging reconciler won't skip updates for push pipeline which have nu…

### DIFF
--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -134,16 +134,17 @@ func (r *ComponentDependencyUpdateReconciler) SetupWithManager(manager ctrl.Mana
 				}
 
 				// Ensure we have not finished processing
-				if new.ObjectMeta.Annotations != nil && new.ObjectMeta.Annotations[NudgeProcessedAnnotationName] != "" {
+				// when finalizer is there together with annotation that means some other controller updated finalizers and there was race
+				if new.ObjectMeta.Annotations != nil && new.ObjectMeta.Annotations[NudgeProcessedAnnotationName] != "" && !controllerutil.ContainsFinalizer(new, NudgeFinalizer){
 					return false
 				}
 				return true
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
-				return true
+				return false
 			},
 			GenericFunc: func(e event.GenericEvent) bool {
-				return true
+				return false
 			},
 		})).
 		Named("ComponentDependencyUpdateReconciler").
@@ -177,6 +178,12 @@ func (r *ComponentDependencyUpdateReconciler) Reconcile(ctx context.Context, req
 	if pipelineRun.CreationTimestamp.Add(delayTime).After(time.Now()) {
 		// These objects are super contested at creation, we just wait 10s before attempting anything
 		return ctrl.Result{RequeueAfter: delayTime}, nil
+	}
+
+	// pipeline run was already processed, but finalizer was added again due to race by other controller, remove it again
+	if controllerutil.ContainsFinalizer(pipelineRun, NudgeFinalizer) && pipelineRun.Annotations != nil && pipelineRun.Annotations[NudgeProcessedAnnotationName] != "" {
+		patch := client.MergeFrom(pipelineRun.DeepCopy())
+		return r.removePipelineFinalizer(ctx, pipelineRun, patch)
 	}
 
 	component, err := GetComponentFromPipelineRun(r.Client, ctx, pipelineRun)


### PR DESCRIPTION
…ding annotation and also nudging finalizer

there might be race with other controllers which are patching finalizers, and they can readd nudging finalizer

so reconciler should check if annotation is set and if finalizer is set as well it will remove it again

[KONFLUX-12125](https://redhat.atlassian.net/browse/KONFLUX-12125)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable

[KONFLUX-12125]: https://redhat.atlassian.net/browse/KONFLUX-12125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ