### PR TITLE
fix skip-builds feature

### DIFF
--- a/internal/controller/component_build_controller_pac_repository.go
+++ b/internal/controller/component_build_controller_pac_repository.go
@@ -757,5 +757,5 @@ func generatePaCRepositoryNameFromGitUrl(urlStr string) (string, error) {
 
 // getPaCParamFilterForRevision returns PaC param filter for given revision
 func getPaCParamFilterForRevision(revision string) string {
-	return fmt.Sprintf("%s == %s", PacTargetBranchFilterKey, revision)
+	return fmt.Sprintf("%s == '%s'", PacTargetBranchFilterKey, revision)
 }

--- a/internal/controller/component_build_controller_unit_test.go
+++ b/internal/controller/component_build_controller_unit_test.go
@@ -868,7 +868,7 @@ func TestGeneratePACRepository(t *testing.T) {
 			expectedGithubAppTokenScopeRepos: nil,
 			expectedCommentStrategy:          "",
 			skipBuildsMap:                    map[string]bool{"main": false, "feature": true},
-			expectedSkipBuildParams:          map[string]string{fmt.Sprintf("%s == main", PacTargetBranchFilterKey): "true", fmt.Sprintf("%s == feature", PacTargetBranchFilterKey): "false"},
+			expectedSkipBuildParams:          map[string]string{fmt.Sprintf("%s == 'main'", PacTargetBranchFilterKey): "true", fmt.Sprintf("%s == 'feature'", PacTargetBranchFilterKey): "false"},
 		},
 		{
 			name:    "should create PaC repository for GitHub application even if Github webhook configured",
@@ -883,7 +883,7 @@ func TestGeneratePACRepository(t *testing.T) {
 			expectedGithubAppTokenScopeRepos: nil,
 			expectedCommentStrategy:          "",
 			skipBuildsMap:                    map[string]bool{"main": true, "feature": false},
-			expectedSkipBuildParams:          map[string]string{fmt.Sprintf("%s == main", PacTargetBranchFilterKey): "false", fmt.Sprintf("%s == feature", PacTargetBranchFilterKey): "true"},
+			expectedSkipBuildParams:          map[string]string{fmt.Sprintf("%s == 'main'", PacTargetBranchFilterKey): "false", fmt.Sprintf("%s == 'feature'", PacTargetBranchFilterKey): "true"},
 		},
 		{
 			name:    "should create PaC repository for GitHub webhook",

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -843,7 +843,7 @@ func validatePaCRepository(component *compapiv1alpha1.Component, secretName, sec
 			Expect(*repository.Spec.Params).Should(ContainElement(And(
 				HaveField("Name", BuildsEnabledParamName),
 				HaveField("Value", strconv.FormatBool(!skipBuild)),
-				HaveField("Filter", fmt.Sprintf("%s == %s", PacTargetBranchFilterKey, revision)),
+				HaveField("Filter", fmt.Sprintf("%s == '%s'", PacTargetBranchFilterKey, revision)),
 			)))
 		}
 	}


### PR DESCRIPTION
when specifying filter in params in Repository CR
  params:
    - filter: pac.target_branch == main

branch name needs to have quotas for PaC to be able to use those parms in on-cel

  params:
    - filter: pac.target_branch == 'main'

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable