### PR TITLE
bump application-api to get new component CRD and

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,13 +25,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - ""
   resources:
   - namespaces

--- a/e2e-tests/go.mod
+++ b/e2e-tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/devfile/library/v2 v2.2.1-0.20230418160146-e75481b7eebd
 	github.com/google/go-containerregistry v0.21.0
 	github.com/google/go-github/v66 v66.0.0
-	github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17
+	github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104
 	github.com/konflux-ci/build-service v0.0.0-20240611083846-2dee6cfe6fe4
 	github.com/konflux-ci/e2e-tests v0.0.0-20260521070148-51052ba6ac77
 	github.com/konflux-ci/release-service v0.0.0-20260127184035-c36c56a3c440

--- a/e2e-tests/go.sum
+++ b/e2e-tests/go.sum
@@ -2103,8 +2103,8 @@ github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17 h1:auNv0idITCdlV3fP9i+V6EeT2MbZc/9+05GtKzOk1Ss=
-github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104 h1:OoqVKDkEgLfVGoCuqIzTn5QsRgk9mklgvfXjkLXjK58=
+github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
 github.com/konflux-ci/build-service v0.0.0-20240611083846-2dee6cfe6fe4 h1:oZpPHgpAUI9OyvirRJ+0r0QFuiP8Par/CFZIwlr/6Ps=
 github.com/konflux-ci/build-service v0.0.0-20240611083846-2dee6cfe6fe4/go.mod h1:KgSj+voT2lpIu54zzUkHEXCMdnMGmf+Z9cQh+wTQ6ns=
 github.com/konflux-ci/e2e-tests v0.0.0-20260521070148-51052ba6ac77 h1:KyOsGQkr7ZftjI/GajKjh0H6F3rMGlIM5L0zAh8R334=

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/xanzy/go-gitlab v0.108.0
 	go.uber.org/zap v1.27.1
-	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
 	golang.org/x/oauth2 v0.35.0
 	gotest.tools/v3 v3.5.2
 	k8s.io/api v0.35.0
@@ -30,7 +29,7 @@ require (
 
 // If you update dependencies below you must also update internal/controller/suite_test.go
 require (
-	github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17
+	github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104
 	github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c
 	github.com/konflux-ci/release-service v0.0.0-20240610124538-758a1d48d002
 	github.com/openshift-pipelines/pipelines-as-code v0.43.0
@@ -138,6 +137,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
-github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17 h1:auNv0idITCdlV3fP9i+V6EeT2MbZc/9+05GtKzOk1Ss=
-github.com/konflux-ci/application-api v0.0.0-20260312190025-5154ad273e17/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104 h1:OoqVKDkEgLfVGoCuqIzTn5QsRgk9mklgvfXjkLXjK58=
+github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b h1:NoriO1KRc+7d2/JA07JizqxP0LlA2oJdD5AuQOvEIjE=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c h1:+LtI4WT2KDDpCbVki47dLIu03NH6+Qj0d/MKNu3MZYk=

--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -46,11 +46,11 @@ import (
 )
 
 type BuildPipeline struct {
-	Name                   string                                 `json:"name,omitempty"`
-	Bundle                 string                                 `json:"bundle,omitempty"`
-	AdditionalParams       []string                               `json:"additional-params,omitempty"`
-	PipelineRefGit         compapiv1alpha1.PipelineRefGit         `json:"pipelineref-by-git-resolver,omitempty"`
-	PipelineSpecFromBundle compapiv1alpha1.PipelineSpecFromBundle `json:"pipelinespec-from-bundle,omitempty"`
+	Name                   string                                  `json:"name,omitempty"`
+	Bundle                 string                                  `json:"bundle,omitempty"`
+	AdditionalParams       []string                                `json:"additional-params,omitempty"`
+	PipelineRefGit         *compapiv1alpha1.PipelineRefGit         `json:"pipelineref-by-git-resolver,omitempty"`
+	PipelineSpecFromBundle *compapiv1alpha1.PipelineSpecFromBundle `json:"pipelinespec-from-bundle,omitempty"`
 }
 
 type pipelineConfig struct {

--- a/internal/controller/component_build_controller_v2_test.go
+++ b/internal/controller/component_build_controller_v2_test.go
@@ -426,11 +426,11 @@ var _ = Describe("Component build controller new model", func() {
 						AllVersions: true,
 					},
 				},
-				defaultPipeline: compapiv1alpha1.ComponentBuildPipeline{
-					PullAndPush: compapiv1alpha1.PipelineDefinition{
+				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+					PullAndPush: &compapiv1alpha1.PipelineDefinition{
 						PipelineRefName: "docker-build",
 					},
-					Pull: compapiv1alpha1.PipelineDefinition{
+					Pull: &compapiv1alpha1.PipelineDefinition{
 						PipelineRefName: "docker-build",
 					},
 				},
@@ -454,9 +454,9 @@ var _ = Describe("Component build controller new model", func() {
 						AllVersions: true,
 					},
 				},
-				defaultPipeline: compapiv1alpha1.ComponentBuildPipeline{
-					Pull: compapiv1alpha1.PipelineDefinition{
-						PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+					Pull: &compapiv1alpha1.PipelineDefinition{
+						PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 							Url: "https://github.com/test/pipelines",
 							// Missing PathInRepo and Revision
 						},
@@ -1851,8 +1851,8 @@ spec:
 					{
 						Name:     versionName,
 						Revision: "main",
-						BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-							Pull: compapiv1alpha1.PipelineDefinition{
+						BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+							Pull: &compapiv1alpha1.PipelineDefinition{
 								PipelineRefName: "custom-pull-pipeline",
 							},
 						},
@@ -1984,9 +1984,9 @@ spec:
 					{
 						Name:     versionName,
 						Revision: "main",
-						BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-							Push: compapiv1alpha1.PipelineDefinition{
-								PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+						BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+							Push: &compapiv1alpha1.PipelineDefinition{
+								PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 									Url:        "https://github.com/custom-pipelines/pipelines.git",
 									Revision:   "main",
 									PathInRepo: "pipelines/push.yaml",
@@ -2083,9 +2083,9 @@ spec:
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
-				defaultPipeline: compapiv1alpha1.ComponentBuildPipeline{
-					PullAndPush: compapiv1alpha1.PipelineDefinition{
-						PipelineSpecFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+					PullAndPush: &compapiv1alpha1.PipelineDefinition{
+						PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 							Bundle: "latest",
 							Name:   defaultPipelineName,
 						},

--- a/internal/controller/component_build_controller_v2_validations.go
+++ b/internal/controller/component_build_controller_v2_validations.go
@@ -78,8 +78,8 @@ func validateVersions(component *compapiv1alpha1.Component) (validationErrors []
 
 // hasPipelineRefGit checks if any PipelineRefGit field is set.
 // Returns true if any field is non-empty, false otherwise.
-func hasPipelineRefGit(refGit compapiv1alpha1.PipelineRefGit) bool {
-	return refGit.Url != "" || refGit.PathInRepo != "" || refGit.Revision != ""
+func hasPipelineRefGit(refGit *compapiv1alpha1.PipelineRefGit) bool {
+	return refGit != nil && (refGit.Url != "" || refGit.PathInRepo != "" || refGit.Revision != "")
 }
 
 // hasPipelineRefName checks if PipelineRefName is set.
@@ -90,14 +90,17 @@ func hasPipelineRefName(refName string) bool {
 
 // hasPipelineSpecFromBundle checks if any PipelineSpecFromBundle field is set.
 // Returns true if any field is non-empty, false otherwise.
-func hasPipelineSpecFromBundle(specFromBundle compapiv1alpha1.PipelineSpecFromBundle) bool {
-	return specFromBundle.Bundle != "" || specFromBundle.Name != ""
+func hasPipelineSpecFromBundle(specFromBundle *compapiv1alpha1.PipelineSpecFromBundle) bool {
+	return specFromBundle != nil && (specFromBundle.Bundle != "" || specFromBundle.Name != "")
 }
 
 // validatePipelineRefGitFields validates that all PipelineRefGit fields are set.
 // Returns a slice of validation error messages for any missing required fields,
 // or an empty slice if all fields are present.
-func validatePipelineRefGitFields(refGit compapiv1alpha1.PipelineRefGit, errorPrefix string) (errors []string) {
+func validatePipelineRefGitFields(refGit *compapiv1alpha1.PipelineRefGit, errorPrefix string) (errors []string) {
+	if refGit == nil {
+		return nil
+	}
 	if refGit.Url == "" {
 		errors = append(errors, fmt.Sprintf("%s: pipelineref-by-git-resolver.url is required", errorPrefix))
 	}
@@ -113,7 +116,10 @@ func validatePipelineRefGitFields(refGit compapiv1alpha1.PipelineRefGit, errorPr
 // validatePipelineSpecFromBundleFields validates that all PipelineSpecFromBundle fields are set.
 // Returns a slice of validation error messages for any missing required fields,
 // or an empty slice if all fields are present.
-func validatePipelineSpecFromBundleFields(specFromBundle compapiv1alpha1.PipelineSpecFromBundle, errorPrefix string) (errors []string) {
+func validatePipelineSpecFromBundleFields(specFromBundle *compapiv1alpha1.PipelineSpecFromBundle, errorPrefix string) (errors []string) {
+	if specFromBundle == nil {
+		return nil
+	}
 	if specFromBundle.Bundle == "" {
 		errors = append(errors, fmt.Sprintf("%s: pipelinespec-from-bundle.bundle is required", errorPrefix))
 	}
@@ -125,7 +131,10 @@ func validatePipelineSpecFromBundleFields(specFromBundle compapiv1alpha1.Pipelin
 
 // hasPipelineDefConfig checks if a pipeline definition has any configuration.
 // Returns true if any pipeline configuration is present, false otherwise.
-func hasPipelineDefConfig(pipelineDef compapiv1alpha1.PipelineDefinition) bool {
+func hasPipelineDefConfig(pipelineDef *compapiv1alpha1.PipelineDefinition) bool {
+	if pipelineDef == nil {
+		return false
+	}
 	return hasPipelineRefGit(pipelineDef.PipelineRefGit) ||
 		hasPipelineRefName(pipelineDef.PipelineRefName) ||
 		hasPipelineSpecFromBundle(pipelineDef.PipelineSpecFromBundle)
@@ -133,7 +142,10 @@ func hasPipelineDefConfig(pipelineDef compapiv1alpha1.PipelineDefinition) bool {
 
 // hasPipelineConfig checks if any pipeline configuration is set.
 // Returns true if any pipeline configuration (PullAndPush, Pull, or Push) is present, false otherwise.
-func hasPipelineConfig(pipeline compapiv1alpha1.ComponentBuildPipeline) bool {
+func hasPipelineConfig(pipeline *compapiv1alpha1.ComponentBuildPipeline) bool {
+	if pipeline == nil {
+		return false
+	}
 	hasPullAndPush := hasPipelineDefConfig(pipeline.PullAndPush)
 	hasPull := hasPipelineDefConfig(pipeline.Pull)
 	hasPush := hasPipelineDefConfig(pipeline.Push)
@@ -143,12 +155,18 @@ func hasPipelineConfig(pipeline compapiv1alpha1.ComponentBuildPipeline) bool {
 
 // extractPipelineDef extracts a PipelineDef from a PipelineDefinition.
 // Returns a pointer to the extracted PipelineDef structure.
-func extractPipelineDef(pipelineDef compapiv1alpha1.PipelineDefinition) *PipelineDef {
+// Deep-copies pointer fields to prevent aliasing with the original Component spec.
+func extractPipelineDef(pipelineDef *compapiv1alpha1.PipelineDefinition) *PipelineDef {
+	if pipelineDef == nil {
+		return nil
+	}
 	def := &PipelineDef{}
 
 	// Check if PipelineRefGit is set
 	if hasPipelineRefGit(pipelineDef.PipelineRefGit) {
-		def.PipelineRefGit = &pipelineDef.PipelineRefGit
+		// Deep copy to prevent aliasing
+		rg := *pipelineDef.PipelineRefGit
+		def.PipelineRefGit = &rg
 	}
 
 	// Check if PipelineRefName is set
@@ -158,7 +176,9 @@ func extractPipelineDef(pipelineDef compapiv1alpha1.PipelineDefinition) *Pipelin
 
 	// Check if PipelineSpecFromBundle is set
 	if hasPipelineSpecFromBundle(pipelineDef.PipelineSpecFromBundle) {
-		def.PipelineSpecFromBundle = &pipelineDef.PipelineSpecFromBundle
+		// Deep copy to prevent aliasing
+		sfb := *pipelineDef.PipelineSpecFromBundle
+		def.PipelineSpecFromBundle = &sfb
 	}
 
 	return def
@@ -173,7 +193,10 @@ func extractPipelineDef(pipelineDef compapiv1alpha1.PipelineDefinition) *Pipelin
 // - Validates that all required fields are set for PipelineRefGit and PipelineSpecFromBundle when used
 // Returns a slice of validation error messages describing any issues found,
 // or an empty slice if all validations pass.
-func validatePipelineConfiguration(pipeline compapiv1alpha1.ComponentBuildPipeline, versionName string) (validationErrors []string) {
+func validatePipelineConfiguration(pipeline *compapiv1alpha1.ComponentBuildPipeline, versionName string) (validationErrors []string) {
+	if pipeline == nil {
+		return nil
+	}
 	// Determine the prefix for error messages
 	prefix := "default pipeline"
 	if versionName != "" {
@@ -193,7 +216,7 @@ func validatePipelineConfiguration(pipeline compapiv1alpha1.ComponentBuildPipeli
 	}
 
 	// Validate each pipeline definition section
-	checkPipelineDef := func(pipelineDef compapiv1alpha1.PipelineDefinition, pipelineType string) {
+	checkPipelineDef := func(pipelineDef *compapiv1alpha1.PipelineDefinition, pipelineType string) {
 		if !hasPipelineDefConfig(pipelineDef) {
 			return // Skip validation if no configuration is set
 		}
@@ -285,7 +308,9 @@ func validatePipelines(component *compapiv1alpha1.Component) ([]string, map[stri
 			hasPipeline = true
 		} else if hasDefaultPipeline && hasPipelineDefConfig(defaultPipeline.PullAndPush) {
 			// Fall back to default PullAndPush only if version doesn't have separate Pull/Push
-			if !hasPipelineDefConfig(versionPipeline.Pull) && !hasPipelineDefConfig(versionPipeline.Push) {
+			hasVersionPull := hasVersionPipeline && hasPipelineDefConfig(versionPipeline.Pull)
+			hasVersionPush := hasVersionPipeline && hasPipelineDefConfig(versionPipeline.Push)
+			if !hasVersionPull && !hasVersionPush {
 				pipelineDef := extractPipelineDef(defaultPipeline.PullAndPush)
 				versionPipelineDef.Pull = pipelineDef
 				versionPipelineDef.Push = pipelineDef
@@ -396,7 +421,7 @@ func validatePipelineResolution(versionPipelines map[string]*VersionPipelineDefi
 				for _, configPipeline := range defaultPipelinesConfig.Pipelines {
 					if configPipeline.Name == pipelineName {
 						// Check if pipeline in config has bundle defined (either in PipelineSpecFromBundle or directly)
-						hasBundle := configPipeline.PipelineSpecFromBundle.Bundle != "" || configPipeline.Bundle != ""
+						hasBundle := (configPipeline.PipelineSpecFromBundle != nil && configPipeline.PipelineSpecFromBundle.Bundle != "") || configPipeline.Bundle != ""
 						if !hasBundle {
 							errors = append(errors, fmt.Sprintf("version '%s' %s pipeline references '%s' with bundle 'latest', but pipeline in config has no bundle specified", versionName, pipelineType, pipelineName))
 						}
@@ -417,13 +442,18 @@ func validatePipelineResolution(versionPipelines map[string]*VersionPipelineDefi
 
 // resolvePipelineDefinitions resolves missing pipeline definitions to defaults and "latest" bundle references to actual values
 func resolvePipelineDefinitions(versionPipelines map[string]*VersionPipelineDefinition, versionsToOnboardWithPR []string, defaultPipeline *BuildPipeline, defaultPipelinesConfig *pipelineConfig) {
-	// Helper function to create a default PipelineDef from the default pipeline configuration
+	// Helper function to create a default PipelineDef from the default pipeline configuration.
+	// Deep-copies pointer fields to prevent aliasing with the default pipeline configuration.
 	createDefaultPipelineDef := func() *PipelineDef {
 		def := &PipelineDef{}
-		if defaultPipeline.PipelineRefGit.Url != "" {
-			def.PipelineRefGit = &defaultPipeline.PipelineRefGit
-		} else if defaultPipeline.PipelineSpecFromBundle.Bundle != "" {
-			def.PipelineSpecFromBundle = &defaultPipeline.PipelineSpecFromBundle
+		if defaultPipeline.PipelineRefGit != nil && defaultPipeline.PipelineRefGit.Url != "" {
+			// Deep copy to prevent aliasing
+			rg := *defaultPipeline.PipelineRefGit
+			def.PipelineRefGit = &rg
+		} else if defaultPipeline.PipelineSpecFromBundle != nil && defaultPipeline.PipelineSpecFromBundle.Bundle != "" {
+			// Deep copy to prevent aliasing
+			sfb := *defaultPipeline.PipelineSpecFromBundle
+			def.PipelineSpecFromBundle = &sfb
 		} else {
 			// Fall back to Name & Bundle
 			def.PipelineSpecFromBundle = &compapiv1alpha1.PipelineSpecFromBundle{
@@ -444,7 +474,7 @@ func resolvePipelineDefinitions(versionPipelines map[string]*VersionPipelineDefi
 			matched := false
 
 			// Match by PipelineRefGit
-			if def.PipelineRefGit != nil && configPipeline.PipelineRefGit.Url != "" {
+			if def.PipelineRefGit != nil && configPipeline.PipelineRefGit != nil && configPipeline.PipelineRefGit.Url != "" {
 				if def.PipelineRefGit.Url == configPipeline.PipelineRefGit.Url &&
 					def.PipelineRefGit.PathInRepo == configPipeline.PipelineRefGit.PathInRepo &&
 					def.PipelineRefGit.Revision == configPipeline.PipelineRefGit.Revision {
@@ -457,15 +487,22 @@ func resolvePipelineDefinitions(versionPipelines map[string]*VersionPipelineDefi
 				// Handle "latest" bundle - resolve to actual bundle and set AdditionalParams
 				if def.PipelineSpecFromBundle.Bundle == "latest" && def.PipelineSpecFromBundle.Name == configPipeline.Name {
 					// Check PipelineSpecFromBundle.Bundle first, fall back to Bundle
-					bundle := configPipeline.PipelineSpecFromBundle.Bundle
+					bundle := ""
+					if configPipeline.PipelineSpecFromBundle != nil {
+						bundle = configPipeline.PipelineSpecFromBundle.Bundle
+					}
 					if bundle == "" {
 						bundle = configPipeline.Bundle
 					}
 					def.PipelineSpecFromBundle.Bundle = bundle
 					matched = true
 				} else {
-					// Match by exact bundle and name
-					configBundle := configPipeline.PipelineSpecFromBundle.Bundle
+					// Match by exact bundle and name (to find AdditionalParams for specific bundles)
+					// This doesn't mutate the bundle - just checks if this specific pipeline exists in config
+					configBundle := ""
+					if configPipeline.PipelineSpecFromBundle != nil {
+						configBundle = configPipeline.PipelineSpecFromBundle.Bundle
+					}
 					if configBundle == "" {
 						configBundle = configPipeline.Bundle
 					}

--- a/internal/controller/component_build_controller_v2_validations_unit_test.go
+++ b/internal/controller/component_build_controller_v2_validations_unit_test.go
@@ -184,18 +184,18 @@ func TestValidateVersions(t *testing.T) {
 func TestValidatePipelineConfiguration(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipeline    compapiv1alpha1.ComponentBuildPipeline
+		pipeline    *compapiv1alpha1.ComponentBuildPipeline
 		versionName string
 		wantErrors  int
 		errorSubstr string
 	}{
 		{
 			name: "should validate that PullAndPush cannot be used with Pull or Push",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Pull: compapiv1alpha1.PipelineDefinition{
+				Pull: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -205,11 +205,11 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate that PullAndPush cannot be used with Push",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Push: compapiv1alpha1.PipelineDefinition{
+				Push: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -219,9 +219,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineRefGit required fields - missing pathInRepo",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Pull: compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Pull: &compapiv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 						Url:      "https://github.com/test/pipelines",
 						Revision: "main",
 					},
@@ -233,9 +233,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineRefGit required fields - missing url and revision",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Pull: compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Pull: &compapiv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 						PathInRepo: ".tekton/pipeline.yaml",
 					},
 				},
@@ -246,9 +246,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineSpecFromBundle required fields",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Push: compapiv1alpha1.PipelineDefinition{
-					PipelineSpecFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Push: &compapiv1alpha1.PipelineDefinition{
+					PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 						Bundle: "quay.io/repo/bundle:latest",
 					},
 				},
@@ -259,10 +259,10 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate multiple definition types cannot be used together",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Pull: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Pull: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
-					PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 						Url:        "https://github.com/test/pipelines",
 						PathInRepo: ".tekton/pipeline.yaml",
 						Revision:   "main",
@@ -274,18 +274,24 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 			errorSubstr: "has multiple definitions specified",
 		},
 		{
+			name:        "should accept nil pipeline configuration",
+			pipeline:    nil,
+			versionName: "test-version",
+			wantErrors:  0,
+		},
+		{
 			name:        "should accept empty pipeline configuration",
-			pipeline:    compapiv1alpha1.ComponentBuildPipeline{},
+			pipeline:    &compapiv1alpha1.ComponentBuildPipeline{},
 			versionName: "test-version",
 			wantErrors:  0,
 		},
 		{
 			name: "should accept valid pipeline with PipelineRefName",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Pull: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Pull: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Push: compapiv1alpha1.PipelineDefinition{
+				Push: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -294,9 +300,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should accept valid pipeline with PullAndPush using PipelineRefGit",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compapiv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 						Url:        "https://github.com/test/pipelines",
 						PathInRepo: ".tekton/pipeline.yaml",
 						Revision:   "main",
@@ -590,12 +596,12 @@ func TestGetVersionsForAction(t *testing.T) {
 func TestHasPipelineRefGit(t *testing.T) {
 	tests := []struct {
 		name     string
-		refGit   compapiv1alpha1.PipelineRefGit
+		refGit   *compapiv1alpha1.PipelineRefGit
 		expected bool
 	}{
 		{
 			name: "should return true when all fields set",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
@@ -604,14 +610,19 @@ func TestHasPipelineRefGit(t *testing.T) {
 		},
 		{
 			name: "should return true when only url set",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				Url: "https://github.com/test/repo",
 			},
 			expected: true,
 		},
 		{
 			name:     "should return false when all fields empty",
-			refGit:   compapiv1alpha1.PipelineRefGit{},
+			refGit:   &compapiv1alpha1.PipelineRefGit{},
+			expected: false,
+		},
+		{
+			name:     "should return false when nil",
+			refGit:   nil,
 			expected: false,
 		},
 	}
@@ -653,12 +664,12 @@ func TestHasPipelineRefName(t *testing.T) {
 func TestHasPipelineSpecFromBundle(t *testing.T) {
 	tests := []struct {
 		name           string
-		specFromBundle compapiv1alpha1.PipelineSpecFromBundle
+		specFromBundle *compapiv1alpha1.PipelineSpecFromBundle
 		expected       bool
 	}{
 		{
 			name: "should return true when both fields set",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 				Name:   "docker-build",
 			},
@@ -666,14 +677,19 @@ func TestHasPipelineSpecFromBundle(t *testing.T) {
 		},
 		{
 			name: "should return true when only bundle set",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 			},
 			expected: true,
 		},
 		{
 			name:           "should return false when all fields empty",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{},
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{},
+			expected:       false,
+		},
+		{
+			name:           "should return false when nil",
+			specFromBundle: nil,
 			expected:       false,
 		},
 	}
@@ -689,14 +705,20 @@ func TestHasPipelineSpecFromBundle(t *testing.T) {
 func TestValidatePipelineRefGitFields(t *testing.T) {
 	tests := []struct {
 		name        string
-		refGit      compapiv1alpha1.PipelineRefGit
+		refGit      *compapiv1alpha1.PipelineRefGit
 		errorPrefix string
 		wantErrors  int
 		errorSubstr string
 	}{
 		{
+			name:        "should accept nil input",
+			refGit:      nil,
+			errorPrefix: "test",
+			wantErrors:  0,
+		},
+		{
 			name: "should accept all fields set",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
@@ -706,7 +728,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing url",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
 			},
@@ -716,7 +738,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing pathInRepo",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				Url:      "https://github.com/test/repo",
 				Revision: "main",
 			},
@@ -726,7 +748,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing revision",
-			refGit: compapiv1alpha1.PipelineRefGit{
+			refGit: &compapiv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 			},
@@ -736,7 +758,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name:        "should reject all missing fields",
-			refGit:      compapiv1alpha1.PipelineRefGit{},
+			refGit:      &compapiv1alpha1.PipelineRefGit{},
 			errorPrefix: "version v1",
 			wantErrors:  3,
 		},
@@ -763,14 +785,20 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 	tests := []struct {
 		name           string
-		specFromBundle compapiv1alpha1.PipelineSpecFromBundle
+		specFromBundle *compapiv1alpha1.PipelineSpecFromBundle
 		errorPrefix    string
 		wantErrors     int
 		errorSubstr    string
 	}{
 		{
+			name:           "should accept nil input",
+			specFromBundle: nil,
+			errorPrefix:    "test",
+			wantErrors:     0,
+		},
+		{
 			name: "should accept both fields set",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 				Name:   "docker-build",
 			},
@@ -779,7 +807,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing bundle",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 				Name: "docker-build",
 			},
 			errorPrefix: "test",
@@ -788,7 +816,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing name",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 			},
 			errorPrefix: "test",
@@ -797,7 +825,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name:           "should reject all missing fields",
-			specFromBundle: compapiv1alpha1.PipelineSpecFromBundle{},
+			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{},
 			errorPrefix:    "version v1",
 			wantErrors:     2,
 		},
@@ -824,13 +852,13 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 func TestHasPipelineDefConfig(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipelineDef compapiv1alpha1.PipelineDefinition
+		pipelineDef *compapiv1alpha1.PipelineDefinition
 		expected    bool
 	}{
 		{
 			name: "should return true for PipelineRefGit",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
-				PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+				PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 					Url: "https://github.com/test/repo",
 				},
 			},
@@ -838,15 +866,15 @@ func TestHasPipelineDefConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for PipelineRefName",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
 				PipelineRefName: "docker-build",
 			},
 			expected: true,
 		},
 		{
 			name: "should return true for PipelineSpecFromBundle",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
-				PipelineSpecFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+				PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 					Bundle: "quay.io/repo/bundle:latest",
 				},
 			},
@@ -854,7 +882,12 @@ func TestHasPipelineDefConfig(t *testing.T) {
 		},
 		{
 			name:        "should return false for empty definition",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{},
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{},
+			expected:    false,
+		},
+		{
+			name:        "should return false for nil definition",
+			pipelineDef: nil,
 			expected:    false,
 		},
 	}
@@ -870,13 +903,13 @@ func TestHasPipelineDefConfig(t *testing.T) {
 func TestHasPipelineConfig(t *testing.T) {
 	tests := []struct {
 		name     string
-		pipeline compapiv1alpha1.ComponentBuildPipeline
+		pipeline *compapiv1alpha1.ComponentBuildPipeline
 		expected bool
 	}{
 		{
 			name: "should return true for PullAndPush",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -884,8 +917,8 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for Pull",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Pull: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Pull: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -893,8 +926,8 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for Push",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{
-				Push: compapiv1alpha1.PipelineDefinition{
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
+				Push: &compapiv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -902,7 +935,12 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name:     "should return false for empty pipeline",
-			pipeline: compapiv1alpha1.ComponentBuildPipeline{},
+			pipeline: &compapiv1alpha1.ComponentBuildPipeline{},
+			expected: false,
+		},
+		{
+			name:     "should return false for nil pipeline",
+			pipeline: nil,
 			expected: false,
 		},
 	}
@@ -918,13 +956,13 @@ func TestHasPipelineConfig(t *testing.T) {
 func TestExtractPipelineDef(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipelineDef compapiv1alpha1.PipelineDefinition
+		pipelineDef *compapiv1alpha1.PipelineDefinition
 		validate    func(t *testing.T, result *PipelineDef)
 	}{
 		{
 			name: "should extract PipelineRefGit",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
-				PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+				PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 					Url:        "https://github.com/test/repo",
 					PathInRepo: ".tekton/pipeline.yaml",
 					Revision:   "main",
@@ -939,7 +977,7 @@ func TestExtractPipelineDef(t *testing.T) {
 		},
 		{
 			name: "should extract PipelineRefName",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
 				PipelineRefName: "docker-build",
 			},
 			validate: func(t *testing.T, result *PipelineDef) {
@@ -950,8 +988,8 @@ func TestExtractPipelineDef(t *testing.T) {
 		},
 		{
 			name: "should extract PipelineSpecFromBundle",
-			pipelineDef: compapiv1alpha1.PipelineDefinition{
-				PipelineSpecFromBundle: compapiv1alpha1.PipelineSpecFromBundle{
+			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+				PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
 					Bundle: "quay.io/repo/bundle:latest",
 					Name:   "docker-build",
 				},
@@ -961,6 +999,13 @@ func TestExtractPipelineDef(t *testing.T) {
 				assert.Equal(t, "quay.io/repo/bundle:latest", result.PipelineSpecFromBundle.Bundle)
 				assert.Assert(t, result.PipelineRefGit == nil)
 				assert.Equal(t, "", result.PipelineRefName)
+			},
+		},
+		{
+			name:        "should handle nil pipelineDef",
+			pipelineDef: nil,
+			validate: func(t *testing.T, result *PipelineDef) {
+				assert.Assert(t, result == nil)
 			},
 		},
 	}
@@ -986,8 +1031,8 @@ func TestValidatePipelines(t *testing.T) {
 			name: "should validate and extract pipelines from default and versions",
 			component: &compapiv1alpha1.Component{
 				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-						Pull: compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+						Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
 					},
 					Source: compapiv1alpha1.ComponentSource{
 						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
@@ -1013,8 +1058,8 @@ func TestValidatePipelines(t *testing.T) {
 			name: "should merge default pipeline with version-specific pipeline",
 			component: &compapiv1alpha1.Component{
 				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-						Pull: compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pull"},
+					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+						Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pull"},
 					},
 					Source: compapiv1alpha1.ComponentSource{
 						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
@@ -1022,8 +1067,8 @@ func TestValidatePipelines(t *testing.T) {
 								{
 									Name:     "v1",
 									Revision: "main",
-									BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-										Push: compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
+									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+										Push: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
 									},
 								},
 								{Name: "v2", Revision: "develop"},
@@ -1046,8 +1091,8 @@ func TestValidatePipelines(t *testing.T) {
 			name: "should handle default PullAndPush with version-specific Pull, Push, and PullAndPush",
 			component: &compapiv1alpha1.Component{
 				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-						PullAndPush: compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pullandpush"},
+					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pullandpush"},
 					},
 					Source: compapiv1alpha1.ComponentSource{
 						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
@@ -1055,22 +1100,22 @@ func TestValidatePipelines(t *testing.T) {
 								{
 									Name:     "v1",
 									Revision: "main",
-									BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-										Pull: compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pull"},
+									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+										Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pull"},
 									},
 								},
 								{
 									Name:     "v2",
 									Revision: "develop",
-									BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-										Push: compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
+									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+										Push: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
 									},
 								},
 								{
 									Name:     "v3",
 									Revision: "release",
-									BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-										PullAndPush: compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pullandpush"},
+									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+										PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pullandpush"},
 									},
 								},
 								{Name: "v4", Revision: "staging"},
@@ -1101,9 +1146,9 @@ func TestValidatePipelines(t *testing.T) {
 			name: "should detect validation errors in default pipeline",
 			component: &compapiv1alpha1.Component{
 				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-						PullAndPush: compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
-						Pull:        compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+						Pull:        &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
 					},
 					Source: compapiv1alpha1.ComponentSource{
 						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
@@ -1124,9 +1169,9 @@ func TestValidatePipelines(t *testing.T) {
 								{
 									Name:     "v1",
 									Revision: "main",
-									BuildPipeline: compapiv1alpha1.ComponentBuildPipeline{
-										Pull: compapiv1alpha1.PipelineDefinition{
-											PipelineRefGit: compapiv1alpha1.PipelineRefGit{
+									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+										Pull: &compapiv1alpha1.PipelineDefinition{
+											PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
 												Url: "https://github.com/test/repo",
 												// Missing required fields
 											},
@@ -1134,6 +1179,30 @@ func TestValidatePipelines(t *testing.T) {
 			},
 			wantErrors:  2, // missing pathInRepo and revision
 			errorSubstr: "is required",
+		},
+		{
+			name: "should propagate default PullAndPush to version with nil BuildPipeline",
+			component: &compapiv1alpha1.Component{
+				Spec: compapiv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pipeline"},
+					},
+					Source: compapiv1alpha1.ComponentSource{
+						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
+							Versions: []compapiv1alpha1.ComponentVersion{
+								// Explicitly set to nil to test this critical scenario
+								{Name: "v1", Revision: "main", BuildPipeline: nil},
+							}}}},
+			},
+			wantErrors:        0,
+			wantPipelineCount: 1,
+			wantPipelines: map[string]*VersionPipelineDefinition{
+				"v1": {
+					// Both Pull and Push should inherit from default PullAndPush
+					Pull: &PipelineDef{PipelineRefName: "default-pipeline"},
+					Push: &PipelineDef{PipelineRefName: "default-pipeline"},
+				},
+			},
 		},
 	}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	applicationApiDepVersion := "v0.0.0-20260312190025-5154ad273e17"
+	applicationApiDepVersion := "v0.0.0-20260529131129-a9594acdc104"
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "hack", "routecrd", "route.yaml"),

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -97,7 +97,7 @@ type componentConfig struct {
 	finalizers         []string
 	actions            compapiv1alpha1.ComponentActions
 	repositorySettings compapiv1alpha1.RepositorySettings
-	defaultPipeline    compapiv1alpha1.ComponentBuildPipeline
+	defaultPipeline    *compapiv1alpha1.ComponentBuildPipeline
 	skipOffboardingPr  bool
 }
 


### PR DESCRIPTION
BuildPipeline and DefaultBuildPipeline are now pointers to ComponentBuildPipeline PullAndPush and Pull and Push are now pointers to PipelineDefinition PipelineRefGit is pointer to PipelineRefGit
PipelineSpecFromBundle is pointer to PipelineSpecFromBundle

all this prevents components having build pipelines structures expanded with empty values like

```
  default-build-pipeline:
    pull:
      pipelineref-by-git-resolver:
        pathInRepo: ''
        revision: ''
        url: ''
      pipelinespec-from-bundle:
        bundle: ''
        name: ''
    pull-and-push:
      pipelineref-by-git-resolver:
        pathInRepo: ''
        revision: ''
        url: ''
      pipelinespec-from-bundle:
        bundle: ''
        name: ''
    push:
      pipelineref-by-git-resolver:
        pathInRepo: ''
        revision: ''
        url: ''
      pipelinespec-from-bundle:
        bundle: ''
        name: ''
```

and only explicitly set values will be present

```
  default-build-pipeline:
    pull-and-push:
      pipelinespec-from-bundle:
        bundle: latest
        name: docker-build-oci-ta
```

removing from role events with apiGroup events.k8s.io, because we have there already events without apiGroup (since it is core object)

[STONEBLD-4790](https://redhat.atlassian.net/browse/STONEBLD-4790)

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable

[STONEBLD-4790]: https://redhat.atlassian.net/browse/STONEBLD-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ