### PR TITLE
fix: use minimal pipeline in tests

### DIFF
--- a/e2e-tests/tests/annotations.go
+++ b/e2e-tests/tests/annotations.go
@@ -44,7 +44,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			componentName = fmt.Sprintf("%s-%s", "test-annotations", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTA)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 

--- a/e2e-tests/tests/multi_component.go
+++ b/e2e-tests/tests/multi_component.go
@@ -61,7 +61,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			multiComponentPRBranchName = fmt.Sprintf("%s-%s", "pr-branch", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTA)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 

--- a/e2e-tests/tests/pac_build.go
+++ b/e2e-tests/tests/pac_build.go
@@ -89,7 +89,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				componentBaseBranchName = fmt.Sprintf("base-%s", util.GenerateRandomString(6))
 
 				gitClient, helloWorldComponentGitSourceURL, helloWorldRepository = setupGitProvider(f, gitProvider)
-				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTA)
+				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 				if gitProvider == git.ForgejoProvider {
 					gitProviderAnnotation = map[string]string{"git-provider": "forgejo"}

--- a/e2e-tests/tests/renovate.go
+++ b/e2e-tests/tests/renovate.go
@@ -184,7 +184,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			Expect(err).NotTo(HaveOccurred())
 
 		// get the build pipeline bundle annotation
-		buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTA)
+		buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		if gitProvider == git.ForgejoProvider {
 			gitProviderAnnotation = map[string]string{"git-provider": "forgejo"}

--- a/e2e-tests/tests/secret_lookup.go
+++ b/e2e-tests/tests/secret_lookup.go
@@ -54,7 +54,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			// use custom bundle if env defined
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTA)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 


### PR DESCRIPTION
Using minimal docker build pipeline in e2e-tests, this change lost during migration of tests.