### PR TITLE
Replace cache polling sleep loops with wait.PollUntilContextTimeout

### DIFF
--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -527,40 +528,24 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
-// WaitForCacheUpdateOldModel waits for cache update
+// WaitForCacheUpdateOldModel waits for the controller cache to reflect the latest component update.
 // TODO remove after only new model is used
 func (r *ComponentBuildReconciler) WaitForCacheUpdateOldModel(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component) {
 	log := ctrllog.FromContext(ctx)
 
-	// Here we do some trick.
-	// The problem is that the component update triggers both: a new reconcile and operator cache update.
-	// In other words we are getting race condition. If a new reconcile is triggered before cache update,
-	// requested build action will be repeated, because the last update has not yet visible for the operator.
-	// For example, instead of one initial pipeline run we could get two.
-	// To resolve the problem above, instead of just ending the reconcile loop here,
-	// we are waiting for the cache update. This approach prevents next reconciles with outdated cache.
-	isComponentInCacheUpToDate := false
-	for i := 0; i < 20; i++ {
-		if err := r.Client.Get(ctx, namespace, component); err == nil {
-			_, buildRequestAnnotationExists := component.Annotations[BuildRequestAnnotationName]
-			_, buildStatusAnnotationExists := component.Annotations[BuildStatusAnnotationName]
-			if !buildRequestAnnotationExists && buildStatusAnnotationExists {
-				// Cache contains updated component
-				isComponentInCacheUpToDate = true
-				break
-			}
-			// Outdated version of the component, wait more.
-		} else {
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if err := r.Client.Get(ctx, namespace, component); err != nil {
 			if errors.IsNotFound(err) {
-				// The component was deleted
-				isComponentInCacheUpToDate = true
-				break
+				return true, nil
 			}
 			log.Error(err, "failed to get the component", l.Action, l.ActionView)
+			return false, nil
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !isComponentInCacheUpToDate {
+		_, buildRequestAnnotationExists := component.Annotations[BuildRequestAnnotationName]
+		_, buildStatusAnnotationExists := component.Annotations[BuildStatusAnnotationName]
+		return !buildRequestAnnotationExists && buildStatusAnnotationExists, nil
+	})
+	if err != nil {
 		log.Info("failed to wait for updated cache. Requested action could be repeated.", l.Audit, "true")
 	}
 }

--- a/internal/controller/component_build_controller_v2.go
+++ b/internal/controller/component_build_controller_v2.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -601,35 +602,21 @@ func (r *ComponentBuildReconciler) waitForCacheUpdate(ctx context.Context, names
 		failureMessage = "failed to wait for cache to have latest ResourceVersion. Status updates could conflict."
 	}
 
-	isComponentInCacheUpToDate := false
-	for i := 0; i < 20; i++ {
-		// Use a temporary component to avoid overwriting the caller's component variable with stale cache data
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		cachedComponent := &compapiv1alpha1.Component{}
-		if err := r.Client.Get(ctx, namespace, cachedComponent); err == nil {
-			var upToDate bool
-			if checkGeneration {
-				upToDate = originalGeneration == cachedComponent.Generation
-			} else {
-				upToDate = originalResourceVersion == cachedComponent.ResourceVersion
-			}
-
-			if upToDate {
-				// Cache now has the updated component with the new Generation/ResourceVersion.
-				isComponentInCacheUpToDate = true
-				break
-			}
-			// Cache still has outdated value, continue waiting.
-		} else {
+		if err := r.Client.Get(ctx, namespace, cachedComponent); err != nil {
 			if k8serrors.IsNotFound(err) {
-				// Component was deleted, no need to wait for cache update.
-				isComponentInCacheUpToDate = true
-				break
+				return true, nil
 			}
 			log.Error(err, "failed to get the component", l.Action, l.ActionView)
+			return false, nil
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !isComponentInCacheUpToDate {
+		if checkGeneration {
+			return originalGeneration == cachedComponent.Generation, nil
+		}
+		return originalResourceVersion == cachedComponent.ResourceVersion, nil
+	})
+	if err != nil {
 		log.Info(failureMessage, l.Audit, "true")
 	}
 }


### PR DESCRIPTION
The manual time.Sleep polling loops in WaitForCacheUpdateOldModel and waitForCacheUpdate did not respect context cancellation, blocking up to 2s even during controller shutdown. Use the idiomatic Kubernetes wait.PollUntilContextTimeout utility instead, which properly cancels on context deadline while preserving the same 100ms interval and 2s timeout.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable