### PR TITLE
Always use PaC Service to communicate with PaC endpoint from operator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -219,16 +219,16 @@ func main() {
 
 	ensureBuildPipelineClusterRoleExist(mgr.GetClient())
 
-	webhookConfig, err := pacwebhook.LoadMappingFromFile(webhookConfigPath, os.ReadFile)
+	pacWebhookMapping, err := pacwebhook.NewPaCWebhookMapping(webhookConfigPath)
 	if err != nil {
-		setupLog.Error(err, "Failed to load webhook config file", "path", webhookConfigPath)
+		setupLog.Error(err, "Failed to load webhook config mapping file", "path", webhookConfigPath)
 		os.Exit(1)
 	}
 	if err = (&controllers.ComponentBuildReconciler{
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		EventRecorder:      mgr.GetEventRecorderFor("ComponentOnboarding"),
-		WebhookURLLoader:   pacwebhook.NewConfigWebhookURLLoader(webhookConfig),
+		PaCWebhookMapping:  pacWebhookMapping,
 		CredentialProvider: k8s.NewGitCredentialProvider(mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ComponentOnboarding")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -297,6 +297,7 @@ func getCacheExcludedObjectsTypes() []client.Object {
 	return []client.Object{
 		&corev1.Secret{},
 		&corev1.ConfigMap{},
+		&corev1.Service{},
 		&rbacv1.ClusterRole{},
 	}
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - services
   verbs:
   - get
   - list

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -176,6 +176,7 @@ func isComponentUsingNewModel(component *compapiv1alpha1.Component) bool {
 // The following line is needed for component_dependency_update_controller since config there is overriden from here.
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch;update;delete
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -109,7 +109,7 @@ type ComponentBuildReconciler struct {
 	Scheme             *runtime.Scheme
 	EventRecorder      record.EventRecorder
 	CredentialProvider *k8s.GitCredentialProvider
-	WebhookURLLoader   pacwebhook.WebhookURLLoader
+	PaCWebhookMapping  *pacwebhook.PaCWebhookMapping
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/component_build_controller_pac.go
+++ b/internal/controller/component_build_controller_pac.go
@@ -51,8 +51,9 @@ const (
 	pipelineRunOnPRSuffix             = "-on-pull-request"
 	pipelineRunOnPushFilename         = "push.yaml"
 	pipelineRunOnPRFilename           = "pull-request.yaml"
-	pipelinesAsCodeNamespace          = "openshift-pipelines"
-	pipelinesAsCodeNamespaceFallback  = "pipelines-as-code"
+	pipelinesAsCodeNamespaceEnvVar    = "PAC_NAMESPACE"
+	pipelinesAsCodeNamespaceOpenshift = "openshift-pipelines"
+	pipelinesAsCodeNamespace          = "pipelines-as-code"
 	pipelinesAsCodeRouteName          = "pipelines-as-code-controller"
 	pipelinesAsCodeRouteEnvVar        = "PAC_WEBHOOK_URL"
 	pipelinesAsCodeWebhooksSecretName = "pipelines-as-code-webhooks-secret"
@@ -89,9 +90,9 @@ Please follow the block sequence indentation style introduced by the proprosed P
 // GetHttpClientFunction can be mocked in tests.
 var GetHttpClientFunction = getHttpClient
 
-// GetWebhookDataAndPacSecret gets and validates webhookSecretString, webhookTargetUrl, pacSecret
+// GetPacSecrets gets and validates webhookSecretString and pacSecret.
 // TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) GetWebhookDataAndPacSecret(ctx context.Context, component *compapiv1alpha1.Component) (string, string, *corev1.Secret, error) {
+func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component *compapiv1alpha1.Component) (string, *corev1.Secret, error) {
 	log := ctrllog.FromContext(ctx).WithName("GetWebhookAndPacSecret")
 	newModel := true
 
@@ -100,31 +101,31 @@ func (r *ComponentBuildReconciler) GetWebhookDataAndPacSecret(ctx context.Contex
 	gitProvider, err := getGitProvider(*component, newModel)
 	if err != nil {
 		// Do not reconcile, because configuration must be fixed before it is possible to proceed.
-		return "", "", nil, err
+		return "", nil, err
 	}
 	repoUrl := getGitRepoUrl(*component, newModel)
 
 	if strings.HasPrefix(repoUrl, "http:") {
-		return "", "", nil, boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
+		return "", nil, boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
 			fmt.Errorf("git repository URL can't use insecure HTTP: %s", repoUrl))
 	}
 
 	if url, ok := component.Annotations[GitProviderAnnotationURL]; ok {
 		if strings.HasPrefix(url, "http:") {
-			return "", "", nil, boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
+			return "", nil, boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
 				fmt.Errorf("git repository URL in annotation %s can't use insecure HTTP: %s", GitProviderAnnotationURL, repoUrl))
 		}
 	}
 
 	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider, newModel)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	if err := validatePaCConfiguration(gitProvider, *pacSecret); err != nil {
 		r.EventRecorder.Event(pacSecret, "Warning", "ErrorValidatingPaCSecret", err.Error())
 		// Do not reconcile, because configuration must be fixed before it is possible to proceed.
-		return "", "", nil, boerrors.NewBuildOpError(boerrors.EPaCSecretInvalid,
+		return "", nil, boerrors.NewBuildOpError(boerrors.EPaCSecretInvalid,
 			fmt.Errorf("invalid configuration in Pipelines as Code secret: %w", err))
 	}
 
@@ -134,17 +135,11 @@ func (r *ComponentBuildReconciler) GetWebhookDataAndPacSecret(ctx context.Contex
 		// and stores it in the corresponding k8s secret.
 		webhookSecretString, err = r.ensureWebhookSecret(ctx, component, newModel)
 		if err != nil {
-			return "", "", nil, err
+			return "", nil, err
 		}
 	}
 
-	// Obtain Pipelines as Code callback URL (needed for both webhook mode and app mode for incoming triggers)
-	webhookTargetUrl, err := r.getPaCWebhookTargetUrl(ctx, repoUrl, true)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	return webhookSecretString, webhookTargetUrl, pacSecret, nil
+	return webhookSecretString, pacSecret, nil
 }
 
 // ProvisionPaCForComponentOldModel does Pipelines as Code provision for the given component.
@@ -198,7 +193,7 @@ func (r *ComponentBuildReconciler) ProvisionPaCForComponentOldModel(ctx context.
 		}
 
 		// Obtain Pipelines as Code callback URL
-		webhookTargetUrl, err = r.getPaCWebhookTargetUrl(ctx, repoUrl, true)
+		webhookTargetUrl, err = r.getPaCWebhookTargetUrl(ctx, repoUrl)
 		if err != nil {
 			return "", err
 		}
@@ -337,7 +332,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	component *compapiv1alpha1.Component,
 	sanitizedVersionName string,
 	targetBranch string,
-	webhookTargetUrl string,
+	pacInternalUrl string,
 	incomingSecret *corev1.Secret,
 	repository *pacv1alpha1.Repository,
 ) error {
@@ -348,7 +343,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	secretValue := string(incomingSecret.Data[pacIncomingSecretKey])
 	pipelineRunName := getPipelineRunDefinitionName(component.Name, sanitizedVersionName, false)
 
-	triggerURL := fmt.Sprintf("%s/incoming", webhookTargetUrl)
+	triggerURL := fmt.Sprintf("%s/incoming", pacInternalUrl)
 	HttpClient := GetHttpClientFunction()
 
 	// we have to supply source_url as additional param, because PaC isn't able to resolve it for trigger
@@ -446,7 +441,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 		return true, nil
 	}
 
-	webhookTargetUrl, err := r.getPaCWebhookTargetUrl(ctx, repoUrl, false)
+	pacInternalUrl, err := r.getPaCRoutePublicUrl(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -455,7 +450,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 
 	pipelineRunName := getPipelineRunDefinitionName(component.Name, "", false)
 
-	triggerURL := fmt.Sprintf("%s/incoming", webhookTargetUrl)
+	triggerURL := fmt.Sprintf("%s/incoming", pacInternalUrl)
 	HttpClient := GetHttpClientFunction()
 
 	// we have to supply source_url as additional param, because PaC isn't able to resolve it for trigger
@@ -508,7 +503,7 @@ func (r *ComponentBuildReconciler) UndoPaCProvisionForComponentOldModel(ctx cont
 	repoUrl := getGitRepoUrl(*component, newModel)
 	webhookTargetUrl := ""
 	if !common.IsPaCApplicationConfigured(gitProvider, pacSecret.Data) {
-		webhookTargetUrl, err = r.getPaCWebhookTargetUrl(ctx, repoUrl, true)
+		webhookTargetUrl, err = r.getPaCWebhookTargetUrl(ctx, repoUrl)
 		if err != nil {
 			// Just log the error and continue with pruning merge request creation
 			log.Error(err, "failed to get Pipelines as Code webhook target URL. Webhook will not be deleted.", l.Action, l.ActionView, l.Audit, "true")
@@ -542,49 +537,54 @@ func (r *ComponentBuildReconciler) UndoPaCProvisionForComponentOldModel(ctx cont
 }
 
 // getPaCWebhookTargetUrl returns URL to which events from git repository should be sent.
-// it will first try to get url from env variable
-// then when useWebhookUrlConfig is true it will try to get it from webhook config
-// and lastly it will try to get it from PaC route url
-func (r *ComponentBuildReconciler) getPaCWebhookTargetUrl(ctx context.Context, repositoryURL string, useWebhookUrlConfig bool) (string, error) {
-	webhookTargetUrl := os.Getenv(pipelinesAsCodeRouteEnvVar)
+// First, it checks provided mapping, if any.
+// If no match found, reads PAC_WEBHOOK_URL environment variable.
+// Lastly, falls back to PaC Route URL.
+func (r *ComponentBuildReconciler) getPaCWebhookTargetUrl(ctx context.Context, repositoryURL string) (string, error) {
+	webhookTargetUrl := r.PaCWebhookMapping.GetPaCWebhookUrlForGitRepo(repositoryURL)
 
-	if webhookTargetUrl == "" && useWebhookUrlConfig {
-		webhookTargetUrl = r.WebhookURLLoader.Load(repositoryURL)
+	if webhookTargetUrl == "" {
+		webhookTargetUrl = os.Getenv(pipelinesAsCodeRouteEnvVar)
 	}
 
 	if webhookTargetUrl == "" {
-		// The env variable is not set
-		// Use the installed on the cluster Pipelines as Code
 		var err error
 		webhookTargetUrl, err = r.getPaCRoutePublicUrl(ctx)
 		if err != nil {
 			return "", err
 		}
 	}
+
 	return webhookTargetUrl, nil
 }
 
 // getPaCRoutePublicUrl returns Pipelines as Code public route that recieves events to trigger new pipeline runs.
+// It checks "openshift-pipelines", "pipelines-as-code" namespaces
+// and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
+// The operator should always use this Route when communicating with PaC endpoint.
 func (r *ComponentBuildReconciler) getPaCRoutePublicUrl(ctx context.Context) (string, error) {
 	pacWebhookRoute := &routev1.Route{}
-	pacWebhookRouteKey := types.NamespacedName{Namespace: pipelinesAsCodeNamespace, Name: pipelinesAsCodeRouteName}
-	if err := r.Client.Get(ctx, pacWebhookRouteKey, pacWebhookRoute); err != nil {
-		if !errors.IsNotFound(err) {
-			return "", fmt.Errorf("failed to get Pipelines as Code route in %s namespace: %w", pacWebhookRouteKey.Namespace, err)
-		}
-		// Fallback to old PaC namesapce
-		pacWebhookRouteKey.Namespace = pipelinesAsCodeNamespaceFallback
+
+	namespacesToCheck := []string{pipelinesAsCodeNamespaceOpenshift, pipelinesAsCodeNamespace}
+	customPacNamespace := os.Getenv(pipelinesAsCodeNamespaceEnvVar)
+	if customPacNamespace != "" {
+		namespacesToCheck = append([]string{customPacNamespace}, namespacesToCheck...)
+	}
+
+	for _, namespace := range namespacesToCheck {
+		pacWebhookRouteKey := types.NamespacedName{Namespace: namespace, Name: pipelinesAsCodeRouteName}
 		if err := r.Client.Get(ctx, pacWebhookRouteKey, pacWebhookRoute); err != nil {
 			if !errors.IsNotFound(err) {
-				return "", fmt.Errorf("failed to get Pipelines as Code route in %s namespace: %w", pacWebhookRouteKey.Namespace, err)
+				return "", fmt.Errorf("failed to get Pipelines as Code route in %s namespace: %w", namespace, err)
 			}
-			// Pipelines as Code public route was not found in expected namespaces
-			// Consider this error permanent
-			return "", boerrors.NewBuildOpError(boerrors.EPaCRouteDoesNotExist,
-				fmt.Errorf("PaC route not found in %s nor %s namespace", pipelinesAsCodeNamespace, pipelinesAsCodeNamespaceFallback))
+			// Not found, continue
+		} else {
+			// Route found
+			return "https://" + pacWebhookRoute.Spec.Host, nil
 		}
 	}
-	return "https://" + pacWebhookRoute.Spec.Host, nil
+	// Checked all candidate namespaces	for PaC installation, the PaC Route not found.
+	return "", fmt.Errorf("PaC route not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
 }
 
 // TODO remove newModel handling after only new model is used
@@ -640,15 +640,21 @@ func GetGitClient(component *compapiv1alpha1.Component, pacConfig map[string][]b
 // The webhook is only created when PaC GitHub/GitLab App is not configured (checks via IsPaCApplicationConfigured).
 // When using App-based integration, webhooks are managed automatically by the git provider and this setup is skipped.
 // TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) SetupPacWebhookWhenAppNotUsed(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte, webhookTargetUrl, webhookSecret string) error {
-	log := ctrllog.FromContext(ctx).WithValues("repository", component.Spec.Source.GitURL)
+func (r *ComponentBuildReconciler) SetupPacWebhookWhenAppNotUsed(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte, webhookSecret string) error {
 	newModel := true
 
 	gitProvider, _ := getGitProvider(*component, newModel)
 	repoUrl := getGitRepoUrl(*component, newModel)
 
+	log := ctrllog.FromContext(ctx).WithValues("repository", repoUrl)
+
 	isAppUsed := common.IsPaCApplicationConfigured(gitProvider, pacConfig)
 	if !isAppUsed {
+		webhookTargetUrl, err := r.getPaCWebhookTargetUrl(ctx, repoUrl)
+		if err != nil {
+			return fmt.Errorf("failed to get PaC webhook URL: %w", err)
+		}
+
 		if err := gitClient.SetupPaCWebhook(repoUrl, webhookTargetUrl, webhookSecret); err != nil {
 			log.Error(err, fmt.Sprintf("failed to setup Pipelines as Code webhook %s for %s Component in %s namespace", webhookTargetUrl, component.Name, component.Namespace), l.Audit, "true")
 			return err
@@ -811,7 +817,7 @@ func (r *ComponentBuildReconciler) ConfigureRepositoryForPaCOldModel(ctx context
 
 // RemovePacWebhook removes repository webhook, but only when no other component is using it, used only when component is removed
 // TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte, webhookTargetUrl string) error {
+func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte) error {
 	log := ctrllog.FromContext(ctx)
 	newModel := true
 
@@ -819,7 +825,12 @@ func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, compone
 	repoUrl := getGitRepoUrl(*component, newModel)
 
 	isAppUsed := common.IsPaCApplicationConfigured(gitProvider, pacConfig)
-	if !isAppUsed && webhookTargetUrl != "" {
+	if !isAppUsed {
+		webhookTargetUrl, err := r.getPaCWebhookTargetUrl(ctx, repoUrl)
+		if err != nil {
+			return fmt.Errorf("failed to get PaC webhook URL: %w", err)
+		}
+
 		componentList := &compapiv1alpha1.ComponentList{}
 		if err := r.Client.List(ctx, componentList, &client.ListOptions{Namespace: component.Namespace}); err != nil {
 			log.Error(err, "failed to list components")

--- a/internal/controller/component_build_controller_pac.go
+++ b/internal/controller/component_build_controller_pac.go
@@ -608,8 +608,15 @@ func (r *ComponentBuildReconciler) getInternalPaCEndpoint(ctx context.Context) (
 			}
 			// Not found, continue
 		} else {
-			// Service found, generate URL: http://<service-name>.<namespace-name>.svc.cluster.local
-			internalServiceUrl := fmt.Sprintf("http://%s.%s.svc.cluster.local", pacEndpointServiceKey.Name, pacEndpointServiceKey.Namespace)
+			// Service found, generate URL: http://<service-name>.<namespace-name>.svc.cluster.local:<service-port>
+			port := 80
+			for _, servicePortConfig := range pacEndpointService.Spec.Ports {
+				if servicePortConfig.Name == "http-listener" {
+					port = int(servicePortConfig.Port)
+					break
+				}
+			}
+			internalServiceUrl := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", pacEndpointServiceKey.Name, pacEndpointServiceKey.Namespace, port)
 			return internalServiceUrl, nil
 		}
 	}

--- a/internal/controller/component_build_controller_pac.go
+++ b/internal/controller/component_build_controller_pac.go
@@ -55,7 +55,7 @@ const (
 	pipelinesAsCodeNamespaceOpenshift = "openshift-pipelines"
 	pipelinesAsCodeNamespace          = "pipelines-as-code"
 	pipelinesAsCodeRouteName          = "pipelines-as-code-controller"
-	pipelinesAsCodeRouteEnvVar        = "PAC_WEBHOOK_URL"
+	pipelinesAsCodeWebhookUrlEnvVar   = "PAC_WEBHOOK_URL"
 	pipelinesAsCodeWebhooksSecretName = "pipelines-as-code-webhooks-secret"
 
 	pacCelExpressionAnnotationName = "pipelinesascode.tekton.dev/on-cel-expression"
@@ -441,7 +441,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 		return true, nil
 	}
 
-	pacInternalUrl, err := r.getPaCRoutePublicUrl(ctx)
+	pacInternalUrl, err := r.getInternalPaCEndpoint(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -544,7 +544,7 @@ func (r *ComponentBuildReconciler) getPaCWebhookTargetUrl(ctx context.Context, r
 	webhookTargetUrl := r.PaCWebhookMapping.GetPaCWebhookUrlForGitRepo(repositoryURL)
 
 	if webhookTargetUrl == "" {
-		webhookTargetUrl = os.Getenv(pipelinesAsCodeRouteEnvVar)
+		webhookTargetUrl = os.Getenv(pipelinesAsCodeWebhookUrlEnvVar)
 	}
 
 	if webhookTargetUrl == "" {
@@ -561,7 +561,7 @@ func (r *ComponentBuildReconciler) getPaCWebhookTargetUrl(ctx context.Context, r
 // getPaCRoutePublicUrl returns Pipelines as Code public route that recieves events to trigger new pipeline runs.
 // It checks "openshift-pipelines", "pipelines-as-code" namespaces
 // and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
-// The operator should always use this Route when communicating with PaC endpoint.
+// Note, it makes sense only for Openshift as in pure k8s PaC doesn't have Ingress by default.
 func (r *ComponentBuildReconciler) getPaCRoutePublicUrl(ctx context.Context) (string, error) {
 	pacWebhookRoute := &routev1.Route{}
 
@@ -583,8 +583,38 @@ func (r *ComponentBuildReconciler) getPaCRoutePublicUrl(ctx context.Context) (st
 			return "https://" + pacWebhookRoute.Spec.Host, nil
 		}
 	}
-	// Checked all candidate namespaces	for PaC installation, the PaC Route not found.
+	// Checked all candidate namespaces for PaC installation, the PaC Route not found.
 	return "", fmt.Errorf("PaC route not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
+}
+
+// getInternalPaCEndpoint returns cluster internal URL to PaC endpoint.
+// It searches for PaC Service (which has the same name as Route) in "openshift-pipelines", "pipelines-as-code" namespaces
+// and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
+// The operator should always use this endpoint when communicating with PaC within the cluster.
+func (r *ComponentBuildReconciler) getInternalPaCEndpoint(ctx context.Context) (string, error) {
+	pacEndpointService := &corev1.Service{}
+
+	namespacesToCheck := []string{pipelinesAsCodeNamespaceOpenshift, pipelinesAsCodeNamespace}
+	customPacNamespace := os.Getenv(pipelinesAsCodeNamespaceEnvVar)
+	if customPacNamespace != "" {
+		namespacesToCheck = append([]string{customPacNamespace}, namespacesToCheck...)
+	}
+
+	for _, namespace := range namespacesToCheck {
+		pacEndpointServiceKey := types.NamespacedName{Namespace: namespace, Name: pipelinesAsCodeRouteName}
+		if err := r.Client.Get(ctx, pacEndpointServiceKey, pacEndpointService); err != nil {
+			if !errors.IsNotFound(err) {
+				return "", fmt.Errorf("failed to get Pipelines as Code service in %s namespace: %w", namespace, err)
+			}
+			// Not found, continue
+		} else {
+			// Service found, generate URL: http://<service-name>.<namespace-name>.svc.cluster.local
+			internalServiceUrl := fmt.Sprintf("http://%s.%s.svc.cluster.local", pacEndpointServiceKey.Name, pacEndpointServiceKey.Namespace)
+			return internalServiceUrl, nil
+		}
+	}
+	// Checked all candidate namespaces for PaC installation, the PaC Service not found.
+	return "", fmt.Errorf("PaC service not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
 }
 
 // TODO remove newModel handling after only new model is used

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -1872,14 +1872,14 @@ var _ = Describe("Component build controller", func() {
 			repositoryName, _     = generatePaCRepositoryNameFromGitUrl(SampleRepoLink + "-" + resourcePacTriggerKey.Name)
 			repositoryNameKey     = types.NamespacedName{Name: repositoryName, Namespace: namespace}
 			pacServiceKey         = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
-			internalPaCEndpoint   = fmt.Sprintf("http://%s.%s.svc.cluster.local", pacServiceKey.Name, pacServiceKey.Namespace)
+			internalPaCEndpoint   = fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", pacServiceKey.Name, pacServiceKey.Namespace)
 		)
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
-			createService(pacServiceKey)
+			createPaCService(pacServiceKey)
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			pacSecretData := map[string]string{

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Component build controller", func() {
 
 	var (
 		// All related to the component resources have the same key (but different type)
-		pacRouteKey  = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
+		pacRouteKey  = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
 		pacSecretKey = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: BuildServiceNamespaceName}
 	)
 
@@ -101,7 +101,7 @@ var _ = Describe("Component build controller", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
 			createNamespace(BuildServiceNamespaceName)
 			pacSecretData := map[string]string{
@@ -480,7 +480,7 @@ var _ = Describe("Component build controller", func() {
 			})
 			Expect(k8sClient.Update(ctx, contextNamespace)).Should(Succeed())
 
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
@@ -1139,7 +1139,7 @@ var _ = Describe("Component build controller", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
@@ -1661,7 +1661,7 @@ var _ = Describe("Component build controller", func() {
 			deleteAllPaCRepositories(anotherComponentKey.Namespace)
 
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
@@ -1876,7 +1876,7 @@ var _ = Describe("Component build controller", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
@@ -1992,6 +1992,126 @@ var _ = Describe("Component build controller", func() {
 
 			repository = waitPaCRepositoryCreated(repositoryNameKey)
 
+			Expect(repository.Spec.Incomings).ToNot(BeNil())
+			Expect(len(*repository.Spec.Incomings)).To(Equal(1))
+			Expect((*repository.Spec.Incomings)[0].Secret.Name).To(Equal(incomingSecretName))
+			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
+			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"main"}))
+			Expect(len((*repository.Spec.Incomings)[0].Params)).To(Equal(1))
+			Expect((*repository.Spec.Incomings)[0].Params).To(Equal([]string{"source_url"}))
+		})
+
+		It("should trigger build if proxy is used for git events to PaC webhook", func() {
+			gitRepoUrl := "https://githost.com/org/repo"
+			repositoryName, _ := generatePaCRepositoryNameFromGitUrl(gitRepoUrl)
+			repositoryNameKey := types.NamespacedName{Namespace: namespace, Name: repositoryName}
+
+			mergeUrl := "merge-url"
+			EnsurePaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (string, error) {
+				return mergeUrl, nil
+			}
+
+			isSetupPaCWebhookInvoked := false
+			SetupPaCWebhookFunc = func(repoUrl, webhookUrl, webhookSecret string) error {
+				defer GinkgoRecover()
+				isSetupPaCWebhookInvoked = true
+				Expect(repoUrl).To(Equal(gitRepoUrl))
+				// The mapping between git repo URL and webhook URL is defined at controller creation in suite_test.go
+				Expect(webhookUrl).To(Equal("https://githost.proxy.net"))
+				Expect(webhookSecret).ToNot(BeEmpty())
+				return nil
+			}
+
+			// Use token-based auth instead of GitHub App
+			scmSecretKey := types.NamespacedName{Name: "gitlab-token-secret", Namespace: namespace}
+			scmSecretData := map[string]string{
+				"password": "test-token",
+			}
+			labels := map[string]string{
+				"appstudio.redhat.com/credentials": "scm",
+				"appstudio.redhat.com/scm.host":    "githost.com",
+			}
+			createSCMSecret(scmSecretKey, scmSecretData, corev1.SecretTypeBasicAuth, nil, labels)
+			defer deleteSecret(scmSecretKey)
+
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: resourcePacTriggerKey,
+				annotations: map[string]string{
+					defaultBuildPipelineAnnotation: defaultPipelineAnnotationValue,
+					"git-provider":                 "gitlab",
+				},
+				gitURL: gitRepoUrl,
+			}, BuildRequestConfigurePaCAnnotationValue)
+			Eventually(func() bool { return isSetupPaCWebhookInvoked }, timeout, interval).Should(BeTrue())
+			waitPaCFinalizerOnComponent(resourcePacTriggerKey)
+			expectPacBuildStatusOldModel(resourcePacTriggerKey, "enabled", 0, "", mergeUrl)
+
+			repository := waitPaCRepositoryCreated(repositoryNameKey)
+			component := getComponent(resourcePacTriggerKey)
+
+			pacWebhookRoute := &routev1.Route{}
+			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
+			// Despite using proxy for the git events delivery to PaC,
+			// trigger build requiest should be made using internal connection (PaC Route).
+			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
+			pipelineRunName := component.Name + pipelineRunOnPushSuffix
+
+			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+			gock.InterceptClient(client)
+			getHttpClientMocked := func() *http.Client { return client }
+			GetHttpClientFunction = getHttpClientMocked
+			defer gock.Off()
+
+			var (
+				requestValueSourceUrl   string
+				requestValueSecret      string
+				requestValueRepository  string
+				requestValueBranch      string
+				requestValuePipelinerun string
+				requestValueNamespace   string
+			)
+			req := gock.New(webhookTargetUrl).
+				Post("/incoming").
+				MatchType("json").
+				SetMatcher(gock.NewBasicMatcher()).
+				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
+					var bodyJson map[string]interface{}
+					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
+						return false, err
+					}
+					requestValueRepository = bodyJson["repository"].(string)
+					requestValueBranch = bodyJson["branch"].(string)
+					requestValueSecret = bodyJson["secret"].(string)
+					requestValuePipelinerun = bodyJson["pipelinerun"].(string)
+					requestValueNamespace = bodyJson["namespace"].(string)
+					requestValueSourceUrl = bodyJson["params"].(map[string]interface{})["source_url"].(string)
+					return true, nil
+				})).
+				Reply(202).JSON(map[string]string{})
+
+			setComponentBuildRequestOldModel(resourcePacTriggerKey, BuildRequestTriggerPaCBuildAnnotationValue)
+
+			incomingSecretName := getPaCIncomingSecretName(repository.Name)
+			incomingSecretResourceKey := types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}
+			waitSecretCreated(incomingSecretResourceKey)
+			defer deleteSecret(incomingSecretResourceKey)
+
+			incomingSecret := corev1.Secret{}
+			Expect(k8sClient.Get(ctx, incomingSecretResourceKey, &incomingSecret)).To(Succeed())
+			secretValue := string(incomingSecret.Data[pacIncomingSecretKey])
+
+			waitComponentAnnotationGone(resourcePacTriggerKey, BuildRequestAnnotationName)
+			// verify that request matched
+			Expect(req.Done()).To(BeTrue())
+			// verify that request body json params match
+			Expect(requestValueSourceUrl).To(Equal(component.Spec.Source.GitSource.URL))
+			Expect(requestValueSecret).To(Equal(secretValue))
+			Expect(requestValueRepository).To(Equal(repositoryName))
+			Expect(requestValueBranch).To(Equal("main"))
+			Expect(requestValuePipelinerun).To(Equal(pipelineRunName))
+			Expect(requestValueNamespace).To(Equal(component.Namespace))
+
+			repository = waitPaCRepositoryCreated(repositoryNameKey)
 			Expect(repository.Spec.Incomings).ToNot(BeNil())
 			Expect(len(*repository.Spec.Incomings)).To(Equal(1))
 			Expect((*repository.Spec.Incomings)[0].Secret.Name).To(Equal(incomingSecretName))

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1872,12 +1871,15 @@ var _ = Describe("Component build controller", func() {
 			webhookSecretKey      = types.NamespacedName{Name: pipelinesAsCodeWebhooksSecretName, Namespace: namespace}
 			repositoryName, _     = generatePaCRepositoryNameFromGitUrl(SampleRepoLink + "-" + resourcePacTriggerKey.Name)
 			repositoryNameKey     = types.NamespacedName{Name: repositoryName, Namespace: namespace}
+			pacServiceKey         = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
+			internalPaCEndpoint   = fmt.Sprintf("http://%s.%s.svc.cluster.local", pacServiceKey.Name, pacServiceKey.Namespace)
 		)
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, "pac-host")
+			createService(pacServiceKey)
 			createNamespace(BuildServiceNamespaceName)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 			pacSecretData := map[string]string{
@@ -1898,6 +1900,7 @@ var _ = Describe("Component build controller", func() {
 
 			deleteSecret(pacSecretKey)
 			deleteRoute(pacRouteKey)
+			deleteService(pacServiceKey)
 		})
 
 		It("should successfully trigger PaC build", func() {
@@ -1917,9 +1920,6 @@ var _ = Describe("Component build controller", func() {
 			repository := waitPaCRepositoryCreated(repositoryNameKey)
 			component := getComponent(resourcePacTriggerKey)
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			pipelineRunName := component.Name + pipelineRunOnPushSuffix
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
@@ -1934,7 +1934,7 @@ var _ = Describe("Component build controller", func() {
 
 			// return 505 on the first request, so there will be new reconcile
 			// just to test that it will trigger new reconcile
-			gock.New(webhookTargetUrl).
+			gock.New(internalPaCEndpoint).
 				BodyString("").
 				Post("/incoming").
 				Reply(505)
@@ -1948,7 +1948,7 @@ var _ = Describe("Component build controller", func() {
 				requestValueNamespace   string
 			)
 
-			req := gock.New(webhookTargetUrl).
+			req := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2049,11 +2049,6 @@ var _ = Describe("Component build controller", func() {
 			repository := waitPaCRepositoryCreated(repositoryNameKey)
 			component := getComponent(resourcePacTriggerKey)
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			// Despite using proxy for the git events delivery to PaC,
-			// trigger build requiest should be made using internal connection (PaC Route).
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			pipelineRunName := component.Name + pipelineRunOnPushSuffix
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
@@ -2070,7 +2065,7 @@ var _ = Describe("Component build controller", func() {
 				requestValuePipelinerun string
 				requestValueNamespace   string
 			)
-			req := gock.New(webhookTargetUrl).
+			req := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2149,9 +2144,6 @@ var _ = Describe("Component build controller", func() {
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
 			defer deleteComponent(component2Key)
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			incomingSecretName := getPaCIncomingSecretName(repository.Name)
 
 			component1 := getComponent(resourcePacTriggerKey)
@@ -2167,7 +2159,7 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			req1 := gock.New(webhookTargetUrl).
+			req1 := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2196,7 +2188,7 @@ var _ = Describe("Component build controller", func() {
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
-			req2 := gock.New(webhookTargetUrl).
+			req2 := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2249,9 +2241,6 @@ var _ = Describe("Component build controller", func() {
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
 			defer deleteComponent(component2Key)
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
 			incomingSecretName := getPaCIncomingSecretName(repository.Name)
 
 			component1 := getComponent(resourcePacTriggerKey)
@@ -2267,7 +2256,7 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			req1 := gock.New(webhookTargetUrl).
+			req1 := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2296,7 +2285,7 @@ var _ = Describe("Component build controller", func() {
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
-			req2 := gock.New(webhookTargetUrl).
+			req2 := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2372,14 +2361,10 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
-
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
-			req := gock.New(webhookTargetUrl).
+			req := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2460,14 +2445,10 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
-
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
-			req := gock.New(webhookTargetUrl).
+			req := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).
@@ -2542,14 +2523,10 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			pacWebhookRoute := &routev1.Route{}
-			Expect(k8sClient.Get(ctx, pacRouteKey, pacWebhookRoute)).To(Succeed())
-			webhookTargetUrl := "https://" + pacWebhookRoute.Spec.Host
-
 			component2 := getComponent(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
-			req := gock.New(webhookTargetUrl).
+			req := gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				MatchType("json").
 				SetMatcher(gock.NewBasicMatcher()).

--- a/internal/controller/component_build_controller_v2.go
+++ b/internal/controller/component_build_controller_v2.go
@@ -204,13 +204,12 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 	}
 
 	var webhookSecretString string
-	var webhookTargetUrl string
 	var pacSecret *corev1.Secret
 	var gitClient gitprovider.GitProviderClient
 
 	// Get webhook data and PaC secret and git client if any action needs to be performed
 	if createOrUpdateRepository || len(versionsToOnboard) > 0 || len(versionsToOffboard) > 0 || len(versionsToTriggerBuildFor) > 0 || len(versionsToCreatePRFor) > 0 {
-		webhookSecretString, webhookTargetUrl, pacSecret, err = r.GetWebhookDataAndPacSecret(ctx, &component)
+		webhookSecretString, pacSecret, err = r.GetPacSecrets(ctx, &component)
 		if err != nil {
 			return ctrl.Result{}, r.handlePersistentError(ctx, &component, err, "Failed to get webhook data and PaC secret")
 		}
@@ -252,7 +251,7 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 	// Setup PaC webhook for the component git repository when GitHub/GitLab App is not configured
 	// (App-based repos skip webhook setup as the app manages webhooks automatically)
 	if len(versionsToOnboard) > 0 || len(versionsToCreatePRFor) > 0 {
-		if err := r.SetupPacWebhookWhenAppNotUsed(ctx, &component, gitClient, pacSecret.Data, webhookTargetUrl, webhookSecretString); err != nil {
+		if err := r.SetupPacWebhookWhenAppNotUsed(ctx, &component, gitClient, pacSecret.Data, webhookSecretString); err != nil {
 			return ctrl.Result{}, r.handlePersistentError(ctx, &component, err, "Failed to setup PaC webhook")
 		}
 	}
@@ -282,12 +281,17 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 			return ctrl.Result{Requeue: true}, nil
 		}
 
+		pacInternalUrl, err := r.getPaCRoutePublicUrl(ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
 		// Trigger builds for the requested versions
 		successfullyTriggered := make([]string, 0, len(versionsToTriggerBuildFor))
 		for _, versionName := range versionsToTriggerBuildFor {
 			versionInfo := existingSpecVersions[versionName]
 			// Trigger PaC build by calling the incoming webhook endpoint
-			err := r.TriggerPaCBuild(ctx, &component, versionInfo.SanitizedVersion, versionInfo.Revision, webhookTargetUrl, incomingSecret, repository)
+			err := r.TriggerPaCBuild(ctx, &component, versionInfo.SanitizedVersion, versionInfo.Revision, pacInternalUrl, incomingSecret, repository)
 			if err != nil {
 				log.Error(err, "Failed to trigger build for component version", "Version", versionName)
 
@@ -684,8 +688,7 @@ func (r *ComponentBuildReconciler) cleanupComponentPaCResources(ctx context.Cont
 	// Generate version info from status for offboarding
 	existingStatusVersions := buildVersionInfoMap(component, true)
 
-	// Get webhook data and PaC secret
-	_, webhookTargetUrl, pacSecret, err := r.GetWebhookDataAndPacSecret(ctx, component)
+	_, pacSecret, err := r.GetPacSecrets(ctx, component)
 	if err != nil {
 		log.Info("Error during component cleanup: failed to get webhook data and PaC secret", "error", err)
 	}
@@ -697,10 +700,8 @@ func (r *ComponentBuildReconciler) cleanupComponentPaCResources(ctx context.Cont
 			log.Info("Error during component cleanup: failed to get git client", "error", err)
 		} else {
 			// Remove webhook only when other component isn't using the same git repository
-			if webhookTargetUrl != "" {
-				if err := r.RemovePacWebhook(ctx, component, gitClient, pacSecret.Data, webhookTargetUrl); err != nil {
-					log.Info("Error during component cleanup: failed to remove PaC webhook", "error", err)
-				}
+			if err := r.RemovePacWebhook(ctx, component, gitClient, pacSecret.Data); err != nil {
+				log.Info("Error during component cleanup: failed to remove PaC webhook", "error", err)
 			}
 
 			// Remove PaC configuration for all versions from the component git repository

--- a/internal/controller/component_build_controller_v2.go
+++ b/internal/controller/component_build_controller_v2.go
@@ -281,7 +281,7 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		pacInternalUrl, err := r.getPaCRoutePublicUrl(ctx)
+		pacInternalUrl, err := r.getInternalPaCEndpoint(ctx)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/component_build_controller_v2_test.go
+++ b/internal/controller/component_build_controller_v2_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Component build controller new model", func() {
 	var (
 		pacRouteKey         = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
 		pacServiceKey       = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
-		internalPaCEndpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local", pacServiceKey.Name, pacServiceKey.Namespace)
+		internalPaCEndpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", pacServiceKey.Name, pacServiceKey.Namespace)
 		pacSecretKey        = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: BuildServiceNamespaceName}
 	)
 
@@ -711,7 +711,7 @@ var _ = Describe("Component build controller new model", func() {
 			component = waitForComponentStatusVersions(componentKey, 1)
 
 			// Create PaC endpoint Service
-			createService(pacServiceKey)
+			createPaCService(pacServiceKey)
 			defer deleteService(pacServiceKey)
 
 			// Now add trigger build action with invalid version
@@ -2362,7 +2362,7 @@ spec:
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
-			createService(pacServiceKey)
+			createPaCService(pacServiceKey)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
 				"github-private-key":    githubAppPrivateKey,
@@ -3505,7 +3505,7 @@ spec:
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
-			createService(pacServiceKey)
+			createPaCService(pacServiceKey)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
 				"github-private-key":    githubAppPrivateKey,

--- a/internal/controller/component_build_controller_v2_test.go
+++ b/internal/controller/component_build_controller_v2_test.go
@@ -79,8 +79,10 @@ var _ = Describe("Component build controller new model", func() {
 	)
 
 	var (
-		pacRouteKey  = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
-		pacSecretKey = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: BuildServiceNamespaceName}
+		pacRouteKey         = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
+		pacServiceKey       = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
+		internalPaCEndpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local", pacServiceKey.Name, pacServiceKey.Namespace)
+		pacSecretKey        = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: BuildServiceNamespaceName}
 	)
 
 	BeforeEach(func() {
@@ -707,6 +709,10 @@ var _ = Describe("Component build controller new model", func() {
 
 			// Wait for v1 to be onboarded
 			component = waitForComponentStatusVersions(componentKey, 1)
+
+			// Create PaC endpoint Service
+			createService(pacServiceKey)
+			defer deleteService(pacServiceKey)
 
 			// Now add trigger build action with invalid version
 			component.Spec.Actions.TriggerBuilds = []string{versionName, "nonexistent"}
@@ -2356,6 +2362,7 @@ spec:
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
+			createService(pacServiceKey)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
 				"github-private-key":    githubAppPrivateKey,
@@ -2383,22 +2390,20 @@ spec:
 			version2Name := "v2"
 
 			// Mock HTTP POST request
-			var capturedPostData map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = bodyJson
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// First onboard versions
 			component := getComponentData(componentConfig{
@@ -2452,13 +2457,10 @@ spec:
 		It("should trigger build if proxy is used for git events to PaC webhook", func() {
 			version1Name := "v1"
 			gitRepoUrl := "https://githost.com/org/repo"
-			// Despite using proxy for the git events delivery to PaC above,
-			// trigger build requiest should be made using internal connection (PaC Route).
-			webhookTargetUrl := "https://" + pacHost
 
 			// Mock HTTP POST request
 			var capturedPostData map[string]any
-			gock.New(webhookTargetUrl).
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
@@ -2552,23 +2554,21 @@ spec:
 			version3Name := "v3"
 
 			// Mock HTTP POST requests
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData []map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				Times(2). // Expect 2 POST requests (one for v1, one for v2)
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = append(capturedPostData, bodyJson)
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// First onboard versions
 			component := getComponentData(componentConfig{
@@ -2614,7 +2614,7 @@ spec:
 			v2PipelineRunName := component.Name + "-" + version2Name + pipelineRunOnPushSuffix
 
 			// Find which request is for which version
-			var v1Data, v2Data map[string]interface{}
+			var v1Data, v2Data map[string]any
 			for _, data := range capturedPostData {
 				pipelinerun := data["pipelinerun"].(string)
 				if pipelinerun == v1PipelineRunName {
@@ -2645,23 +2645,21 @@ spec:
 			version3Name := "v3"
 
 			// Mock HTTP POST requests
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData []map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				Times(2). // Expect 2 POST requests (one for v1, one for v2)
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = append(capturedPostData, bodyJson)
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// First onboard versions - all using same revision
 			component := getComponentData(componentConfig{
@@ -2707,7 +2705,7 @@ spec:
 			v2PipelineRunName := component.Name + "-" + version2Name + pipelineRunOnPushSuffix
 
 			// Find which request is for which version
-			var v1Data, v2Data map[string]interface{}
+			var v1Data, v2Data map[string]any
 			for _, data := range capturedPostData {
 				pipelinerun := data["pipelinerun"].(string)
 				if pipelinerun == v1PipelineRunName {
@@ -2738,23 +2736,21 @@ spec:
 			version3Name := "v3"
 
 			// Mock HTTP POST requests
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData []map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				Times(1). // Expect 1 POST request (only for v2, v1 is being offboarded)
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = append(capturedPostData, bodyJson)
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// First onboard versions
 			component := getComponentData(componentConfig{
@@ -2836,13 +2832,11 @@ spec:
 			version2Name := "v2"
 
 			// Track which POST requests were made
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
+			var capturedPostData []map[string]any
 			// Create matcher function that captures all requests
 			captureRequestMatcher := gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 				defer GinkgoRecover()
-				var bodyJson map[string]interface{}
+				var bodyJson map[string]any
 				if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 					return false, err
 				}
@@ -2852,25 +2846,25 @@ spec:
 
 			// Mock HTTP POST requests - gock consumes mocks in FIFO order
 			// 1st request: succeed (v1)
-			gock.New(webhookTargetUrl).
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(captureRequestMatcher).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// 2nd request: fail (v2 first attempt)
-			gock.New(webhookTargetUrl).
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(captureRequestMatcher).
-				Reply(500).JSON(map[string]interface{}{"error": "internal server error"})
+				Reply(500).JSON(map[string]any{"error": "internal server error"})
 
 			// 3rd request: succeed (v2 retry)
-			gock.New(webhookTargetUrl).
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(captureRequestMatcher).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// First onboard both versions
 			component := getComponentData(componentConfig{
@@ -2918,7 +2912,7 @@ spec:
 			// Count POST requests by version
 			v1Count := 0
 			v2Count := 0
-			var v1Data, v2Data map[string]interface{}
+			var v1Data, v2Data map[string]any
 			for _, data := range capturedPostData {
 				pipelinerun := data["pipelinerun"].(string)
 				if pipelinerun == v1PipelineRunName {
@@ -3511,6 +3505,7 @@ spec:
 			createNamespace(namespace)
 			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
+			createService(pacServiceKey)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
 				"github-private-key":    githubAppPrivateKey,
@@ -3530,6 +3525,7 @@ spec:
 
 		_ = AfterEach(func() {
 			deleteComponentAndOwnedResources(componentKey)
+			deleteService(pacServiceKey)
 			gock.Off()
 		})
 
@@ -3637,23 +3633,21 @@ spec:
 			}
 
 			// Track trigger build POST requests
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData []map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				Persist(). // Allow multiple calls - exact count verified later in test
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = append(capturedPostData, bodyJson)
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// Verify SetupPaCWebhookFunc is NOT called when using GitHub App
 			SetupPaCWebhookFunc = func(string, string, string) error {
@@ -3766,7 +3760,7 @@ spec:
 			}, timeout, interval).Should(Equal(1))
 
 			// Find v2 POST data
-			var v2Data map[string]interface{}
+			var v2Data map[string]any
 			v2PipelineRunName := component.Name + "-" + version2Name + pipelineRunOnPushSuffix
 			for _, data := range capturedPostData {
 				if pipelinerun, ok := data["pipelinerun"].(string); ok && pipelinerun == v2PipelineRunName {
@@ -4009,23 +4003,21 @@ spec:
 			}
 
 			// Track trigger build POST requests
-			var capturedPostData []map[string]interface{}
-			webhookTargetUrl := "https://" + pacHost
-
-			gock.New(webhookTargetUrl).
+			var capturedPostData []map[string]any
+			gock.New(internalPaCEndpoint).
 				Post("/incoming").
 				Persist(). // Allow multiple calls - exact count verified later in test
 				SetMatcher(gock.NewBasicMatcher()).
 				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
 					defer GinkgoRecover()
-					var bodyJson map[string]interface{}
+					var bodyJson map[string]any
 					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
 						return false, err
 					}
 					capturedPostData = append(capturedPostData, bodyJson)
 					return true, nil
 				})).
-				Reply(202).JSON(map[string]interface{}{})
+				Reply(202).JSON(map[string]any{})
 
 			// PHASE 1: Create component with v1 and v2 for onboarding
 			// CreateConfiguration includes v1 (valid) and "nonexistent-v1" (invalid)
@@ -4142,7 +4134,7 @@ spec:
 			}, timeout, interval).Should(Equal(1))
 
 			// Find v2 POST data
-			var v2Data map[string]interface{}
+			var v2Data map[string]any
 			v2PipelineRunName := component.Name + "-" + version2Name + pipelineRunOnPushSuffix
 			for _, data := range capturedPostData {
 				if pipelinerun, ok := data["pipelinerun"].(string); ok && pipelinerun == v2PipelineRunName {
@@ -4216,7 +4208,7 @@ spec:
 			}, timeout, interval).Should(Equal(2))
 
 			// Find v1 POST data
-			var v1Data map[string]interface{}
+			var v1Data map[string]any
 			v1PipelineRunName := component.Name + "-" + version1Name + pipelineRunOnPushSuffix
 			for _, data := range capturedPostData {
 				if pipelinerun, ok := data["pipelinerun"].(string); ok && pipelinerun == v1PipelineRunName {

--- a/internal/controller/component_build_controller_v2_test.go
+++ b/internal/controller/component_build_controller_v2_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Component build controller new model", func() {
 	)
 
 	var (
-		pacRouteKey  = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
+		pacRouteKey  = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespaceOpenshift}
 		pacSecretKey = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: BuildServiceNamespaceName}
 	)
 
@@ -98,7 +98,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -397,7 +397,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -487,7 +487,7 @@ var _ = Describe("Component build controller new model", func() {
 			})
 			Expect(k8sClient.Update(ctx, contextNamespace)).Should(Succeed())
 
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -532,7 +532,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -653,7 +653,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -734,7 +734,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -1129,7 +1129,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -1382,7 +1382,7 @@ var _ = Describe("Component build controller new model", func() {
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -2354,7 +2354,7 @@ spec:
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -2444,6 +2444,103 @@ spec:
 
 			// Verify Repository CR was created with correct URL and no GitProvider (GitHub App)
 			repository := validatePaCRepository(component, "", "")
+
+			// Verify Repository.Spec.Incomings was updated
+			validatePaCRepositoryIncomings(repository, []string{"main"})
+		})
+
+		It("should trigger build if proxy is used for git events to PaC webhook", func() {
+			version1Name := "v1"
+			gitRepoUrl := "https://githost.com/org/repo"
+			// Despite using proxy for the git events delivery to PaC above,
+			// trigger build requiest should be made using internal connection (PaC Route).
+			webhookTargetUrl := "https://" + pacHost
+
+			// Mock HTTP POST request
+			var capturedPostData map[string]any
+			gock.New(webhookTargetUrl).
+				Post("/incoming").
+				SetMatcher(gock.NewBasicMatcher()).
+				AddMatcher(gock.MatchFunc(func(req *http.Request, _ *gock.Request) (bool, error) {
+					defer GinkgoRecover()
+					var bodyJson map[string]any
+					if err := json.NewDecoder(req.Body).Decode(&bodyJson); err != nil {
+						return false, err
+					}
+					capturedPostData = bodyJson
+					return true, nil
+				})).
+				Reply(202).JSON(map[string]any{})
+
+			isSetupPaCWebhookInvoked := false
+			SetupPaCWebhookFunc = func(repoUrl, webhookUrl, webhookSecret string) error {
+				defer GinkgoRecover()
+				isSetupPaCWebhookInvoked = true
+				Expect(repoUrl).To(Equal(gitRepoUrl))
+				// The mapping between git repo URL and webhook URL is defined at controller creation in suite_test.go
+				Expect(webhookUrl).To(Equal("https://githost.proxy.net"))
+				Expect(webhookSecret).ToNot(BeEmpty())
+				return nil
+			}
+
+			// Use token-based auth instead of GitHub App
+			scmSecretKey := types.NamespacedName{Name: "gitlab-token-secret", Namespace: namespace}
+			scmSecretData := map[string]string{
+				"password": "test-token",
+			}
+			labels := map[string]string{
+				"appstudio.redhat.com/credentials": "scm",
+				"appstudio.redhat.com/scm.host":    "githost.com",
+			}
+			createSCMSecret(scmSecretKey, scmSecretData, corev1.SecretTypeBasicAuth, nil, labels)
+			defer deleteSecret(scmSecretKey)
+
+			// Onboard component
+			component := getComponentData(componentConfig{
+				componentKey: componentKey,
+				annotations: map[string]string{
+					"git-provider": "gitlab",
+				},
+				gitURL: gitRepoUrl,
+				versions: []compapiv1alpha1.ComponentVersion{
+					{Name: version1Name, Revision: "main"},
+				},
+			})
+			createComponent(component)
+
+			// Wait for the version to be onboarded
+			Eventually(func() bool { return isSetupPaCWebhookInvoked }, timeout, interval).Should(BeTrue())
+			component = waitForComponentStatusVersions(componentKey, 1)
+
+			// Get repository name for verification
+			repositoryName, err := generatePaCRepositoryNameFromGitUrl(component.Spec.Source.GitURL)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Now add trigger build action using TriggerBuild field
+			component.Spec.Actions.TriggerBuild = version1Name
+			Expect(k8sClient.Update(ctx, component)).To(Succeed())
+
+			// Get incoming secret for verification (created after trigger)
+			incomingSecretName := getPaCIncomingSecretName(repositoryName)
+			incomingSecretKey := types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}
+			waitSecretCreated(incomingSecretKey)
+
+			var incomingSecret corev1.Secret
+			Expect(k8sClient.Get(ctx, incomingSecretKey, &incomingSecret)).To(Succeed())
+			secretValue := string(incomingSecret.Data[pacIncomingSecretKey])
+
+			// TriggerBuild action should be removed after successful trigger
+			component = waitForComponentSpecActionEmpty(componentKey, "trigger", "build")
+
+			// Verify HTTP POST request was made
+			Eventually(func() bool { return capturedPostData != nil }, timeout, interval).Should(BeTrue())
+
+			// Verify all POST request fields
+			v1PipelineRunName := component.Name + "-" + version1Name + pipelineRunOnPushSuffix
+			verifyPacWebhookIncomingPostData(capturedPostData, repositoryName, secretValue, v1PipelineRunName, namespace, "main", component.Spec.Source.GitURL)
+
+			// Verify Repository CR was created with correct URL and no GitProvider (GitHub App)
+			repository := validatePaCRepository(component, scmSecretKey.Name, "password")
 
 			// Verify Repository.Spec.Incomings was updated
 			validatePaCRepositoryIncomings(repository, []string{"main"})
@@ -2863,7 +2960,7 @@ spec:
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 
 			// Use token-based auth instead of GitHub App to test ensureWebhookSecret
@@ -3045,7 +3142,7 @@ spec:
 	// These tests verify onboarding, trigger builds, and configuration creation using token authentication (GitLab, GitHub, Forgejo)
 	Context("Token-based authentication", func() {
 		_ = BeforeEach(func() {
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			createDefaultBuildPipelineConfigMap(defaultPipelineConfigMapKey)
 
@@ -3218,7 +3315,7 @@ spec:
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
@@ -3412,7 +3509,7 @@ spec:
 
 		_ = BeforeEach(func() {
 			createNamespace(namespace)
-			createNamespace(pipelinesAsCodeNamespace)
+			createNamespace(pipelinesAsCodeNamespaceOpenshift)
 			createRoute(pacRouteKey, pacHost)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"go/build"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -140,14 +139,16 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	webhookConfig, err := pacwebhook.LoadMappingFromFile("", os.ReadFile)
-	Expect(err).ToNot(HaveOccurred())
+	pacWebhookMapping := pacwebhook.NewPaCWebhookMappingFromMap(map[string]string{
+		"https://githost.com":           "https://githost.proxy.net",
+		"https://somehost.com/org/repo": "https://somehost.proxy.net",
+	})
 
 	err = (&ComponentBuildReconciler{
 		Client:             k8sManager.GetClient(),
 		Scheme:             k8sManager.GetScheme(),
 		EventRecorder:      k8sManager.GetEventRecorderFor("ComponentOnboarding"),
-		WebhookURLLoader:   pacwebhook.NewConfigWebhookURLLoader(webhookConfig),
+		PaCWebhookMapping:  pacWebhookMapping,
 		CredentialProvider: k8s.NewGitCredentialProvider(k8sManager.GetClient()),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -67,6 +67,7 @@ func getCacheExcludedObjectsTypes() []client.Object {
 	return []client.Object{
 		&corev1.Secret{},
 		&corev1.ConfigMap{},
+		&corev1.Service{},
 	}
 }
 

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -963,6 +964,41 @@ func waitForComponentSpecActionEmpty(componentKey types.NamespacedName, actionTy
 		return false
 	}, timeout, interval).Should(BeTrue())
 	return component
+}
+
+func createService(serviceKey types.NamespacedName) {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceKey.Name,
+			Namespace: serviceKey.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8000,
+					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8000},
+				},
+			},
+		},
+	}
+
+	if err := k8sClient.Create(ctx, &service); err != nil && !k8sErrors.IsAlreadyExists(err) {
+		Fail(err.Error())
+	}
+}
+
+func deleteService(serviceKey types.NamespacedName) {
+	service := &corev1.Service{}
+	if err := k8sClient.Get(ctx, serviceKey, service); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return
+		}
+		Fail(err.Error())
+	}
+	if err := k8sClient.Delete(ctx, service); err != nil && !k8sErrors.IsNotFound(err) {
+		Fail(err.Error())
+	}
 }
 
 func createRoute(routeKey types.NamespacedName, host string) {

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -966,20 +966,26 @@ func waitForComponentSpecActionEmpty(componentKey types.NamespacedName, actionTy
 	return component
 }
 
-func createService(serviceKey types.NamespacedName) {
+func createPaCService(serviceKey types.NamespacedName) {
+	port := corev1.ServicePort{
+		Name: "http-listener",
+		Port: 8080,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: 8082,
+		},
+	}
+	createService(serviceKey, port)
+}
+
+func createService(serviceKey types.NamespacedName, ports ...corev1.ServicePort) {
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceKey.Name,
 			Namespace: serviceKey.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       8000,
-					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8000},
-				},
-			},
+			Ports: ports,
 		},
 	}
 

--- a/pkg/pacwebhook/webhook.go
+++ b/pkg/pacwebhook/webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2025 Red Hat, Inc.
+Copyright 2023-2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,64 +17,47 @@ package webhook
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"strings"
-
-	"github.com/go-logr/logr"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var log logr.Logger = ctrl.Log.WithName("webhook")
-
-type WebhookURLLoader interface {
-	Load(repositoryUrl string) string
-}
-
-type ConfigWebhookURLLoader struct {
-	// Prefix to target url mapping
+// PaCWebhookMapping allows to configure PaC webhook URL based on git repository URL.
+type PaCWebhookMapping struct {
+	// Git repository URL prefix to target webhook URL mapping
 	mapping map[string]string
 }
 
-func NewConfigWebhookURLLoader(mapping map[string]string) ConfigWebhookURLLoader {
-	return ConfigWebhookURLLoader{mapping: mapping}
+func NewPaCWebhookMappingFromMap(mapping map[string]string) *PaCWebhookMapping {
+	return &PaCWebhookMapping{mapping: mapping}
 }
 
-// Load implements WebhookURLLoader.
-// Load allows to configure the PaC webhook target url based on the repository url of the component.
-// The PaC webhook target url config is read from the provided config file or environment variable (has precedence).
-// In case no config file or environment variable are provided, the default PaC route in the cluster will be used.
-// Find the longest prefix match of `repositoryUrl` and the keys of `mapping`, and return the value of that key.
-func (c ConfigWebhookURLLoader) Load(repositoryUrl string) string {
-	longestPrefixLen := 0
-	matchedTarget := ""
-	for prefix, target := range c.mapping {
-		if strings.HasPrefix(repositoryUrl, prefix) && len(prefix) > longestPrefixLen {
-			longestPrefixLen = len(prefix)
-			matchedTarget = target
-		}
-	}
+func NewPaCWebhookMapping(webhookConfigPath string) (*PaCWebhookMapping, error) {
+	webhookMapping := &PaCWebhookMapping{}
 
-	// Provide a default using the empty string
-	if matchedTarget == "" {
-		if val, ok := c.mapping[""]; ok {
-			matchedTarget = val
-		}
+	mapping, err := readMapping(webhookConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PaC webhook mapping: %w", err)
 	}
+	webhookMapping.mapping = mapping
 
-	return matchedTarget
+	return webhookMapping, nil
 }
 
-var _ WebhookURLLoader = ConfigWebhookURLLoader{}
-
-type FileReader func(name string) ([]byte, error)
-
-// LoadMappingFromFile loads the prefix to target url mapping from a file.
-func LoadMappingFromFile(path string, fileReader FileReader) (map[string]string, error) {
-	if path == "" {
-		log.Info("Webhook config was not provided")
-		return map[string]string{}, nil
+// readMapping reads JSON config file with mapping between git repository URL prefix and target PaC webhook URL.
+// Example config file content:
+//
+//	{
+//	    "https://my-gitlab.com": "https://my.event.proxy.net:1234",
+//	    "https://github.com/my-org/": "https://smee.io/SomeChannel1234"
+//	}
+func readMapping(webhookConfigPath string) (map[string]string, error) {
+	if webhookConfigPath == "" {
+		// No config is provided, don't do any mapping
+		return nil, nil
 	}
 
-	content, err := fileReader(path)
+	content, err := os.ReadFile(webhookConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +68,22 @@ func LoadMappingFromFile(path string, fileReader FileReader) (map[string]string,
 		return nil, err
 	}
 
-	log.Info("Using webhook config", "config", mapping)
-
 	return mapping, nil
+}
+
+// GetPaCWebhookUrlForGitRepo returns PaC webhook URL to set into git repository webhook configuration for git providers
+// that cannot access the cluster PaC Route directly (e.g. the cluster in behind a VPN and a proxy for git events needed).
+// The URL is resolved based on the provided mapping between git repository url prefix and desired webhook URL.
+// It finds the longest prefix match for the given git repository URL.
+// It returns empty string if no mapping for the given git defined. In such case, cluster PaC Route should be used.
+func (w *PaCWebhookMapping) GetPaCWebhookUrlForGitRepo(repositoryUrl string) string {
+	longestPrefixLen := 0
+	matchedTarget := ""
+	for prefix, target := range w.mapping {
+		if strings.HasPrefix(repositoryUrl, prefix) && len(prefix) > longestPrefixLen {
+			longestPrefixLen = len(prefix)
+			matchedTarget = target
+		}
+	}
+	return matchedTarget
 }

--- a/pkg/pacwebhook/webhook.go
+++ b/pkg/pacwebhook/webhook.go
@@ -75,9 +75,10 @@ func readMapping(webhookConfigPath string) (map[string]string, error) {
 // that cannot access the cluster PaC Route directly (e.g. the cluster in behind a VPN and a proxy for git events needed).
 // The URL is resolved based on the provided mapping between git repository url prefix and desired webhook URL.
 // It finds the longest prefix match for the given git repository URL.
+// Note, it's possible to have empty prefix entry, so it will match any git repo URL unless better match is found.
 // It returns empty string if no mapping for the given git defined. In such case, cluster PaC Route should be used.
 func (w *PaCWebhookMapping) GetPaCWebhookUrlForGitRepo(repositoryUrl string) string {
-	longestPrefixLen := 0
+	longestPrefixLen := -1
 	matchedTarget := ""
 	for prefix, target := range w.mapping {
 		if strings.HasPrefix(repositoryUrl, prefix) && len(prefix) > longestPrefixLen {

--- a/pkg/pacwebhook/webhook_test.go
+++ b/pkg/pacwebhook/webhook_test.go
@@ -146,6 +146,17 @@ func Test_GetPaCWebhookUrlForGitRepo(t *testing.T) {
 			gitRepoUrl: "https://githost.com/org/repo.git",
 			expected:   "https://githost.org.proxy.net",
 		},
+		{
+			name: "Should match empty key entry if no netter mapping is found",
+			webhookConfig: map[string]string{
+				"https://githost.com":      "https://githost.proxy.net",
+				"https://githost.com/org/": "https://githost.org.proxy.net",
+				"":                         "https://default.proxy.net",
+				"https://special.net":      "https://special.proxy.net",
+			},
+			gitRepoUrl: "https://some-host.com/org/repo.git",
+			expected:   "https://default.proxy.net",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/pacwebhook/webhook_test.go
+++ b/pkg/pacwebhook/webhook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2025 Red Hat, Inc.
+Copyright 2023-2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,162 +16,142 @@ limitations under the License.
 package webhook
 
 import (
-	"errors"
-	"reflect"
+	"os"
+	"path"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
-func TestConfigWebhookURLLoader_Load(t *testing.T) {
-	type fields struct {
-		mapping map[string]string
-	}
-	type args struct {
-		repositoryUrl string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "No match should return an empty string",
-			fields: fields{
-				mapping: map[string]string{},
-			},
-			args: args{
-				repositoryUrl: "https://github.com/org/repo",
-			},
-			want: "",
-		},
-		{
-			name: "Multiple prefix' with an exact match",
-			fields: fields{
-				mapping: map[string]string{
-					"https://github.com/org/repo": "chosenTarget",
-					"https://github.com/org/":     "otherTarget1",
-					"https://github.com/":         "otherTarget2",
-					"https://gitlab.com/":         "otherTarget3",
-				},
-			},
-			args: args{
-				repositoryUrl: "https://github.com/org/repo",
-			},
-			want: "chosenTarget",
-		},
-		{
-			name: "No exact match, the longest prefix is chosen",
-			fields: fields{
-				mapping: map[string]string{
-					"https://github.com/org/": "chosenTarget",
-					"https://github.com/":     "otherTarget1",
-					"https://gitlab.com/":     "otherTarget2",
-				},
-			},
-			args: args{
-				repositoryUrl: "https://github.com/org/repo",
-			},
-			want: "chosenTarget",
-		},
-		{
-			name: "Match on an empty string",
-			fields: fields{
-				mapping: map[string]string{
-					"":                    "chosenTarget",
-					"https://gitlab.com/": "otherTarget2",
-				},
-			},
-			args: args{
-				repositoryUrl: "https://github.com/org/repo",
-			},
-			want: "chosenTarget",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := NewConfigWebhookURLLoader(tt.fields.mapping)
-			if got := c.Load(tt.args.repositoryUrl); got != tt.want {
-				t.Errorf("ConfigWebhookURLLoader.Load() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+func Test_NewPaCWebhookMappingFromMap(t *testing.T) {
+	g := NewWithT(t)
+	t.Run("Should create empty mapping from data in map", func(t *testing.T) {
+		mappingConfig := map[string]string{
+			"https://githost.com":      "https://githost.proxy.net",
+			"https://githost.com/org/": "https://githost.org.proxy.net",
+		}
+		m := NewPaCWebhookMappingFromMap(mappingConfig)
+		g.Expect(m).ToNot(BeNil())
+		g.Expect(m.mapping).To(Equal(mappingConfig))
+	})
+
 }
 
-func TestLoadMappingFromFile(t *testing.T) {
-	type args struct {
-		path string
+func Test_NewPaCWebhookMapping(t *testing.T) {
+	g := NewWithT(t)
+
+	createTempWebhookConfigJson := func(t *testing.T, webhookConfigJson string) (string, error) {
+		tmpFile, err := os.CreateTemp("", "webhook-config-*.json")
+		if err != nil {
+			return "", err
+		}
+		defer func() {
+			_ = tmpFile.Close()
+		}()
+
+		configPath := tmpFile.Name()
+		t.Cleanup(func() {
+			_ = os.Remove(configPath)
+		})
+
+		_, err = tmpFile.WriteString(webhookConfigJson)
+		if err != nil {
+			return "", err
+		}
+		return configPath, nil
 	}
+
+	t.Run("Should create empty webhook mapping", func(t *testing.T) {
+		m, err := NewPaCWebhookMapping("")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(m).ToNot(BeNil())
+	})
+
+	t.Run("Should create webhook mapping", func(t *testing.T) {
+		mappingConfig := `{
+			"https://githost.com":      "https://githost.proxy.net",
+			"https://githost.com/org/": "https://githost.org.proxy.net"
+		}`
+		configPath, err := createTempWebhookConfigJson(t, mappingConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		m, err := NewPaCWebhookMapping(configPath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(m).ToNot(BeNil())
+		g.Expect(m.mapping).To(HaveLen(2))
+		g.Expect(m.mapping).To(HaveKeyWithValue("https://githost.com", "https://githost.proxy.net"))
+		g.Expect(m.mapping).To(HaveKeyWithValue("https://githost.com/org/", "https://githost.org.proxy.net"))
+	})
+
+	t.Run("Should fail to create webhook mapping if config file doesn't exist", func(t *testing.T) {
+		m, err := NewPaCWebhookMapping(path.Join(os.TempDir(), "non-existent-file.json"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(m).To(BeNil())
+	})
+
+	t.Run("Should fail to create webhook mapping if config file has invalid json", func(t *testing.T) {
+		mappingConfig := `{
+			"https://githost.com":      "https://githost.proxy.net,
+			"https://githost.com/org/": "https://githost.org.proxy.net"
+		}`
+		configPath, err := createTempWebhookConfigJson(t, mappingConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		m, err := NewPaCWebhookMapping(configPath)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(m).To(BeNil())
+	})
+}
+
+func Test_GetPaCWebhookUrlForGitRepo(t *testing.T) {
+	g := NewWithT(t)
 	tests := []struct {
-		name       string
-		args       args
-		fileReader FileReader
-		want       map[string]string
-		wantErr    bool
+		name          string
+		webhookConfig map[string]string
+		gitRepoUrl    string
+		expected      string
 	}{
 		{
-			name: "Load empty file",
-			args: args{path: "file"},
-			fileReader: func(name string) ([]byte, error) {
-				return []byte("{}"), nil
-			},
-			want:    map[string]string{},
-			wantErr: false,
+			name:          "Should return empty value if config is empty",
+			webhookConfig: nil,
+			gitRepoUrl:    "https://githost.com/org/repo.git",
+			expected:      "",
 		},
 		{
-			name: "Load non empty file",
-			args: args{path: "file"},
-			fileReader: func(name string) ([]byte, error) {
-				return []byte(`
-					{
-						"a": "1",
-						"b": "2"
-					}
-				`), nil
+			name: "Should return empty value if mapping for the git provider if not defined",
+			webhookConfig: map[string]string{
+				"https://githost.com":      "https://githost.proxy.net",
+				"https://githost.com/org/": "https://githost.org.proxy.net",
 			},
-			want: map[string]string{
-				"a": "1",
-				"b": "2",
-			},
-			wantErr: false,
+			gitRepoUrl: "https://myhost.com/org/repo.git",
+			expected:   "",
 		},
 		{
-			name: "The given path is an empty string",
-			args: args{path: ""},
-			fileReader: func(name string) ([]byte, error) {
-				return nil, nil
+			name: "Should return defined mapping",
+			webhookConfig: map[string]string{
+				"https://somehost.com":     "https://somehost.proxy.net",
+				"https://githost.com/":     "https://githost.proxy.net",
+				"https://anotherhost.com/": "https://anotherhost.proxy.net",
 			},
-			want:    map[string]string{},
-			wantErr: false,
+			gitRepoUrl: "https://githost.com/org/repo.git",
+			expected:   "https://githost.proxy.net",
 		},
 		{
-			name: "Load file with broken json",
-			args: args{path: "file"},
-			fileReader: func(name string) ([]byte, error) {
-				return []byte("abc"), nil
+			name: "Should return most matched mapping",
+			webhookConfig: map[string]string{
+				"https://githost.com":      "https://githost.proxy.net",
+				"https://githost.com/org/": "https://githost.org.proxy.net",
+				"https://somehost.com":     "https://somehost.proxy.net",
 			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "Load file random error",
-			args: args{path: "file"},
-			fileReader: func(name string) ([]byte, error) {
-				return nil, errors.New("Random Error")
-			},
-			want:    nil,
-			wantErr: true,
+			gitRepoUrl: "https://githost.com/org/repo.git",
+			expected:   "https://githost.org.proxy.net",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadMappingFromFile(tt.args.path, tt.fileReader)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LoadMappingFromFile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LoadMappingFromFile() = %v, want %v", got, tt.want)
-			}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := PaCWebhookMapping{mapping: tc.webhookConfig}
+			got := m.GetPaCWebhookUrlForGitRepo(tc.gitRepoUrl)
+			g.Expect(got).To(Equal(tc.expected))
 		})
 	}
 }


### PR DESCRIPTION
Always use PaC Service for direct Build Service to PaC communication and configure users' git repositories web hook URL as defined in `webhook-config.json`, if any. 

Also, cache the `webhook-config.json` and don’t re-read. A change in the corresponding config map will cause the deployment change and operator pod rollout anyway.