### PR TITLE
feat: add dual-group Component support and rename appstudio strings to konflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Monitors Component CRs and manages the entire build pipeline lifecycle:
 
 ### PaC PipelineRun Pruner Controller
 
-Removes PipelineRun CRs created for Components that are being deleted, ensuring proper cleanup based on the `appstudio.openshift.io/component` label.
+Removes PipelineRun CRs created for Components that are being deleted, ensuring proper cleanup based on the `build.konflux-ci.dev/component` label (`appstudio.openshift.io/component` in case of old Component API Group used).
 
 ### Component Dependency Update Controller (Nudging)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,9 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
@@ -61,7 +59,8 @@ import (
 	l "github.com/konflux-ci/build-service/pkg/logs"
 	pacwebhook "github.com/konflux-ci/build-service/pkg/pacwebhook"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	imagerepositoryapi "github.com/konflux-ci/image-controller/api/v1alpha1"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -78,7 +77,8 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(compapiv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(compapiv1alpha1.AddToScheme(scheme)) // TODO remove after only new model is used and old model is gone
+	utilruntime.Must(compv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -227,11 +227,23 @@ func main() {
 	if err = (&controllers.ComponentBuildReconciler{
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
-		EventRecorder:      mgr.GetEventRecorder("ComponentOnboarding"),
+		EventRecorder:      mgr.GetEventRecorder("ComponentBuildReconciler"),
 		PaCWebhookMapping:  pacWebhookMapping,
 		CredentialProvider: k8s.NewGitCredentialProvider(mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ComponentOnboarding")
+		setupLog.Error(err, "unable to create controller", "controller", "ComponentBuildReconciler")
+		os.Exit(1)
+	}
+
+	// TODO remove after only new model is used and old model is gone
+	if err = (&controllers.ComponentBuildReconcilerOldModel{
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		EventRecorder:      mgr.GetEventRecorder("ComponentBuildReconcilerOldModel"),
+		PaCWebhookMapping:  pacWebhookMapping,
+		CredentialProvider: k8s.NewGitCredentialProvider(mgr.GetClient()),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create old controller", "controller", "ComponentBuildReconcilerOldModel")
 		os.Exit(1)
 	}
 
@@ -241,6 +253,16 @@ func main() {
 		EventRecorder: mgr.GetEventRecorder("PaCPipelineRunPruner"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PaCPipelineRunPruner")
+		os.Exit(1)
+	}
+
+	// TODO remove after only new model is used and old model is gone
+	if err = (&controllers.PaCPipelineRunPrunerReconcilerOldModel{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorder("PaCPipelineRunPrunerOld"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create old controller", "controller", "PaCPipelineRunPrunerOld")
 		os.Exit(1)
 	}
 
@@ -299,25 +321,14 @@ func getCacheExcludedObjectsTypes() []client.Object {
 		&corev1.ConfigMap{},
 		&corev1.Service{},
 		&rbacv1.ClusterRole{},
+		&tektonapi.PipelineRun{},
 	}
 }
 
 func getCacheOptions() cache.Options {
 	var syncPeriod time.Duration
-	componentPipelineRunRequirement, err := labels.NewRequirement(controllers.ComponentNameLabelName, selection.Exists, []string{})
-	if err != nil {
-		// With valid arguments for the requirement above, the error is always nil.
-		panic(err)
-	}
-	appStudioComponentPipelineRunSelector := labels.NewSelector().Add(*componentPipelineRunRequirement)
 
 	return cache.Options{
-		ByObject: map[client.Object]cache.ByObject{
-			&tektonapi.PipelineRun{}: {
-				Label: appStudioComponentPipelineRunSelector,
-			},
-			&releaseapi.ReleasePlanAdmission{}: {},
-		},
 		// disable periodic all objects requeue by passing 0 time
 		SyncPeriod: &syncPeriod,
 	}
@@ -335,6 +346,9 @@ func ensureRequiredAPIGroupsAndResourcesExist(restConfig *rest.Config) {
 		},
 		"pipelinesascode.tekton.dev": {
 			"repositories",
+		},
+		"konflux-ci.dev": {
+			"components",
 		},
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -28,17 +29,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
   - events.k8s.io
   resources:
   - events
@@ -55,7 +45,6 @@ rules:
   - appstudio.redhat.com
   resources:
   - components
-  - components/status
   verbs:
   - get
   - list
@@ -65,6 +54,7 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - components/status
   - imagerepositories
   - imagerepositories/status
   - nudgeconfigs
@@ -72,6 +62,17 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - components
+  - components/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - pipelinesascode.tekton.dev

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 
 // If you update dependencies below you must also update internal/controller/suite_test.go
 require (
-	github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104
+	github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6
 	github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c
 	github.com/konflux-ci/release-service v0.0.0-20240610124538-758a1d48d002
 	github.com/openshift-pipelines/pipelines-as-code v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
-github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104 h1:OoqVKDkEgLfVGoCuqIzTn5QsRgk9mklgvfXjkLXjK58=
-github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6 h1:zKKze/yi6mNUlubVW0LRRorZh7cZ/yQ1cSMALqHFQgk=
+github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b h1:NoriO1KRc+7d2/JA07JizqxP0LlA2oJdD5AuQOvEIjE=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127115143-b5207b335f8b/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/konflux-ci/image-controller v0.0.0-20250424143112-69ec692d353c h1:+LtI4WT2KDDpCbVki47dLIu03NH6+Qj0d/MKNu3MZYk=

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2023-2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/controller/component_build_controller.go
+++ b/internal/controller/component_build_controller.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO remove whole file after only new model is used and old model is gone
+
 package controllers
 
 import (
@@ -45,36 +47,24 @@ import (
 )
 
 const (
+	PaCProvisionFinalizerOldModel = "pac.component.appstudio.openshift.io/finalizer"
+
 	BuildRequestAnnotationName                  = "build.appstudio.openshift.io/request"
 	BuildRequestTriggerPaCBuildAnnotationValue  = "trigger-pac-build"
 	BuildRequestConfigurePaCAnnotationValue     = "configure-pac"
 	BuildRequestConfigurePaCNoMrAnnotationValue = "configure-pac-no-mr"
 	BuildRequestUnconfigurePaCAnnotationValue   = "unconfigure-pac"
 
-	BuildStatusAnnotationName = "build.appstudio.openshift.io/status"
+	BuildStatusAnnotationName             = "build.appstudio.openshift.io/status"
+	defaultBuildPipelineAnnotation        = "build.appstudio.openshift.io/pipeline"
+	gitCommitShaAnnotationNameOldModel    = "build.appstudio.redhat.com/commit_sha"
+	gitRepoAtShaAnnotationNameOldModel    = "build.appstudio.openshift.io/repo"
+	gitPRAnnotationNameOldModel           = "build.appstudio.redhat.com/pull_request_number"
+	gitTargetBranchAnnotationNameOldModel = "build.appstudio.redhat.com/target_branch"
 
-	PaCProvisionFinalizer            = "pac.component.appstudio.openshift.io/finalizer"
 	ImageRegistrySecretLinkFinalizer = "image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer"
-
-	ApplicationNameLabelName  = "appstudio.openshift.io/application"
-	ComponentNameLabelName    = "appstudio.openshift.io/component"
-	PartOfLabelName           = "app.kubernetes.io/part-of"
-	PartOfAppStudioLabelValue = "appstudio"
-
-	gitCommitShaAnnotationName = "build.appstudio.redhat.com/commit_sha"
-	gitRepoAtShaAnnotationName = "build.appstudio.openshift.io/repo"
-	ContextAnnotationName      = "appstudio.openshift.io/context"
-	VersionAnnotationName      = "appstudio.openshift.io/version"
-
-	defaultBuildPipelineAnnotation     = "build.appstudio.openshift.io/pipeline"
-	buildPipelineConfigMapResourceName = "build-pipeline-config"
-	buildPipelineConfigName            = "config.yaml"
-
-	waitForContainerImageMessage = "waiting for spec.containerImage to be set by ImageRepository with annotation image-controller.appstudio.redhat.com/update-component-image"
-
-	ComponentModelVersionAnnotation = "build.appstudio.openshift.io/component_model_version"
-	DefaultComponentModelVersion    = "v1"
-	NewComponentModelVersion        = "v2"
+	ApplicationNameLabelName         = "appstudio.openshift.io/application"
+	ComponentNameLabelNameOldModel   = "appstudio.openshift.io/component"
 )
 
 type BuildStatus struct {
@@ -101,10 +91,10 @@ type PaCBuildStatus struct {
 	ErrorInfo
 }
 
-// ComponentBuildReconciler watches AppStudio Component objects in order to
+// ComponentBuildReconcilerOldModel watches AppStudio Component objects in order to
 // provision Pipelines as Code configuration for the Component or
 // submit initial builds and dependent resources if PaC is not configured.
-type ComponentBuildReconciler struct {
+type ComponentBuildReconcilerOldModel struct {
 	Client             client.Client
 	Scheme             *runtime.Scheme
 	EventRecorder      events.EventRecorder
@@ -113,24 +103,14 @@ type ComponentBuildReconciler struct {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ComponentBuildReconcilerOldModel) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&compapiv1alpha1.Component{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
 				return true
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				component, ok := e.ObjectNew.(*compapiv1alpha1.Component)
-				if !ok {
-					return false
-				}
-
-				// TODO remove newModel handling after only new model is used
-				// For new model: only reconcile when spec changes (Generation increments), not on status-only updates
-				// For old model: always reconcile on update (old model uses annotations which don't increment Generation)
-				if isComponentUsingNewModel(component) {
-					return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
-				}
+				// always reconcile on update (old model uses annotations which don't increment Generation)
 				return true
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
@@ -158,13 +138,6 @@ func updateMetricsTimes(componentIdForMetrics string, requestedAction string, re
 	}
 }
 
-// isComponentUsingNewModel checks if the component is configured to use the new model (v2).
-// Returns true if the component has the new model annotation set to v2 or if the default model is v2.
-func isComponentUsingNewModel(component *compapiv1alpha1.Component) bool {
-	requestedModel, requestedModelAnnotationExists := component.Annotations[ComponentModelVersionAnnotation]
-	return (requestedModelAnnotationExists && requestedModel == NewComponentModelVersion) || DefaultComponentModelVersion == NewComponentModelVersion
-}
-
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
@@ -180,11 +153,11 @@ func isComponentUsingNewModel(component *compapiv1alpha1.Component) bool {
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 
-func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ComponentBuildReconcilerOldModel) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 	ctx = ctrllog.IntoContext(ctx, log)
 	reconcileStartTime := time.Now()
@@ -203,10 +176,6 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if isComponentUsingNewModel(&component) {
-		return r.ReconcileNewModel(ctx, req)
-	}
-
 	log = ctrllog.FromContext(ctx).WithName("ComponentOnboarding")
 
 	// Don't recreate build pipeline Service Account upon component deletion.
@@ -218,7 +187,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if getContainerImageRepositoryForComponent(&component) == "" {
+	if getContainerImageRepositoryForComponentOldModel(&component) == "" {
 		// Container image must be set. It's not possible to proceed without it.
 		log.Info("Waiting for ContainerImage to be set")
 
@@ -276,12 +245,12 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, err
 		}
 
-		if controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizer) {
+		if controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizerOldModel) {
 			// In order to not to block the deletion of the Component,
 			// delete finalizer unconditionally and then try to do clean up ignoring errors.
 
 			// Delete Pipelines as Code provision finalizer
-			controllerutil.RemoveFinalizer(&component, PaCProvisionFinalizer)
+			controllerutil.RemoveFinalizer(&component, PaCProvisionFinalizerOldModel)
 			if err := r.Client.Update(ctx, &component); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -436,8 +405,8 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Add finalizer to clean up Pipelines as Code configuration on component deletion
 		if component.ObjectMeta.DeletionTimestamp.IsZero() && pacBuildStatus.ErrId == 0 {
-			if !controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizer) {
-				controllerutil.AddFinalizer(&component, PaCProvisionFinalizer)
+			if !controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizerOldModel) {
+				controllerutil.AddFinalizer(&component, PaCProvisionFinalizerOldModel)
 				log.Info("adding PaC finalizer")
 			}
 		}
@@ -457,8 +426,8 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		updateMetricsTimes(componentIdForMetrics, requestedAction, reconcileStartTime)
 
 		// Remove Pipelines as Code configuration finalizer
-		if controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizer) {
-			controllerutil.RemoveFinalizer(&component, PaCProvisionFinalizer)
+		if controllerutil.ContainsFinalizer(&component, PaCProvisionFinalizerOldModel) {
+			controllerutil.RemoveFinalizer(&component, PaCProvisionFinalizerOldModel)
 			if err := r.Client.Update(ctx, &component); err != nil {
 				log.Error(err, "failed to remove PaC finalizer to the Component", l.Action, l.ActionUpdate)
 				return ctrl.Result{}, err
@@ -529,8 +498,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 // WaitForCacheUpdateOldModel waits for cache update
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) WaitForCacheUpdateOldModel(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component) {
+func (r *ComponentBuildReconcilerOldModel) WaitForCacheUpdateOldModel(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component) {
 	log := ctrllog.FromContext(ctx)
 
 	// Here we do some trick.

--- a/internal/controller/component_build_controller_oldmodel_unit_test.go
+++ b/internal/controller/component_build_controller_oldmodel_unit_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO remove whole file after only new model is used
+// TODO remove whole file after only new model is used and old model is gone
 package controllers
 
 import (
@@ -36,7 +36,6 @@ import (
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-// TODO remove after only new model is used
 func TestReadBuildStatusOldModel(t *testing.T) {
 	tests := []struct {
 		name                       string
@@ -88,7 +87,6 @@ func TestReadBuildStatusOldModel(t *testing.T) {
 	}
 }
 
-// TODO remove after only new model is used
 func TestWriteBuildStatusOldModel(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -175,7 +173,6 @@ func TestWriteBuildStatusOldModel(t *testing.T) {
 	}
 }
 
-// TODO remove after only new model is used
 func TestGeneratePaCPipelineRunForComponentOldModel(t *testing.T) {
 	component := &compapiv1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -240,11 +237,11 @@ func TestGeneratePaCPipelineRunForComponentOldModel(t *testing.T) {
 	if pipelineRun.Labels[ApplicationNameLabelName] != "my-application" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", ApplicationNameLabelName)
 	}
-	if pipelineRun.Labels[ComponentNameLabelName] != "my-component" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", ComponentNameLabelName)
+	if pipelineRun.Labels[ComponentNameLabelNameOldModel] != "my-component" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", ComponentNameLabelNameOldModel)
 	}
-	if pipelineRun.Labels["pipelines.appstudio.openshift.io/type"] != "build" {
-		t.Error("generatePaCPipelineRunForComponent(): wrong pipelines.appstudio.openshift.io/type label value")
+	if pipelineRun.Labels[PipelineRunTypeLabelNameOldModel] != "build" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", PipelineRunTypeLabelNameOldModel)
 	}
 
 	onCel := `event == "pull_request" && target_branch == "custom-branch" && ( "./base_context/***".pathChanged() || ".tekton/my-component-pull-request.yaml".pathChanged() )`
@@ -257,17 +254,17 @@ func TestGeneratePaCPipelineRunForComponentOldModel(t *testing.T) {
 	if pipelineRun.Annotations["pipelinesascode.tekton.dev/cancel-in-progress"] != "true" {
 		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/cancel-in-progress annotation value")
 	}
-	if pipelineRun.Annotations["build.appstudio.redhat.com/target_branch"] != "{{target_branch}}" {
-		t.Error("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/target_branch annotation value")
+	if pipelineRun.Annotations[gitTargetBranchAnnotationNameOldModel] != "{{target_branch}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitTargetBranchAnnotationNameOldModel)
 	}
-	if pipelineRun.Annotations[gitCommitShaAnnotationName] != "{{revision}}" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitCommitShaAnnotationName)
+	if pipelineRun.Annotations[gitCommitShaAnnotationNameOldModel] != "{{revision}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitCommitShaAnnotationNameOldModel)
 	}
-	if pipelineRun.Annotations[gitRepoAtShaAnnotationName] != "https://githost.com/user/repo?rev={{revision}}" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitRepoAtShaAnnotationName)
+	if pipelineRun.Annotations[gitRepoAtShaAnnotationNameOldModel] != "https://githost.com/user/repo?rev={{revision}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitRepoAtShaAnnotationNameOldModel)
 	}
-	if pipelineRun.Annotations["build.appstudio.redhat.com/pull_request_number"] != "{{pull_request_number}}" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/pull_request_number annotation value")
+	if pipelineRun.Annotations[gitPRAnnotationNameOldModel] != "{{pull_request_number}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitPRAnnotationNameOldModel)
 	}
 
 	if len(pipelineRun.Spec.Params) != 8 {
@@ -336,7 +333,6 @@ func TestGeneratePaCPipelineRunForComponentOldModel(t *testing.T) {
 	}
 }
 
-// TODO remove after only new model is used
 func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSetOldModel(t *testing.T) {
 	_, err := generatePaCPipelineRunForComponentOldModel(nil, nil, nil, "", nil, true)
 	if err == nil {
@@ -344,7 +340,6 @@ func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSetOldM
 	}
 }
 
-// TODO remove after only new model is used
 func TestGenerateCelExpressionForPipelineOldModel(t *testing.T) {
 	componentKey := types.NamespacedName{Namespace: "test-ns", Name: "component-name"}
 	ResetTestGitProviderClient()
@@ -470,7 +465,6 @@ func TestGenerateCelExpressionForPipelineOldModel(t *testing.T) {
 	ResetTestGitProviderClient()
 }
 
-// TODO remove after only new model is used
 func TestGeneratePACRepositoryOldModel(t *testing.T) {
 	getComponent := func(repoUrl string, annotations map[string]string) compapiv1alpha1.Component {
 		return compapiv1alpha1.Component{
@@ -530,7 +524,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.com/user/test-component-repository", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://github.com/user/test-component-repository", nil)),
 				},
 				URL:  "",
 				Type: "github",
@@ -565,7 +559,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://github.self-hosted.com",
 				Type: "github",
@@ -588,7 +582,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://github.self-hosted-proxy.com",
 				Type: "github",
@@ -607,7 +601,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://gitlab.com/user/test-component-repository/", nil)),
 				},
 				URL:  "",
 				Type: "gitlab",
@@ -628,7 +622,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://gitlab.com/user/test-component-repository", nil)),
 				},
 				Type: "gitlab",
 			},
@@ -649,7 +643,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://gitlab.self-hosted.com",
 				Type: "gitlab",
@@ -672,7 +666,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://gitlab.self-hosted-proxy.com",
 				Type: "gitlab",
@@ -695,7 +689,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://gitlab.self-hosted-proxy.com",
 				Type: "gitlab",
@@ -717,7 +711,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://forgejo.example.com/user/test-component-repository/", nil), false),
+					Key:  getWebhookSecretKeyForComponentOldModel(getComponent("https://forgejo.example.com/user/test-component-repository/", nil)),
 				},
 				URL:  "https://forgejo.example.com",
 				Type: "forgejo",
@@ -739,7 +733,7 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 				},
 				Data: tt.pacConfig,
 			}
-			pacRepo, err := generatePACRepository(component, secret, nil, nil, false)
+			pacRepo, err := generatePACRepositoryOldModel(component, secret)
 
 			if err != nil {
 				t.Errorf("Failed to generate PaC repository object. Cause: %v", err)
@@ -764,7 +758,6 @@ func TestGeneratePACRepositoryOldModel(t *testing.T) {
 	}
 }
 
-// TODO remove after only new model is used
 func TestPaCRepoAddParamWorkspaceOldModel(t *testing.T) {
 	const workspaceName = "someone-tenant"
 
@@ -796,20 +789,20 @@ func TestPaCRepoAddParamWorkspaceOldModel(t *testing.T) {
 	}
 
 	t.Run("add to Spec.Params", func(t *testing.T) {
-		repository, _ := generatePACRepository(*component, secret, nil, nil, false)
-		pacRepoAddParamWorkspaceName(repository, workspaceName)
+		repository, _ := generatePACRepositoryOldModel(*component, secret)
+		pacRepoAddParamWorkspaceNameOldModel(repository, workspaceName)
 
 		params := convertCustomParamsToMap(repository)
-		param, ok := params[pacCustomParamAppstudioWorkspace]
+		param, ok := params[pacCustomParamKonfluxWorkspaceOldModel]
 		assert.Assert(t, ok)
 		assert.Equal(t, workspaceName, param.Value)
 	})
 
 	t.Run("override existing workspace parameter, unset other fields btw", func(t *testing.T) {
-		repository, _ := generatePACRepository(*component, secret, nil, nil, false)
+		repository, _ := generatePACRepositoryOldModel(*component, secret)
 		params := []pacv1alpha1.Params{
 			{
-				Name:      pacCustomParamAppstudioWorkspace,
+				Name:      pacCustomParamKonfluxWorkspaceOldModel,
 				Value:     "another_workspace",
 				Filter:    "pac.event_type == \"pull_request\"",
 				SecretRef: &pacv1alpha1.Secret{},
@@ -817,10 +810,10 @@ func TestPaCRepoAddParamWorkspaceOldModel(t *testing.T) {
 		}
 		repository.Spec.Params = &params
 
-		pacRepoAddParamWorkspaceName(repository, workspaceName)
+		pacRepoAddParamWorkspaceNameOldModel(repository, workspaceName)
 
 		existingParams := convertCustomParamsToMap(repository)
-		param, ok := existingParams[pacCustomParamAppstudioWorkspace]
+		param, ok := existingParams[pacCustomParamKonfluxWorkspaceOldModel]
 		assert.Assert(t, ok)
 		assert.Equal(t, workspaceName, param.Value)
 
@@ -829,7 +822,6 @@ func TestPaCRepoAddParamWorkspaceOldModel(t *testing.T) {
 	})
 }
 
-// TODO remove after only new model is used
 func TestGetGitProviderOldModel(t *testing.T) {
 	getComponent := func(repoUrl, annotationValue string) compapiv1alpha1.Component {
 		componentMeta := metav1.ObjectMeta{
@@ -1004,7 +996,7 @@ func TestGetGitProviderOldModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			component := getComponent(tt.componentRepoUrl, tt.componentGitProviderAnnotation)
-			got, err := getGitProvider(component, false)
+			got, err := getGitProviderOldModel(component)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("Detecting git provider for component with '%s' url and '%s' annotation value should fail", tt.componentRepoUrl, tt.componentGitProviderAnnotation)
@@ -1020,7 +1012,7 @@ func TestGetGitProviderOldModel(t *testing.T) {
 	t.Run("should return error if git source is nil", func(t *testing.T) {
 		component := getComponent("", "")
 		component.Spec.Source.GitSource = nil
-		_, err := getGitProvider(component, false)
+		_, err := getGitProviderOldModel(component)
 		if err == nil {
 			t.Error("Expected error for nil source URL")
 		}

--- a/internal/controller/component_build_controller_pac.go
+++ b/internal/controller/component_build_controller_pac.go
@@ -28,7 +28,8 @@ import (
 	"strconv"
 	"strings"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,8 +67,12 @@ const (
 
 	pacMergeRequestSourceBranchPrefix = "konflux-"
 
-	appstudioWorkspaceNameLabel      = "appstudio.redhat.com/workspace_name"
-	pacCustomParamAppstudioWorkspace = "appstudio_workspace"
+	konfluxWorkspaceNameLabel = "konflux-ci.dev/workspace_name"
+	// TODO remove after only new model is used and old model is gone
+	appstudioWorkspaceNameLabelOldModel = "appstudio.redhat.com/workspace_name"
+	pacCustomParamKonfluxWorkspace      = "konflux_workspace"
+	// TODO remove after only new model is used and old model is gone
+	pacCustomParamKonfluxWorkspaceOldModel = "appstudio_workspace"
 
 	mergeRequestDescription = `
 # Pipelines as Code configuration proposal
@@ -93,19 +98,17 @@ Please follow the block sequence indentation style introduced by the proprosed P
 var GetHttpClientFunction = getHttpClient
 
 // GetPacSecrets gets and validates webhookSecretString and pacSecret.
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component *compapiv1alpha1.Component) (string, *corev1.Secret, error) {
+func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component *compv1alpha1.Component) (string, *corev1.Secret, error) {
 	log := ctrllog.FromContext(ctx).WithName("GetWebhookAndPacSecret")
-	newModel := true
 
 	log.Info("Getting webhook and pacSecret")
 
-	gitProvider, err := getGitProvider(*component, newModel)
+	gitProvider, err := getGitProvider(*component)
 	if err != nil {
 		// Do not reconcile, because configuration must be fixed before it is possible to proceed.
 		return "", nil, err
 	}
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 
 	if strings.HasPrefix(repoUrl, "http:") {
 		return "", nil, boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
@@ -119,7 +122,7 @@ func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component 
 		}
 	}
 
-	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider, newModel)
+	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider)
 	if err != nil {
 		return "", nil, err
 	}
@@ -135,7 +138,7 @@ func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component 
 	if !common.IsPaCApplicationConfigured(gitProvider, pacSecret.Data) {
 		// Generate webhook secret for the component git repository if not yet generated
 		// and stores it in the corresponding k8s secret.
-		webhookSecretString, err = r.ensureWebhookSecret(ctx, component, newModel)
+		webhookSecretString, err = r.ensureWebhookSecret(ctx, component)
 		if err != nil {
 			return "", nil, err
 		}
@@ -147,19 +150,17 @@ func (r *ComponentBuildReconciler) GetPacSecrets(ctx context.Context, component 
 // ProvisionPaCForComponentOldModel does Pipelines as Code provision for the given component.
 // Mainly, it creates PaC configuration merge request into the component source repositotiry.
 // If GitHub PaC application is not configured, creates a webhook for PaC.
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) ProvisionPaCForComponentOldModel(ctx context.Context, component *compapiv1alpha1.Component) (string, error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) ProvisionPaCForComponentOldModel(ctx context.Context, component *compapiv1alpha1.Component) (string, error) {
 	log := ctrllog.FromContext(ctx).WithName("PaC-setup")
-	newModel := false
-
 	log.Info("Starting Pipelines as Code provision for the Component")
 
-	gitProvider, err := getGitProvider(*component, newModel)
+	gitProvider, err := getGitProviderOldModel(*component)
 	if err != nil {
 		// Do not reconcile, because configuration must be fixed before it is possible to proceed.
 		return "", err
 	}
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrlOldModel(*component)
 
 	if strings.HasPrefix(repoUrl, "http:") {
 		return "", boerrors.NewBuildOpError(boerrors.EHttpUsedForRepository,
@@ -173,7 +174,7 @@ func (r *ComponentBuildReconciler) ProvisionPaCForComponentOldModel(ctx context.
 		}
 	}
 
-	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider, newModel)
+	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider)
 	if err != nil {
 		return "", err
 	}
@@ -189,7 +190,7 @@ func (r *ComponentBuildReconciler) ProvisionPaCForComponentOldModel(ctx context.
 	if !common.IsPaCApplicationConfigured(gitProvider, pacSecret.Data) {
 		// Generate webhook secret for the component git repository if not yet generated
 		// and stores it in the corresponding k8s secret.
-		webhookSecretString, err = r.ensureWebhookSecret(ctx, component, newModel)
+		webhookSecretString, err = r.ensureWebhookSecret(ctx, component)
 		if err != nil {
 			return "", err
 		}
@@ -202,7 +203,7 @@ func (r *ComponentBuildReconciler) ProvisionPaCForComponentOldModel(ctx context.
 	}
 
 	var pacRepositoryName string
-	if pacRepositoryName, err = r.ensurePaCRepository(ctx, component, pacSecret, nil, nil, newModel); err != nil {
+	if pacRepositoryName, err = r.ensurePaCRepository(ctx, component, pacSecret); err != nil {
 		return "", err
 	}
 	log.Info("Using PaC repository", "PaCRepositoryName", pacRepositoryName, l.Action, l.ActionView)
@@ -283,16 +284,14 @@ func checkMandatoryFieldsNotEmpty(config map[string][]byte, mandatoryFields []st
 // TriggerPaCBuildPreparation prepares for triggering builds by ensuring incoming secret and updating incomings for all versions.
 // This should be called once before triggering multiple builds to avoid multiple reconciles.
 // Returns reconcileRequired flag, incomingSecret, repository, and error.
-// TODO remove newModel handling after only new model is used
 func (r *ComponentBuildReconciler) TriggerPaCBuildPreparation(
 	ctx context.Context,
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	targetBranches []string,
 ) (reconcileRequired bool, incomingSecret *corev1.Secret, repository *pacv1alpha1.Repository, err error) {
 	log := ctrllog.FromContext(ctx).WithName("TriggerPaCBuildPrep")
-	newModel := true
 
-	repository, err = r.findPaCRepositoryForComponent(ctx, component, newModel)
+	repository, err = r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return false, nil, nil, err
 	}
@@ -301,7 +300,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildPreparation(
 		return false, nil, nil, fmt.Errorf("PaC repository not found for component %s", component.Name)
 	}
 
-	incomingSecret, reconcileRequired, err = r.ensureIncomingSecret(ctx, component, newModel)
+	incomingSecret, reconcileRequired, err = r.ensureIncomingSecret(ctx, component)
 	if err != nil {
 		return false, nil, nil, err
 	}
@@ -328,10 +327,9 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildPreparation(
 
 // TriggerPaCBuild triggers a PaC build using pre-prepared resources from TriggerPaCBuildPrep.
 // This method doesn't perform reconciliation and should be called after TriggerPaCBuildPrep.
-// TODO remove newModel handling after only new model is used
 func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	ctx context.Context,
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	sanitizedVersionName string,
 	targetBranch string,
 	pacInternalUrl string,
@@ -339,9 +337,8 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	repository *pacv1alpha1.Repository,
 ) error {
 	log := ctrllog.FromContext(ctx).WithName("TriggerPaCBuild")
-	newModel := true
 
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 	secretValue := string(incomingSecret.Data[pacIncomingSecretKey])
 	pipelineRunName := getPipelineRunDefinitionName(component.Name, sanitizedVersionName, false)
 
@@ -351,6 +348,8 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	// we have to supply source_url as additional param, because PaC isn't able to resolve it for trigger
 	jsonTemplate := `{"params": {"source_url": "%s"}, "secret": "%s", "repository": "%s", "branch": "%s", "pipelinerun": "%s", "namespace": "%s"}`
 	bytesParam := []byte(fmt.Sprintf(jsonTemplate, repoUrl, secretValue, repository.Name, targetBranch, pipelineRunName, repository.Namespace))
+	redactedJsonTemplate := `{"params": {"source_url": "%s"}, "secret": "****", "repository": "%s", "branch": "%s", "pipelinerun": "%s", "namespace": "%s"}`
+	redactedBytesParam := []byte(fmt.Sprintf(redactedJsonTemplate, repoUrl, repository.Name, targetBranch, pipelineRunName, repository.Namespace))
 
 	resp, err := HttpClient.Post(triggerURL, "application/json", bytes.NewBuffer(bytesParam))
 	if err != nil {
@@ -360,22 +359,21 @@ func (r *ComponentBuildReconciler) TriggerPaCBuild(
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		log.Info(fmt.Sprintf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(bytesParam), resp.StatusCode))
-		return fmt.Errorf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(bytesParam), resp.StatusCode)
+		log.Info(fmt.Sprintf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(redactedBytesParam), resp.StatusCode))
+		return fmt.Errorf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(redactedBytesParam), resp.StatusCode)
 	}
 
-	log.Info(fmt.Sprintf("PaC build manually triggered push pipeline for component: %s, version: %s, endpoint %s with params %s", component.Name, sanitizedVersionName, triggerURL, string(bytesParam)))
+	log.Info(fmt.Sprintf("PaC build manually triggered push pipeline for component: %s, version: %s, endpoint %s with params %s", component.Name, sanitizedVersionName, triggerURL, string(redactedBytesParam)))
 	return nil
 }
 
 // TriggerPaCBuildOldModel triggers PaC builds for the old model.
 // For new model, use TriggerPaCBuildPrep followed by TriggerPaCBuild.
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, component *compapiv1alpha1.Component) (bool, error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) TriggerPaCBuildOldModel(ctx context.Context, component *compapiv1alpha1.Component) (bool, error) {
 	log := ctrllog.FromContext(ctx).WithName("TriggerPaCBuild")
-	newModel := false
 
-	repository, err := r.findPaCRepositoryForComponent(ctx, component, newModel)
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return false, err
 	}
@@ -384,19 +382,19 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 		return false, fmt.Errorf("PaC repository not found for component %s", component.Name)
 	}
 
-	incomingSecret, reconcileRequired, err := r.ensureIncomingSecret(ctx, component, newModel)
+	incomingSecret, reconcileRequired, err := r.ensureIncomingSecret(ctx, component)
 	if err != nil {
 		return false, err
 	}
 
-	repoUrl := getGitRepoUrl(*component, newModel)
-	gitProvider, err := getGitProvider(*component, newModel)
+	repoUrl := getGitRepoUrlOldModel(*component)
+	gitProvider, err := getGitProviderOldModel(*component)
 	if err != nil {
 		// There is no point to continue if git provider is not known.
 		return false, err
 	}
 
-	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider, newModel)
+	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider)
 	if err != nil {
 		return false, err
 	}
@@ -446,7 +444,7 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 
 	secretValue := string(incomingSecret.Data[pacIncomingSecretKey])
 
-	pipelineRunName := getPipelineRunDefinitionName(component.Name, "", false)
+	pipelineRunName := getPipelineRunDefinitionNameOldModel(component.Name, false)
 
 	triggerURL := fmt.Sprintf("%s/incoming", pacInternalUrl)
 	HttpClient := GetHttpClientFunction()
@@ -454,6 +452,8 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 	// we have to supply source_url as additional param, because PaC isn't able to resolve it for trigger
 	jsonTemplate := `{"params": {"source_url": "%s"}, "secret": "%s", "repository": "%s", "branch": "%s", "pipelinerun": "%s", "namespace": "%s"}`
 	bytesParam := []byte(fmt.Sprintf(jsonTemplate, repoUrl, secretValue, repository.Name, targetBranch, pipelineRunName, repository.Namespace))
+	redactedJsonTemplate := `{"params": {"source_url": "%s"}, "secret": "****", "repository": "%s", "branch": "%s", "pipelinerun": "%s", "namespace": "%s"}`
+	redactedBytesParam := []byte(fmt.Sprintf(redactedJsonTemplate, repoUrl, repository.Name, targetBranch, pipelineRunName, repository.Namespace))
 
 	resp, err := HttpClient.Post(triggerURL, "application/json", bytes.NewBuffer(bytesParam))
 	if err != nil {
@@ -463,38 +463,37 @@ func (r *ComponentBuildReconciler) TriggerPaCBuildOldModel(ctx context.Context, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		log.Info(fmt.Sprintf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(bytesParam), resp.StatusCode))
-		return false, fmt.Errorf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(bytesParam), resp.StatusCode)
+		log.Info(fmt.Sprintf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(redactedBytesParam), resp.StatusCode))
+		return false, fmt.Errorf("PaC incoming endpoint %s with params %s returned HTTP %d", triggerURL, string(redactedBytesParam), resp.StatusCode)
 	}
 
-	log.Info(fmt.Sprintf("PaC build manually triggered push pipeline for component: %s, endpoint %s with params %s", component.Name, triggerURL, string(bytesParam)))
+	log.Info(fmt.Sprintf("PaC build manually triggered push pipeline for component: %s, endpoint %s with params %s", component.Name, triggerURL, string(redactedBytesParam)))
 	return false, nil
 }
 
 // UndoPaCProvisionForComponentOldModel creates merge request that removes Pipelines as Code configuration from component source repository.
 // Deletes PaC webhook if used.
 // In case of any errors just logs them and does not block Component deletion.
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) UndoPaCProvisionForComponentOldModel(ctx context.Context, component *compapiv1alpha1.Component) (string, error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) UndoPaCProvisionForComponentOldModel(ctx context.Context, component *compapiv1alpha1.Component) (string, error) {
 	log := ctrllog.FromContext(ctx).WithName("PaC-cleanup")
-	newModel := false
 
 	log.Info("Starting Pipelines as Code unprovision for the Component")
 
-	gitProvider, err := getGitProvider(*component, newModel)
+	gitProvider, err := getGitProviderOldModel(*component)
 	if err != nil {
 		// There is no point to continue if git provider is not known.
 		return "", err
 	}
 
-	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider, newModel)
+	pacSecret, err := r.lookupPaCSecret(ctx, component, gitProvider)
 	if err != nil {
 		log.Error(err, "error getting git provider credentials secret", l.Action, l.ActionView)
 		// Cannot continue without accessing git provider credentials.
 		return "", boerrors.NewBuildOpError(boerrors.EPaCSecretNotFound, err)
 	}
 
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrlOldModel(*component)
 	webhookTargetUrl := ""
 	if !common.IsPaCApplicationConfigured(gitProvider, pacSecret.Data) {
 		webhookTargetUrl, err = r.getPaCWebhookTargetUrl(ctx, repoUrl)
@@ -511,7 +510,7 @@ func (r *ComponentBuildReconciler) UndoPaCProvisionForComponentOldModel(ctx cont
 		return "", err
 	}
 
-	err = r.cleanupPaCRepositoryIncomingsAndSecretOldModel(ctx, component, baseBranch, newModel)
+	err = r.cleanupPaCRepositoryIncomingsOldModel(ctx, component, baseBranch)
 	if err != nil {
 		log.Error(err, "failed cleanup incomings from repo and incoming secret")
 		return "", err
@@ -535,6 +534,29 @@ func (r *ComponentBuildReconciler) UndoPaCProvisionForComponentOldModel(ctx cont
 // If no match found, reads PAC_WEBHOOK_URL environment variable.
 // Lastly, falls back to PaC Route URL.
 func (r *ComponentBuildReconciler) getPaCWebhookTargetUrl(ctx context.Context, repositoryURL string) (string, error) {
+	webhookTargetUrl := r.PaCWebhookMapping.GetPaCWebhookUrlForGitRepo(repositoryURL)
+
+	if webhookTargetUrl == "" {
+		webhookTargetUrl = os.Getenv(pipelinesAsCodeWebhookUrlEnvVar)
+	}
+
+	if webhookTargetUrl == "" {
+		var err error
+		webhookTargetUrl, err = r.getPaCRoutePublicUrl(ctx)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return webhookTargetUrl, nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// getPaCWebhookTargetUrl returns URL to which events from git repository should be sent.
+// First, it checks provided mapping, if any.
+// If no match found, reads PAC_WEBHOOK_URL environment variable.
+// Lastly, falls back to PaC Route URL.
+func (r *ComponentBuildReconcilerOldModel) getPaCWebhookTargetUrl(ctx context.Context, repositoryURL string) (string, error) {
 	webhookTargetUrl := r.PaCWebhookMapping.GetPaCWebhookUrlForGitRepo(repositoryURL)
 
 	if webhookTargetUrl == "" {
@@ -581,10 +603,41 @@ func (r *ComponentBuildReconciler) getPaCRoutePublicUrl(ctx context.Context) (st
 	return "", fmt.Errorf("PaC route not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
 }
 
+// TODO remove after only new model is used and old model is gone
+// getPaCRoutePublicUrl returns Pipelines as Code public route that receives events to trigger new pipeline runs.
+// It checks "openshift-pipelines", "pipelines-as-code" namespaces
+// and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
+// Note, it makes sense only for Openshift as in pure k8s PaC doesn't have Ingress by default.
+func (r *ComponentBuildReconcilerOldModel) getPaCRoutePublicUrl(ctx context.Context) (string, error) {
+	pacWebhookRoute := &routev1.Route{}
+
+	namespacesToCheck := []string{pipelinesAsCodeNamespaceOpenshift, pipelinesAsCodeNamespace}
+	customPacNamespace := os.Getenv(pipelinesAsCodeNamespaceEnvVar)
+	if customPacNamespace != "" {
+		namespacesToCheck = append([]string{customPacNamespace}, namespacesToCheck...)
+	}
+
+	for _, namespace := range namespacesToCheck {
+		pacWebhookRouteKey := types.NamespacedName{Namespace: namespace, Name: pipelinesAsCodeRouteName}
+		if err := r.Client.Get(ctx, pacWebhookRouteKey, pacWebhookRoute); err != nil {
+			if !errors.IsNotFound(err) {
+				return "", fmt.Errorf("failed to get Pipelines as Code route in %s namespace: %w", namespace, err)
+			}
+			// Not found, continue
+		} else {
+			// Route found
+			return "https://" + pacWebhookRoute.Spec.Host, nil
+		}
+	}
+	// Checked all candidate namespaces for PaC installation, the PaC Route not found.
+	return "", fmt.Errorf("PaC route not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
+}
+
 // getInternalPaCEndpoint returns cluster internal URL to PaC endpoint.
 // It searches for PaC Service (which has the same name as Route) in "openshift-pipelines", "pipelines-as-code" namespaces
 // and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
 // The operator should always use this endpoint when communicating with PaC within the cluster.
+// nolint:dupl
 func (r *ComponentBuildReconciler) getInternalPaCEndpoint(ctx context.Context) (string, error) {
 	pacEndpointService := &corev1.Service{}
 
@@ -618,36 +671,78 @@ func (r *ComponentBuildReconciler) getInternalPaCEndpoint(ctx context.Context) (
 	return "", fmt.Errorf("PaC service not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
 }
 
-// TODO remove newModel handling after only new model is used
-func generateMergeRequestSourceBranch(component *compapiv1alpha1.Component, version string) string {
-	if version != "" {
-		return fmt.Sprintf("%s%s-%s", pacMergeRequestSourceBranchPrefix, component.Name, version)
-	} else {
-		return fmt.Sprintf("%s%s", pacMergeRequestSourceBranchPrefix, component.Name)
+// TODO remove after only new model is used and old model is gone
+// getInternalPaCEndpoint returns cluster internal URL to PaC endpoint.
+// It searches for PaC Service (which has the same name as Route) in "openshift-pipelines", "pipelines-as-code" namespaces
+// and namespace defined in PAC_NAMESPACE environment variable, if any (takes precedence).
+// The operator should always use this endpoint when communicating with PaC within the cluster.
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) getInternalPaCEndpoint(ctx context.Context) (string, error) {
+	pacEndpointService := &corev1.Service{}
+
+	namespacesToCheck := []string{pipelinesAsCodeNamespaceOpenshift, pipelinesAsCodeNamespace}
+	customPacNamespace := os.Getenv(pipelinesAsCodeNamespaceEnvVar)
+	if customPacNamespace != "" {
+		namespacesToCheck = append([]string{customPacNamespace}, namespacesToCheck...)
 	}
+
+	for _, namespace := range namespacesToCheck {
+		pacEndpointServiceKey := types.NamespacedName{Namespace: namespace, Name: pipelinesAsCodeRouteName}
+		if err := r.Client.Get(ctx, pacEndpointServiceKey, pacEndpointService); err != nil {
+			if !errors.IsNotFound(err) {
+				return "", fmt.Errorf("failed to get Pipelines as Code service in %s namespace: %w", namespace, err)
+			}
+			// Not found, continue
+		} else {
+			// Service found, generate URL: http://<service-name>.<namespace-name>.svc.cluster.local:<service-port>
+			port := 80
+			for _, servicePortConfig := range pacEndpointService.Spec.Ports {
+				if servicePortConfig.Name == "http-listener" {
+					port = int(servicePortConfig.Port)
+					break
+				}
+			}
+			internalServiceUrl := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", pacEndpointServiceKey.Name, pacEndpointServiceKey.Namespace, port)
+			return internalServiceUrl, nil
+		}
+	}
+	// Checked all candidate namespaces for PaC installation, the PaC Service not found.
+	return "", fmt.Errorf("PaC service not found in '%s' namespaces", strings.Join(namespacesToCheck, " "))
 }
 
-// TODO remove newModel handling after only new model is used
+func generateMergeRequestSourceBranch(component *compv1alpha1.Component, version string) string {
+	return fmt.Sprintf("%s%s-%s", pacMergeRequestSourceBranchPrefix, component.Name, version)
+}
+
+// TODO remove after only new model is used and old model is gone
+func generateMergeRequestSourceBranchOldModel(component *compapiv1alpha1.Component) string {
+	return fmt.Sprintf("%s%s", pacMergeRequestSourceBranchPrefix, component.Name)
+}
+
 // getPipelineRunDefinitionFilePath returns full path in git repository to the pipeline run definition of the given Component.
 func getPipelineRunDefinitionFilePath(componentName, versionName string, isPullRequest bool) string {
 	pipelineNameSuffix := pipelineRunOnPushFilename
 	if isPullRequest {
 		pipelineNameSuffix = pipelineRunOnPRFilename
 	}
-	if versionName != "" {
-		return ".tekton/" + componentName + "-" + versionName + "-" + pipelineNameSuffix
-	} else {
-		return ".tekton/" + componentName + "-" + pipelineNameSuffix
+	return ".tekton/" + componentName + "-" + versionName + "-" + pipelineNameSuffix
+}
+
+// TODO remove after only new model is used and old model is gone
+// getPipelineRunDefinitionFilePathOldModel returns full path in git repository to the pipeline run definition of the given Component.
+func getPipelineRunDefinitionFilePathOldModel(componentName string, isPullRequest bool) string {
+	pipelineNameSuffix := pipelineRunOnPushFilename
+	if isPullRequest {
+		pipelineNameSuffix = pipelineRunOnPRFilename
 	}
+	return ".tekton/" + componentName + "-" + pipelineNameSuffix
 }
 
 // GetGitClient creates and returns a git provider client for the component's git repository.
 // It uses the PaC configuration to authenticate with the git provider (GitHub, GitLab, etc.).
-// TODO remove newModel handling after only new model is used
-func GetGitClient(component *compapiv1alpha1.Component, pacConfig map[string][]byte) (gp.GitProviderClient, error) {
-	newModel := true
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+func GetGitClient(component *compv1alpha1.Component, pacConfig map[string][]byte) (gp.GitProviderClient, error) {
+	gitProvider, _ := getGitProvider(*component)
+	repoUrl := getGitRepoUrl(*component)
 
 	gitClient, err := gitproviderfactory.CreateGitClient(gitproviderfactory.GitClientConfig{
 		PacSecretData: pacConfig,
@@ -670,12 +765,9 @@ func GetGitClient(component *compapiv1alpha1.Component, pacConfig map[string][]b
 // SetupPacWebhookWhenAppNotUsed configures a webhook in the component's git repository to notify the in-cluster PaC controller.
 // The webhook is only created when PaC GitHub/GitLab App is not configured (checks via IsPaCApplicationConfigured).
 // When using App-based integration, webhooks are managed automatically by the git provider and this setup is skipped.
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) SetupPacWebhookWhenAppNotUsed(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte, webhookSecret string) error {
-	newModel := true
-
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+func (r *ComponentBuildReconciler) SetupPacWebhookWhenAppNotUsed(ctx context.Context, component *compv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte, webhookSecret string) error {
+	gitProvider, _ := getGitProvider(*component)
+	repoUrl := getGitRepoUrl(*component)
 
 	log := ctrllog.FromContext(ctx).WithValues("repository", repoUrl)
 
@@ -700,18 +792,16 @@ func (r *ComponentBuildReconciler) SetupPacWebhookWhenAppNotUsed(ctx context.Con
 
 // CreatePipelineRunsInRepository creates a merge request with pipeline run definitions in the component's git repository.
 // Returns the merge request URL if created, or empty string if pipeline runs are already up to date.
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) CreatePipelineRunsInRepository(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, pipelineDefinition *VersionPipelineDefinition, pacConfig map[string][]byte) (prUrl string, err error) {
+func (r *ComponentBuildReconciler) CreatePipelineRunsInRepository(ctx context.Context, component *compv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, pipelineDefinition *VersionPipelineDefinition, pacConfig map[string][]byte) (prUrl string, err error) {
 	log := ctrllog.FromContext(ctx).WithValues("repository", component.Spec.Source.GitURL)
 	ctx = ctrllog.IntoContext(ctx, log)
-	newModel := true
 
 	pipelineRunOnPushYaml, pipelineRunOnPRYaml, err := r.generatePaCPipelineRunConfigs(ctx, component, gitClient, versionInfo, pipelineDefinition)
 	if err != nil {
 		return "", err
 	}
 
-	gitProvider, _ := getGitProvider(*component, newModel)
+	gitProvider, _ := getGitProvider(*component)
 	authorName := "konflux"
 	authorEmail := konfluxAuthorEmail
 	namePrefix := "Konflux"
@@ -749,7 +839,7 @@ func (r *ComponentBuildReconciler) CreatePipelineRunsInRepository(ctx context.Co
 		},
 	}
 
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 	mrUrl, err := gitClient.EnsurePaCMergeRequest(repoUrl, mrData)
 	if err != nil {
 		return "", err
@@ -768,13 +858,12 @@ func (r *ComponentBuildReconciler) CreatePipelineRunsInRepository(ctx context.Co
 
 // ConfigureRepositoryForPaCOldModel creates a merge request with initial Pipelines as Code configuration
 // and configures a webhook to notify in-cluster PaC unless application (on the repository side) is used.
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) ConfigureRepositoryForPaCOldModel(ctx context.Context, component *compapiv1alpha1.Component, pacConfig map[string][]byte, webhookTargetUrl, webhookSecret string) (prUrl string, err error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) ConfigureRepositoryForPaCOldModel(ctx context.Context, component *compapiv1alpha1.Component, pacConfig map[string][]byte, webhookTargetUrl, webhookSecret string) (prUrl string, err error) {
 	log := ctrllog.FromContext(ctx).WithValues("repository", component.Spec.Source.GitSource.URL)
-	newModel := false
 
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+	gitProvider, _ := getGitProviderOldModel(*component)
+	repoUrl := getGitRepoUrlOldModel(*component)
 
 	gitClient, err := gitproviderfactory.CreateGitClient(gitproviderfactory.GitClientConfig{
 		PacSecretData: pacConfig,
@@ -804,15 +893,15 @@ func (r *ComponentBuildReconciler) ConfigureRepositoryForPaCOldModel(ctx context
 	mrData := &gp.MergeRequestData{
 		CommitMessage:  "Konflux update " + component.Name,
 		SignedOff:      true,
-		BranchName:     generateMergeRequestSourceBranch(component, ""),
+		BranchName:     generateMergeRequestSourceBranchOldModel(component),
 		BaseBranchName: baseBranch,
 		Title:          "Konflux update " + component.Name,
 		Text:           mergeRequestDescription,
 		AuthorName:     "konflux",
 		AuthorEmail:    konfluxAuthorEmail,
 		Files: []gp.RepositoryFile{
-			{FullPath: getPipelineRunDefinitionFilePath(component.Name, "", false), Content: pipelineRunOnPushYaml},
-			{FullPath: getPipelineRunDefinitionFilePath(component.Name, "", true), Content: pipelineRunOnPRYaml},
+			{FullPath: getPipelineRunDefinitionFilePathOldModel(component.Name, false), Content: pipelineRunOnPushYaml},
+			{FullPath: getPipelineRunDefinitionFilePathOldModel(component.Name, true), Content: pipelineRunOnPRYaml},
 		},
 	}
 
@@ -854,13 +943,11 @@ func (r *ComponentBuildReconciler) ConfigureRepositoryForPaCOldModel(ctx context
 }
 
 // RemovePacWebhook removes repository webhook, but only when no other component is using it, used only when component is removed
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte) error {
+func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, component *compv1alpha1.Component, gitClient gp.GitProviderClient, pacConfig map[string][]byte) error {
 	log := ctrllog.FromContext(ctx)
-	newModel := true
 
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+	gitProvider, _ := getGitProvider(*component)
+	repoUrl := getGitRepoUrl(*component)
 
 	isAppUsed := common.IsPaCApplicationConfigured(gitProvider, pacConfig)
 	if !isAppUsed {
@@ -869,18 +956,37 @@ func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, compone
 			return fmt.Errorf("failed to get PaC webhook URL: %w", err)
 		}
 
-		componentList := &compapiv1alpha1.ComponentList{}
+		componentList := &compv1alpha1.ComponentList{}
 		if err := r.Client.List(ctx, componentList, &client.ListOptions{Namespace: component.Namespace}); err != nil {
+			log.Error(err, "failed to list components")
+			return err
+		}
+		// TODO remove after only new model is used and old model is gone
+		componentListOld := &compapiv1alpha1.ComponentList{}
+		if err := r.Client.List(ctx, componentListOld, &client.ListOptions{Namespace: component.Namespace}); err != nil {
 			log.Error(err, "failed to list components")
 			return err
 		}
 
 		sameRepoUsed := false
 		for _, comp := range componentList.Items {
-			if comp.Name == component.Name {
+			// Skip components marked for removal
+			if comp.DeletionTimestamp != nil {
 				continue
 			}
-			componentUrl := getGitRepoUrl(comp, newModel)
+			componentUrl := getGitRepoUrl(comp)
+			if componentUrl == repoUrl {
+				sameRepoUsed = true
+				break
+			}
+		}
+		// TODO remove after only new model is used and old model is gone
+		for _, comp := range componentListOld.Items {
+			// Skip components marked for removal
+			if comp.DeletionTimestamp != nil {
+				continue
+			}
+			componentUrl := getGitRepoUrlOldModel(comp)
 			if componentUrl == repoUrl {
 				sameRepoUsed = true
 				break
@@ -907,15 +1013,13 @@ func (r *ComponentBuildReconciler) RemovePacWebhook(ctx context.Context, compone
 // It first closes any unmerged MRs by deleting their source branches.
 // If the pipeline runs were already merged, it creates a new merge request to delete the pipeline run files.
 // Does not delete the GitHub application from the repository as its installation was done manually by the user.
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) RemovePipelineRunsFromRepository(ctx context.Context, component *compapiv1alpha1.Component, versionInfo *VersionInfo, gitClient gp.GitProviderClient, pacConfig map[string][]byte) error {
+func (r *ComponentBuildReconciler) RemovePipelineRunsFromRepository(ctx context.Context, component *compv1alpha1.Component, versionInfo *VersionInfo, gitClient gp.GitProviderClient, pacConfig map[string][]byte) error {
 	log := ctrllog.FromContext(ctx)
-	newModel := true
 
 	log.Info("Starting Pipelines as Code unprovision for the Component", "componentName", component.Name, "versionName", versionInfo.OriginalVersion)
 
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+	gitProvider, _ := getGitProvider(*component)
+	repoUrl := getGitRepoUrl(*component)
 
 	sourceBranch := generateMergeRequestSourceBranch(component, versionInfo.SanitizedVersion)
 
@@ -1014,13 +1118,12 @@ func (r *ComponentBuildReconciler) RemovePipelineRunsFromRepository(ctx context.
 // Deletes PaC webhook if it's used.
 // Does not delete PaC GitHub application from the repository as its installation was done manually by the user.
 // Returns merge request web URL or empty string if it's not needed.
-// TODO remove after only new model is used
-func (r *ComponentBuildReconciler) UnconfigureRepositoryForPacOldModel(ctx context.Context, component *compapiv1alpha1.Component, pacConfig map[string][]byte, webhookTargetUrl string) (baseBranch string, prUrl string, action string, err error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) UnconfigureRepositoryForPacOldModel(ctx context.Context, component *compapiv1alpha1.Component, pacConfig map[string][]byte, webhookTargetUrl string) (baseBranch string, prUrl string, action string, err error) {
 	log := ctrllog.FromContext(ctx)
-	newModel := false
 
-	gitProvider, _ := getGitProvider(*component, newModel)
-	repoUrl := getGitRepoUrl(*component, newModel)
+	gitProvider, _ := getGitProviderOldModel(*component)
+	repoUrl := getGitRepoUrlOldModel(*component)
 
 	gitClient, err := gitproviderfactory.CreateGitClient(gitproviderfactory.GitClientConfig{
 		PacSecretData: pacConfig,
@@ -1044,13 +1147,30 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPacOldModel(ctx conte
 			log.Error(err, "failed to list components")
 			return "", "", "", err
 		}
+		componentListNew := &compv1alpha1.ComponentList{}
+		if err := r.Client.List(ctx, componentListNew, &client.ListOptions{Namespace: component.Namespace}); err != nil {
+			log.Error(err, "failed to list components")
+			return "", "", "", err
+		}
 
 		sameRepoUsed := false
 		for _, comp := range componentList.Items {
-			if comp.Name == component.Name {
+			// Skip components marked for removal
+			if comp.DeletionTimestamp != nil {
 				continue
 			}
-			componentUrl := getGitRepoUrl(comp, newModel)
+			componentUrl := getGitRepoUrlOldModel(comp)
+			if componentUrl == repoUrl {
+				sameRepoUsed = true
+				break
+			}
+		}
+		for _, comp := range componentListNew.Items {
+			// Skip components marked for removal
+			if comp.DeletionTimestamp != nil {
+				continue
+			}
+			componentUrl := getGitRepoUrl(comp)
 			if componentUrl == repoUrl {
 				sameRepoUsed = true
 				break
@@ -1070,7 +1190,7 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPacOldModel(ctx conte
 		}
 	}
 
-	sourceBranch := generateMergeRequestSourceBranch(component, "")
+	sourceBranch := generateMergeRequestSourceBranchOldModel(component)
 	baseBranch = component.Spec.Source.GitSource.Revision
 	if baseBranch == "" {
 		baseBranch = defaultBranch
@@ -1113,8 +1233,8 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPacOldModel(ctx conte
 			AuthorName:     "konflux",
 			AuthorEmail:    konfluxAuthorEmail,
 			Files: []gp.RepositoryFile{
-				{FullPath: getPipelineRunDefinitionFilePath(component.Name, "", false)},
-				{FullPath: getPipelineRunDefinitionFilePath(component.Name, "", true)},
+				{FullPath: getPipelineRunDefinitionFilePathOldModel(component.Name, false)},
+				{FullPath: getPipelineRunDefinitionFilePathOldModel(component.Name, true)},
 			},
 		}
 
@@ -1142,22 +1262,22 @@ func (r *ComponentBuildReconciler) UnconfigureRepositoryForPacOldModel(ctx conte
 	return baseBranch, prUrl, action_done, err
 }
 
-// TODO remove newModel handling after only new model is used
 // getGitRepoUrl returns trimmed source url
-func getGitRepoUrl(component compapiv1alpha1.Component, newModel bool) string {
-	if newModel {
-		return strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitURL, "/"), ".git")
-	} else {
-		return strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitSource.URL, "/"), ".git")
-	}
+func getGitRepoUrl(component compv1alpha1.Component) string {
+	return strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitURL, "/"), ".git")
 }
 
-// TODO remove newModel handling after only new model is used
+// TODO remove after only new model is used and old model is gone
+// getGitRepoUrlOldModel returns trimmed source url
+func getGitRepoUrlOldModel(component compapiv1alpha1.Component) string {
+	return strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitSource.URL, "/"), ".git")
+}
+
 // validateGitSourceUrl validates if component.Spec.Source.GitSource.URL is valid git url
 // https://github.com/owner/repository is valid
 // https://github.com/owner is invalid
-func validateGitSourceUrl(component compapiv1alpha1.Component, gitProvider string, newModel bool) error {
-	sourceUrl := getGitRepoUrl(component, newModel)
+func validateGitSourceUrl(component compv1alpha1.Component, gitProvider string) error {
+	sourceUrl := getGitRepoUrl(component)
 	gitUrl, err := url.Parse(sourceUrl)
 	if err != nil {
 		return err
@@ -1187,18 +1307,46 @@ func validateGitSourceUrl(component compapiv1alpha1.Component, gitProvider strin
 	return nil
 }
 
-// TODO remove newModel handling after only new model is used
+// TODO remove after only new model is used and old model is gone
+// validateGitSourceUrlOldModel validates if component.Spec.Source.GitSource.URL is valid git url
+// https://github.com/owner/repository is valid
+// https://github.com/owner is invalid
+func validateGitSourceUrlOldModel(component compapiv1alpha1.Component, gitProvider string) error {
+	sourceUrl := getGitRepoUrlOldModel(component)
+	gitUrl, err := url.Parse(sourceUrl)
+	if err != nil {
+		return err
+	}
+	shouldFail := false
+	gitSourceUrlPathParts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(gitUrl.Path, "/"), "/"), "/")
+	if len(gitSourceUrlPathParts) < 2 {
+		shouldFail = true
+	}
+
+	if gitProvider == "github" {
+		if len(gitSourceUrlPathParts) > 2 {
+			shouldFail = true
+		}
+	}
+
+	if gitProvider == "gitlab" {
+		if slices.Contains(gitSourceUrlPathParts, "-") {
+			shouldFail = true
+		}
+	}
+
+	if shouldFail {
+		err := fmt.Errorf("git source URL is not valid git URL '%s' for %s Component in %s namespace", sourceUrl, component.Name, component.Namespace)
+		return err
+	}
+	return nil
+}
+
 // getGitProvider returns git provider name based on the repository url or the git-provider annotation
-func getGitProvider(component compapiv1alpha1.Component, newModel bool) (string, error) {
+func getGitProvider(component compv1alpha1.Component) (string, error) {
 	allowedGitProviders := []string{"github", "gitlab", "forgejo"}
-	if newModel {
-		if component.Spec.Source.GitURL == "" {
-			return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, fmt.Errorf("git source URL is not set for %s Component in %s namespace", component.Name, component.Namespace))
-		}
-	} else {
-		if component.Spec.Source.GitSource == nil {
-			return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, fmt.Errorf("git source URL is not set for %s Component in %s namespace", component.Name, component.Namespace))
-		}
+	if component.Spec.Source.GitURL == "" {
+		return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, fmt.Errorf("git source URL is not set for %s Component in %s namespace", component.Name, component.Namespace))
 	}
 
 	gitProvider := component.GetAnnotations()[GitProviderAnnotationName]
@@ -1211,20 +1359,14 @@ func getGitProvider(component compapiv1alpha1.Component, newModel bool) (string,
 	}
 
 	if gitProvider == "" {
-		var sourceUrl string
-		if newModel {
-			sourceUrl = component.Spec.Source.GitURL
-		} else {
-			sourceUrl = component.Spec.Source.GitSource.URL
-		}
-		var host string
+		sourceUrl := component.Spec.Source.GitURL
 
 		// sourceUrl example: https://github.com/konflux-ci/build-service
 		u, err := url.Parse(sourceUrl)
 		if err != nil {
 			return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, err)
 		}
-		host = u.Hostname()
+		host := u.Hostname()
 
 		for _, provider := range allowedGitProviders {
 			if strings.Contains(host, provider) {
@@ -1243,7 +1385,59 @@ func getGitProvider(component compapiv1alpha1.Component, newModel bool) (string,
 	}
 
 	// validate gitsource URL
-	err := validateGitSourceUrl(component, gitProvider, newModel)
+	err := validateGitSourceUrl(component, gitProvider)
+	if err != nil {
+		return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, err)
+	}
+
+	return gitProvider, nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// getGitProviderOldModel returns git provider name based on the repository url or the git-provider annotation
+func getGitProviderOldModel(component compapiv1alpha1.Component) (string, error) {
+	allowedGitProviders := []string{"github", "gitlab", "forgejo"}
+	if component.Spec.Source.GitSource == nil {
+		return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, fmt.Errorf("git source URL is not set for %s Component in %s namespace", component.Name, component.Namespace))
+	}
+
+	gitProvider := component.GetAnnotations()[GitProviderAnnotationName]
+	// Gitea is API-compatible with Forgejo, treat "gitea" as "forgejo"
+	if gitProvider == "gitea" {
+		gitProvider = "forgejo"
+	}
+	if gitProvider != "" && !slices.Contains(allowedGitProviders, gitProvider) {
+		return "", boerrors.NewBuildOpError(boerrors.EUnknownGitProvider, fmt.Errorf(`unsupported "%s" annotation value: %s`, GitProviderAnnotationName, gitProvider))
+	}
+
+	if gitProvider == "" {
+		sourceUrl := component.Spec.Source.GitSource.URL
+
+		// sourceUrl example: https://github.com/konflux-ci/build-service
+		u, err := url.Parse(sourceUrl)
+		if err != nil {
+			return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, err)
+		}
+		host := u.Hostname()
+
+		for _, provider := range allowedGitProviders {
+			if strings.Contains(host, provider) {
+				gitProvider = provider
+				break
+			}
+		}
+		// Gitea is API-compatible with Forgejo, detect "gitea" in hostname as "forgejo"
+		if gitProvider == "" && strings.Contains(host, "gitea") {
+			gitProvider = "forgejo"
+		}
+	}
+
+	if gitProvider == "" {
+		return "", boerrors.NewBuildOpError(boerrors.EUnknownGitProvider, fmt.Errorf(`failed to determine git provider, please set the "%s" annotation on the component`, GitProviderAnnotationName))
+	}
+
+	// validate gitsource URL
+	err := validateGitSourceUrlOldModel(component, gitProvider)
 	if err != nil {
 		return "", boerrors.NewBuildOpError(boerrors.EWrongGitSourceUrl, err)
 	}

--- a/internal/controller/component_build_controller_pac_repository.go
+++ b/internal/controller/component_build_controller_pac_repository.go
@@ -26,7 +26,8 @@ import (
 	"strconv"
 	"strings"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,10 +47,9 @@ const (
 	PacTargetBranchFilterKey = "pac.target_branch"
 )
 
-// TODO remove newModel handling after only new model is used
 // findPaCRepositoryForComponent searches for existing matching PaC repository object for given component.
 // The search makes sense only in the same namespace.
-func (r *ComponentBuildReconciler) findPaCRepositoryForComponent(ctx context.Context, component *compapiv1alpha1.Component, newModel bool) (*pacv1alpha1.Repository, error) {
+func (r *ComponentBuildReconciler) findPaCRepositoryForComponent(ctx context.Context, component *compv1alpha1.Component) (*pacv1alpha1.Repository, error) {
 	log := ctrllog.FromContext(ctx)
 
 	pacRepositoriesList := &pacv1alpha1.RepositoryList{}
@@ -59,7 +59,29 @@ func (r *ComponentBuildReconciler) findPaCRepositoryForComponent(ctx context.Con
 		return nil, err
 	}
 
-	gitUrl := getGitRepoUrl(*component, newModel)
+	gitUrl := getGitRepoUrl(*component)
+	for _, pacRepository := range pacRepositoriesList.Items {
+		if pacRepository.Spec.URL == gitUrl {
+			return &pacRepository, nil
+		}
+	}
+	return nil, nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// findPaCRepositoryForComponent searches for existing matching PaC repository object for given component.
+// The search makes sense only in the same namespace.
+func (r *ComponentBuildReconcilerOldModel) findPaCRepositoryForComponent(ctx context.Context, component *compapiv1alpha1.Component) (*pacv1alpha1.Repository, error) {
+	log := ctrllog.FromContext(ctx)
+
+	pacRepositoriesList := &pacv1alpha1.RepositoryList{}
+	err := r.Client.List(ctx, pacRepositoriesList, &client.ListOptions{Namespace: component.Namespace})
+	if err != nil {
+		log.Error(err, "failed to list PaC repositories")
+		return nil, err
+	}
+
+	gitUrl := getGitRepoUrlOldModel(*component)
 	for _, pacRepository := range pacRepositoriesList.Items {
 		if pacRepository.Spec.URL == gitUrl {
 			return &pacRepository, nil
@@ -148,8 +170,8 @@ func updatePaCRepositorySkipBuildsParams(repository *pacv1alpha1.Repository, ski
 	return paramsUpdated
 }
 
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, component *compapiv1alpha1.Component, pacConfig *corev1.Secret, repositorySettings *compapiv1alpha1.RepositorySettings, skipBuildsMap map[string]bool, newModel bool) (string, error) {
+// nolint:dupl
+func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, component *compv1alpha1.Component, pacConfig *corev1.Secret, repositorySettings *compv1alpha1.RepositorySettings, skipBuildsMap map[string]bool) (string, error) {
 	log := ctrllog.FromContext(ctx)
 
 	// Check multi component git repository scenario.
@@ -158,7 +180,7 @@ func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, comp
 	// For example, there are several dockerfiles in the same git repository
 	// and each of them builds separate component from the common codebase.
 	// Another scenario is component per branch.
-	repository, err := r.findPaCRepositoryForComponent(ctx, component, newModel)
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return "", err
 	}
@@ -178,48 +200,47 @@ func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, comp
 
 		repositorySettingsUpdated := false
 		repositoryParamsUpdated := false
-		if newModel {
-			// Initialize Settings if nil
-			if repository.Spec.Settings == nil {
-				repository.Spec.Settings = &pacv1alpha1.Settings{}
-			}
-			// Initialize Gitlab if nil
-			if repository.Spec.Settings.Gitlab == nil {
-				repository.Spec.Settings.Gitlab = &pacv1alpha1.GitlabSettings{}
-			}
-			// Initialize Github if nil
-			if repository.Spec.Settings.Github == nil {
-				repository.Spec.Settings.Github = &pacv1alpha1.GithubSettings{}
+
+		// Initialize Settings if nil
+		if repository.Spec.Settings == nil {
+			repository.Spec.Settings = &pacv1alpha1.Settings{}
+		}
+		// Initialize Gitlab if nil
+		if repository.Spec.Settings.Gitlab == nil {
+			repository.Spec.Settings.Gitlab = &pacv1alpha1.GitlabSettings{}
+		}
+		// Initialize Github if nil
+		if repository.Spec.Settings.Github == nil {
+			repository.Spec.Settings.Github = &pacv1alpha1.GithubSettings{}
+		}
+
+		if repositorySettings != nil {
+			// update repository settings when changed
+			if repositorySettings.CommentStrategy != repository.Spec.Settings.Github.CommentStrategy || repositorySettings.CommentStrategy != repository.Spec.Settings.Gitlab.CommentStrategy {
+				repository.Spec.Settings.Github.CommentStrategy = repositorySettings.CommentStrategy
+				repository.Spec.Settings.Gitlab.CommentStrategy = repositorySettings.CommentStrategy
+				repositorySettingsUpdated = true
 			}
 
-			if repositorySettings != nil {
-				// update repository settings when changed
-				if repositorySettings.CommentStrategy != repository.Spec.Settings.Github.CommentStrategy || repositorySettings.CommentStrategy != repository.Spec.Settings.Gitlab.CommentStrategy {
-					repository.Spec.Settings.Github.CommentStrategy = repositorySettings.CommentStrategy
-					repository.Spec.Settings.Gitlab.CommentStrategy = repositorySettings.CommentStrategy
-					repositorySettingsUpdated = true
-				}
-
-				if !equalStringSlicesAsSet(repositorySettings.GithubAppTokenScopeRepos, repository.Spec.Settings.GithubAppTokenScopeRepos) {
-					repository.Spec.Settings.GithubAppTokenScopeRepos = getUniqueStrings(repositorySettings.GithubAppTokenScopeRepos)
-					repositorySettingsUpdated = true
-				}
-			} else {
-				// clean repository settings when not provided
-				if repository.Spec.Settings.Github.CommentStrategy != "" || repository.Spec.Settings.Gitlab.CommentStrategy != "" {
-					repository.Spec.Settings.Github.CommentStrategy = ""
-					repository.Spec.Settings.Gitlab.CommentStrategy = ""
-					repositorySettingsUpdated = true
-				}
-				if len(repository.Spec.Settings.GithubAppTokenScopeRepos) > 0 {
-					repository.Spec.Settings.GithubAppTokenScopeRepos = []string{}
-					repositorySettingsUpdated = true
-				}
+			if !equalStringSlicesAsSet(repositorySettings.GithubAppTokenScopeRepos, repository.Spec.Settings.GithubAppTokenScopeRepos) {
+				repository.Spec.Settings.GithubAppTokenScopeRepos = getUniqueStrings(repositorySettings.GithubAppTokenScopeRepos)
+				repositorySettingsUpdated = true
 			}
-
-			if skipBuildsMap != nil {
-				repositoryParamsUpdated = updatePaCRepositorySkipBuildsParams(repository, skipBuildsMap)
+		} else {
+			// clean repository settings when not provided
+			if repository.Spec.Settings.Github.CommentStrategy != "" || repository.Spec.Settings.Gitlab.CommentStrategy != "" {
+				repository.Spec.Settings.Github.CommentStrategy = ""
+				repository.Spec.Settings.Gitlab.CommentStrategy = ""
+				repositorySettingsUpdated = true
 			}
+			if len(repository.Spec.Settings.GithubAppTokenScopeRepos) > 0 {
+				repository.Spec.Settings.GithubAppTokenScopeRepos = []string{}
+				repositorySettingsUpdated = true
+			}
+		}
+
+		if skipBuildsMap != nil {
+			repositoryParamsUpdated = updatePaCRepositorySkipBuildsParams(repository, skipBuildsMap)
 		}
 
 		if (len(repository.OwnerReferences) > pacRepositoryOwnersNumber) || repositorySettingsUpdated || repositoryParamsUpdated || gitProviderTypeUpdated {
@@ -235,7 +256,7 @@ func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, comp
 	}
 
 	// This is the first Component that does PaC provision for the git repository
-	repository, err = generatePACRepository(*component, pacConfig, repositorySettings, skipBuildsMap, newModel)
+	repository, err = generatePACRepository(*component, pacConfig, repositorySettings, skipBuildsMap)
 	if err != nil {
 		return "", err
 	}
@@ -245,14 +266,124 @@ func (r *ComponentBuildReconciler) ensurePaCRepository(ctx context.Context, comp
 		log.Error(err, "failed to get the component namespace for setting custom parameter.")
 		return "", err
 	}
-	if val, ok := ns.Labels[appstudioWorkspaceNameLabel]; ok {
+	if val, ok := ns.Labels[konfluxWorkspaceNameLabel]; ok {
 		pacRepoAddParamWorkspaceName(repository, val)
+	} else {
+		// TODO remove after only new model is used and old model is gone
+		if val, ok := ns.Labels[appstudioWorkspaceNameLabelOldModel]; ok {
+			pacRepoAddParamWorkspaceName(repository, val)
+		}
 	}
 
 	existingRepository := &pacv1alpha1.Repository{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: repository.Name, Namespace: repository.Namespace}, existingRepository)
 	if err == nil {
-		gitUrl := getGitRepoUrl(*component, newModel)
+		gitUrl := getGitRepoUrl(*component)
+
+		if existingRepository.Spec.URL == gitUrl {
+			return "", nil
+		}
+		// repository with the same name exists but with different git URL, add random string to repository name
+		repository.ObjectMeta.Name = fmt.Sprintf("%s-%s", repository.ObjectMeta.Name, common.RandomString(5))
+	}
+
+	// create repository if not found or when found but with different URL
+	if (err != nil && errors.IsNotFound(err)) || err == nil {
+		if err := controllerutil.SetOwnerReference(component, repository, r.Scheme); err != nil {
+			return "", err
+		}
+		if err := r.Client.Create(ctx, repository); err != nil {
+			if strings.Contains(err.Error(), "repository already exist") {
+				// PaC admission webhook denied creation of the PaC repository,
+				// because PaC repository object that references the same git repository already exists.
+				log.Info("An attempt to create second PaC Repository for the same git repository", "GitRepository", repository.Spec.URL, l.Action, l.ActionAdd, l.Audit, "true")
+				return "", boerrors.NewBuildOpError(boerrors.EPaCDuplicateRepository, err)
+			}
+
+			if strings.Contains(err.Error(), "denied the request: failed to validate") || (strings.Contains(err.Error(), "denied request: Repository URL") && strings.Contains(err.Error(), "is not allowed on this cluster")) {
+				// PaC admission webhook denied creation of the PaC repository,
+				// because PaC repository object references not allowed git repository url.
+				log.Info("An attempt to create PaC Repository for not allowed repository url", "GitRepository", repository.Spec.URL, l.Action, l.ActionAdd, l.Audit, "true")
+				return "", boerrors.NewBuildOpError(boerrors.EPaCNotAllowedRepositoryUrl, err)
+			}
+
+			log.Error(err, "failed to create Component PaC repository object", l.Action, l.ActionAdd)
+			return "", err
+		}
+		log.Info("Created PaC Repository object for the component", "RepositoryName", repository.ObjectMeta.Name)
+
+	} else {
+		log.Error(err, "failed to get Component PaC repository object", l.Action, l.ActionView)
+		return "", err
+	}
+
+	return repository.Name, nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) ensurePaCRepository(ctx context.Context, component *compapiv1alpha1.Component, pacConfig *corev1.Secret) (string, error) {
+	log := ctrllog.FromContext(ctx)
+
+	// Check multi component git repository scenario.
+	// It's not possible to determine multi component git repository scenario by context directory field,
+	// therefore it's required to do the check for all components.
+	// For example, there are several dockerfiles in the same git repository
+	// and each of them builds separate component from the common codebase.
+	// Another scenario is component per branch.
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
+	if err != nil {
+		return "", err
+	}
+	if repository != nil {
+		pacRepositoryOwnersNumber := len(repository.OwnerReferences)
+		if err := controllerutil.SetOwnerReference(component, repository, r.Scheme); err != nil {
+			log.Error(err, "failed to add owner reference to existing PaC repository", "PaCRepositoryName", repository.Name)
+			return "", err
+		}
+
+		// Normalize legacy "gitea" provider type to "forgejo" (gitea is an alias for forgejo in PaC)
+		gitProviderTypeUpdated := false
+		if repository.Spec.GitProvider != nil && repository.Spec.GitProvider.Type == "gitea" {
+			repository.Spec.GitProvider.Type = "forgejo"
+			gitProviderTypeUpdated = true
+		}
+
+		if (len(repository.OwnerReferences) > pacRepositoryOwnersNumber) || gitProviderTypeUpdated {
+			if err := r.Client.Update(ctx, repository); err != nil {
+				log.Error(err, "failed to update existing PaC repository with component owner reference", "PaCRepositoryName", repository.Name)
+				return "", err
+			}
+			log.Info("Added current component to owners of the PaC repository", "PaCRepositoryName", repository.Name, l.Action, l.ActionUpdate)
+		} else {
+			log.Info("Using existing PaC Repository object for the component", "PaCRepositoryName", repository.Name)
+		}
+		return repository.Name, nil
+	}
+
+	// This is the first Component that does PaC provision for the git repository
+	repository, err = generatePACRepositoryOldModel(*component, pacConfig)
+	if err != nil {
+		return "", err
+	}
+
+	ns, err := r.getNamespace(ctx, component.Namespace)
+	if err != nil {
+		log.Error(err, "failed to get the component namespace for setting custom parameter.")
+		return "", err
+	}
+	if val, ok := ns.Labels[appstudioWorkspaceNameLabelOldModel]; ok {
+		pacRepoAddParamWorkspaceNameOldModel(repository, val)
+	} else {
+		if val, ok := ns.Labels[konfluxWorkspaceNameLabel]; ok {
+			pacRepoAddParamWorkspaceNameOldModel(repository, val)
+		}
+	}
+
+	existingRepository := &pacv1alpha1.Repository{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: repository.Name, Namespace: repository.Namespace}, existingRepository)
+	if err == nil {
+		gitUrl := getGitRepoUrlOldModel(*component)
 
 		if existingRepository.Spec.URL == gitUrl {
 			return "", nil
@@ -304,6 +435,17 @@ func (r *ComponentBuildReconciler) getNamespace(ctx context.Context, name string
 	}
 }
 
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) getNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: name}, ns)
+	if err == nil {
+		return ns, nil
+	} else {
+		return nil, err
+	}
+}
+
 // pacRepoAddParamWorkspaceName adds custom parameter workspace name to a PaC repository.
 // Existing parameter will be overridden.
 func pacRepoAddParamWorkspaceName(repository *pacv1alpha1.Repository, workspaceName string) {
@@ -317,13 +459,13 @@ func pacRepoAddParamWorkspaceName(repository *pacv1alpha1.Repository, workspaceN
 	}
 	found := -1
 	for i, param := range params {
-		if param.Name == pacCustomParamAppstudioWorkspace {
+		if param.Name == pacCustomParamKonfluxWorkspace {
 			found = i
 			break
 		}
 	}
 	workspaceParam := pacv1alpha1.Params{
-		Name:  pacCustomParamAppstudioWorkspace,
+		Name:  pacCustomParamKonfluxWorkspace,
 		Value: workspaceName,
 	}
 	if found >= 0 {
@@ -334,15 +476,45 @@ func pacRepoAddParamWorkspaceName(repository *pacv1alpha1.Repository, workspaceN
 	repository.Spec.Params = &params
 }
 
-// TODO remove newModel handling after only new model is used
+// pacRepoAddParamWorkspaceNameOldModel adds custom parameter workspace name to a PaC repository.
+// Existing parameter will be overridden.
+// TODO remove after only new model is used and old model is gone
+func pacRepoAddParamWorkspaceNameOldModel(repository *pacv1alpha1.Repository, workspaceName string) {
+	var params []pacv1alpha1.Params
+	// Before pipelines-as-code gets upgraded for application-service to the
+	// version supporting custom parameters, this check must be taken.
+	if repository.Spec.Params == nil {
+		params = make([]pacv1alpha1.Params, 0)
+	} else {
+		params = *repository.Spec.Params
+	}
+	found := -1
+	for i, param := range params {
+		if param.Name == pacCustomParamKonfluxWorkspaceOldModel {
+			found = i
+			break
+		}
+	}
+	workspaceParam := pacv1alpha1.Params{
+		Name:  pacCustomParamKonfluxWorkspaceOldModel,
+		Value: workspaceName,
+	}
+	if found >= 0 {
+		params[found] = workspaceParam
+	} else {
+		params = append(params, workspaceParam)
+	}
+	repository.Spec.Params = &params
+}
+
 // generatePACRepository creates configuration of Pipelines as Code repository object.
-func generatePACRepository(component compapiv1alpha1.Component, config *corev1.Secret, repositorySettings *compapiv1alpha1.RepositorySettings, skipBuildsMap map[string]bool, newModel bool) (*pacv1alpha1.Repository, error) {
-	gitProvider, err := getGitProvider(component, newModel)
+func generatePACRepository(component compv1alpha1.Component, config *corev1.Secret, repositorySettings *compv1alpha1.RepositorySettings, skipBuildsMap map[string]bool) (*pacv1alpha1.Repository, error) {
+	gitProvider, err := getGitProvider(component)
 	if err != nil {
 		return nil, err
 	}
 
-	gitUrl := getGitRepoUrl(component, newModel)
+	gitUrl := getGitRepoUrl(component)
 	repositoryName, err := generatePaCRepositoryNameFromGitUrl(gitUrl)
 	if err != nil {
 		return nil, err
@@ -360,7 +532,7 @@ func generatePACRepository(component compapiv1alpha1.Component, config *corev1.S
 			},
 			WebhookSecret: &pacv1alpha1.Secret{
 				Name: pipelinesAsCodeWebhooksSecretName,
-				Key:  getWebhookSecretKeyForComponent(component, newModel),
+				Key:  getWebhookSecretKeyForComponent(component),
 			},
 		}
 
@@ -379,13 +551,7 @@ func generatePACRepository(component compapiv1alpha1.Component, config *corev1.S
 			}
 		} else {
 			// Get git provider URL from source URL.
-			var u *url.URL
-			var err error
-			if newModel {
-				u, err = url.Parse(component.Spec.Source.GitURL)
-			} else {
-				u, err = url.Parse(component.Spec.Source.GitSource.URL)
-			}
+			u, err := url.Parse(component.Spec.Source.GitURL)
 			if err != nil {
 				return nil, err
 			}
@@ -418,7 +584,7 @@ func generatePACRepository(component compapiv1alpha1.Component, config *corev1.S
 		},
 	}
 
-	if newModel && repositorySettings != nil {
+	if repositorySettings != nil {
 		if repositorySettings.CommentStrategy != "" {
 			repository.Spec.Settings.Github.CommentStrategy = repositorySettings.CommentStrategy
 			repository.Spec.Settings.Gitlab.CommentStrategy = repositorySettings.CommentStrategy
@@ -429,7 +595,7 @@ func generatePACRepository(component compapiv1alpha1.Component, config *corev1.S
 		}
 	}
 
-	if newModel && skipBuildsMap != nil {
+	if skipBuildsMap != nil {
 		params := []pacv1alpha1.Params{}
 		for revision, skipBuild := range skipBuildsMap {
 			applyParamFilter := getPaCParamFilterForRevision(revision)
@@ -441,13 +607,92 @@ func generatePACRepository(component compapiv1alpha1.Component, config *corev1.S
 	return repository, nil
 }
 
-// TODO remove newModel handling after only new model is used
-// cleanupPaCRepositoryIncomingsAndSkipBuildParams cleans up incomings and skip build params in Repository
-func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSkipBuildParams(ctx context.Context, component *compapiv1alpha1.Component) error {
-	log := ctrllog.FromContext(ctx)
-	newModel := true
+// TODO remove after only new model is used and old model is gone
+// generatePACRepositoryOldModel creates configuration of Pipelines as Code repository object.
+func generatePACRepositoryOldModel(component compapiv1alpha1.Component, config *corev1.Secret) (*pacv1alpha1.Repository, error) {
+	gitProvider, err := getGitProviderOldModel(component)
+	if err != nil {
+		return nil, err
+	}
 
-	repository, err := r.findPaCRepositoryForComponent(ctx, component, newModel)
+	gitUrl := getGitRepoUrlOldModel(component)
+	repositoryName, err := generatePaCRepositoryNameFromGitUrl(gitUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	isAppUsed := common.IsPaCApplicationConfigured(gitProvider, config.Data)
+
+	var gitProviderConfig *pacv1alpha1.GitProvider = nil
+	if !isAppUsed {
+		// Webhook is used
+		gitProviderConfig = &pacv1alpha1.GitProvider{
+			Secret: &pacv1alpha1.Secret{
+				Name: config.Name,
+				Key:  corev1.BasicAuthPasswordKey, // basic-auth secret type expected
+			},
+			WebhookSecret: &pacv1alpha1.Secret{
+				Name: pipelinesAsCodeWebhooksSecretName,
+				Key:  getWebhookSecretKeyForComponentOldModel(component),
+			},
+		}
+
+		// gitProviderType is needed for incoming webhook handling
+		gitProviderType := gitProvider
+		gitProviderConfig.Type = gitProviderType
+
+		var gitProviderUrl string
+		if providerUrlFromAnnotation, configured := component.Annotations[GitProviderAnnotationURL]; configured {
+			// Use git provider URL provided via the annotation.
+			// Make sure that the url has protocol as it's required.
+			if !strings.Contains(providerUrlFromAnnotation, "://") {
+				gitProviderUrl = "https://" + providerUrlFromAnnotation
+			} else {
+				gitProviderUrl = providerUrlFromAnnotation
+			}
+		} else {
+			// Get git provider URL from source URL.
+			u, err := url.Parse(component.Spec.Source.GitSource.URL)
+			if err != nil {
+				return nil, err
+			}
+			if u.Host == "github.com" || u.Host == "gitlab.com" {
+				// Do not attempt to override working defaults
+				gitProviderUrl = ""
+			} else {
+				gitProviderUrl = u.Scheme + "://" + u.Host
+			}
+		}
+		gitProviderConfig.URL = gitProviderUrl
+	}
+
+	repository := &pacv1alpha1.Repository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Repository",
+			APIVersion: "pipelinesascode.tekton.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      repositoryName,
+			Namespace: component.Namespace,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			URL:         gitUrl,
+			GitProvider: gitProviderConfig,
+			Settings: &pacv1alpha1.Settings{
+				Gitlab: &pacv1alpha1.GitlabSettings{},
+				Github: &pacv1alpha1.GithubSettings{},
+			},
+		},
+	}
+
+	return repository, nil
+}
+
+// cleanupPaCRepositoryIncomingsAndSkipBuildParams cleans up incomings and skip build params in Repository
+func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSkipBuildParams(ctx context.Context, component *compv1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return err
 	}
@@ -457,24 +702,47 @@ func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSkipBuildPara
 	}
 
 	// List all components in the namespace
-	componentList := &compapiv1alpha1.ComponentList{}
+	componentList := &compv1alpha1.ComponentList{}
 	if err := r.Client.List(ctx, componentList, &client.ListOptions{Namespace: component.Namespace}); err != nil {
 		log.Error(err, "failed to list Components", l.Action, l.ActionView)
 		return err
 	}
+	// TODO remove after only new model is used and old model is gone
+	componentListOld := &compapiv1alpha1.ComponentList{}
+	if err := r.Client.List(ctx, componentListOld, &client.ListOptions{Namespace: component.Namespace}); err != nil {
+		log.Error(err, "failed to list Components", l.Action, l.ActionView)
+		return err
+	}
 
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 
 	// Collect unique revisions from all components using the same repository
 	usedRevisions := make([]string, 0)
 	for _, comp := range componentList.Items {
-		compRepoUrl := getGitRepoUrl(comp, newModel)
+		// Skip components marked for removal
+		if comp.DeletionTimestamp != nil {
+			continue
+		}
+		compRepoUrl := getGitRepoUrl(comp)
 		if compRepoUrl == repoUrl {
 			// Collect revisions from Status.Versions
 			for _, version := range comp.Status.Versions {
 				if !slices.Contains(usedRevisions, version.Revision) {
 					usedRevisions = append(usedRevisions, version.Revision)
 				}
+			}
+		}
+	}
+	// TODO remove after only new model is used and old model is gone
+	for _, comp := range componentListOld.Items {
+		// Skip components marked for removal
+		if comp.DeletionTimestamp != nil {
+			continue
+		}
+		compRepoUrl := getGitRepoUrlOldModel(comp)
+		if compRepoUrl == repoUrl && comp.Spec.Source.GitSource.Revision != "" {
+			if !slices.Contains(usedRevisions, comp.Spec.Source.GitSource.Revision) {
+				usedRevisions = append(usedRevisions, comp.Spec.Source.GitSource.Revision)
 			}
 		}
 	}
@@ -536,38 +804,13 @@ func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSkipBuildPara
 	return nil
 }
 
-// TODO remove after only new model is used
-// cleanupPaCRepositoryIncomingsAndSecretOldModel is cleaning up incomings in Repository
+// TODO remove after only new model is used and old model is gone
+// cleanupPaCRepositoryIncomingsOldModel is cleaning up incomings in Repository
 // for unprovisioned component, and also removes incoming secret when no longer required
-func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSecretOldModel(ctx context.Context, component *compapiv1alpha1.Component, baseBranch string, newModel bool) error {
+func (r *ComponentBuildReconcilerOldModel) cleanupPaCRepositoryIncomingsOldModel(ctx context.Context, component *compapiv1alpha1.Component, baseBranch string) error {
 	log := ctrllog.FromContext(ctx)
 
-	// check if more components are using same repo with PaC enabled for incomings removal from repository
-	incomingsRepoTargetBranchCount := 0
-	incomingsRepoAllBranchesCount := 0
-	componentList := &compapiv1alpha1.ComponentList{}
-	if err := r.Client.List(ctx, componentList, &client.ListOptions{Namespace: component.Namespace}); err != nil {
-		log.Error(err, "failed to list Components", l.Action, l.ActionView)
-		return err
-	}
-	repoUrl := getGitRepoUrl(*component, newModel)
-
-	buildStatus := &BuildStatus{}
-	for _, comp := range componentList.Items {
-		if comp.Spec.Source.GitSource.URL == repoUrl {
-			buildStatus = readBuildStatus(component)
-			if buildStatus.PaC != nil && buildStatus.PaC.State == "enabled" {
-				incomingsRepoAllBranchesCount += 1
-
-				// revision can be empty and then use default branch
-				if comp.Spec.Source.GitSource.Revision == component.Spec.Source.GitSource.Revision || comp.Spec.Source.GitSource.Revision == baseBranch {
-					incomingsRepoTargetBranchCount += 1
-				}
-			}
-		}
-	}
-
-	repository, err := r.findPaCRepositoryForComponent(ctx, component, newModel)
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return err
 	}
@@ -577,63 +820,78 @@ func (r *ComponentBuildReconciler) cleanupPaCRepositoryIncomingsAndSecretOldMode
 		return nil
 	}
 
-	incomingSecretName := getPaCIncomingSecretName(repository.Name)
-	incomingUpdated := false
-	// update first in case there is multiple incoming entries, and it will be converted to incomings with just 1 entry
-	_ = updateIncoming(repository, incomingSecretName, pacIncomingSecretKey, baseBranch)
+	componentList := &compapiv1alpha1.ComponentList{}
+	if err := r.Client.List(ctx, componentList, &client.ListOptions{Namespace: component.Namespace}); err != nil {
+		log.Error(err, "failed to list Components", l.Action, l.ActionView)
+		return err
+	}
+	componentListNew := &compv1alpha1.ComponentList{}
+	if err := r.Client.List(ctx, componentListNew, &client.ListOptions{Namespace: component.Namespace}); err != nil {
+		log.Error(err, "failed to list Components", l.Action, l.ActionView)
+		return err
+	}
 
-	if len((*repository.Spec.Incomings)[0].Targets) > 1 {
-		// incoming contains target from the current component only
-		if slices.Contains((*repository.Spec.Incomings)[0].Targets, baseBranch) && incomingsRepoTargetBranchCount <= 1 {
-			newTargets := []string{}
-			for _, target := range (*repository.Spec.Incomings)[0].Targets {
-				if target != baseBranch {
-					newTargets = append(newTargets, target)
+	repoUrl := getGitRepoUrlOldModel(*component)
+
+	usedRevisions := make([]string, 0)
+	for _, comp := range componentList.Items {
+		// Skip components marked for removal
+		if comp.DeletionTimestamp != nil {
+			continue
+		}
+		compRepoUrl := getGitRepoUrlOldModel(comp)
+		if compRepoUrl == repoUrl {
+			compRevision := comp.Spec.Source.GitSource.Revision
+			if compRevision == "" {
+				compRevision = baseBranch
+			}
+			if !slices.Contains(usedRevisions, compRevision) {
+				usedRevisions = append(usedRevisions, compRevision)
+			}
+		}
+	}
+	for _, comp := range componentListNew.Items {
+		// Skip components marked for removal
+		if comp.DeletionTimestamp != nil {
+			continue
+		}
+		compRepoUrl := getGitRepoUrl(comp)
+		if compRepoUrl == repoUrl {
+			// Collect revisions from Status.Versions
+			for _, version := range comp.Status.Versions {
+				if !slices.Contains(usedRevisions, version.Revision) {
+					usedRevisions = append(usedRevisions, version.Revision)
 				}
 			}
-			(*repository.Spec.Incomings)[0].Targets = newTargets
-			incomingUpdated = true
-		}
-		// remove secret from incomings if just current component is using incomings in repository
-		if incomingsRepoAllBranchesCount <= 1 && incomingsRepoTargetBranchCount <= 1 {
-			(*repository.Spec.Incomings)[0].Secret = pacv1alpha1.Secret{}
-			incomingUpdated = true
-		}
-
-	} else {
-		// incomings has just 1 target and that target is from the current component only
-		if (*repository.Spec.Incomings)[0].Targets[0] == baseBranch && incomingsRepoTargetBranchCount <= 1 {
-			repository.Spec.Incomings = nil
-			incomingUpdated = true
 		}
 	}
 
-	if incomingUpdated {
+	incomingSecretName := getPaCIncomingSecretName(repository.Name)
+
+	// Consolidate multiple incoming entries into a single entry
+	// Use dummy revision if no revisions exist (it will be removed when we update Targets anyway)
+	dummyRevision := "dummy"
+	if len(usedRevisions) > 0 {
+		dummyRevision = usedRevisions[0]
+	}
+	// Ignore return value - we don't care if incomings changed, we just want to consolidate multiple entries into a single entry
+	_ = updateIncoming(repository, incomingSecretName, pacIncomingSecretKey, dummyRevision)
+
+	updateRequired := false
+	// Update repository incomings to only include used revisions
+	if repository.Spec.Incomings != nil && len(*repository.Spec.Incomings) > 0 {
+		// updateIncoming was called above to ensure there's only one entry, so we can safely access index [0]
+		// Set targets to used revisions (can be empty slice)
+		(*repository.Spec.Incomings)[0].Targets = usedRevisions
+		updateRequired = true
+	}
+
+	if updateRequired {
 		if err := r.Client.Update(ctx, repository); err != nil {
 			log.Error(err, "failed to update existing PaC repository with incomings", "PaCRepositoryName", repository.Name)
 			return err
 		}
-		log.Info("Removed incomings from the PaC repository", "PaCRepositoryName", repository.Name, l.Action, l.ActionUpdate)
-	}
-
-	// remove incoming secret if just current component is using incomings in repository
-	if incomingsRepoAllBranchesCount <= 1 && incomingsRepoTargetBranchCount <= 1 {
-		secret := &corev1.Secret{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}, secret); err != nil {
-			if !errors.IsNotFound(err) {
-				log.Error(err, "failed to get incoming secret", l.Action, l.ActionView)
-				return err
-			}
-			log.Info("incoming secret doesn't exist anymore, removal isn't required")
-		} else {
-			if err := r.Client.Delete(ctx, secret); err != nil {
-				if !errors.IsNotFound(err) {
-					log.Error(err, "failed to remove incoming secret", l.Action, l.ActionView)
-					return err
-				}
-			}
-			log.Info("incoming secret removed")
-		}
+		log.Info("Updated incomings in the PaC repository", "PaCRepositoryName", repository.Name, l.Action, l.ActionUpdate)
 	}
 	return nil
 }

--- a/internal/controller/component_build_controller_pipeline.go
+++ b/internal/controller/component_build_controller_pipeline.go
@@ -26,7 +26,8 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	oci "github.com/tektoncd/pipeline/pkg/remote/oci"
 
@@ -46,11 +47,19 @@ import (
 )
 
 type BuildPipeline struct {
-	Name                   string                                  `json:"name,omitempty"`
-	Bundle                 string                                  `json:"bundle,omitempty"`
-	AdditionalParams       []string                                `json:"additional-params,omitempty"`
-	PipelineRefGit         *compapiv1alpha1.PipelineRefGit         `json:"pipelineref-by-git-resolver,omitempty"`
-	PipelineSpecFromBundle *compapiv1alpha1.PipelineSpecFromBundle `json:"pipelinespec-from-bundle,omitempty"`
+	Name                   string                               `json:"name,omitempty"`
+	Bundle                 string                               `json:"bundle,omitempty"`
+	AdditionalParams       []string                             `json:"additional-params,omitempty"`
+	PipelineRefGit         *compv1alpha1.PipelineRefGit         `json:"pipelineref-by-git-resolver,omitempty"`
+	PipelineSpecFromBundle *compv1alpha1.PipelineSpecFromBundle `json:"pipelinespec-from-bundle,omitempty"`
+}
+
+// BuildPipelineOld pipeline type
+// TODO remove after only new model is used and old model is gone
+type BuildPipelineOld struct {
+	Name             string   `json:"name,omitempty"`
+	Bundle           string   `json:"bundle,omitempty"`
+	AdditionalParams []string `json:"additional-params,omitempty"`
 }
 
 type pipelineConfig struct {
@@ -58,22 +67,24 @@ type pipelineConfig struct {
 	Pipelines           []BuildPipeline `json:"pipelines"`
 }
 
-// TODO remove newModel handling after only new model is used
+// pipelineConfigOld config type
+// TODO remove after only new model is used and old model is gone
+type pipelineConfigOld struct {
+	DefaultPipelineName string             `json:"default-pipeline-name"`
+	Pipelines           []BuildPipelineOld `json:"pipelines"`
+}
+
 // generatePaCPipelineRunConfigs generates PipelineRun YAML configs for given component.
 // The generated PipelineRun Yaml content are returned in byte string and in the order of push and pull request.
-func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, pipelineDefinition *VersionPipelineDefinition) ([]byte, []byte, error) {
-	newModel := true
-
-	var err error
-
+func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Context, component *compv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, pipelineDefinition *VersionPipelineDefinition) ([]byte, []byte, error) {
 	// Get pull pipeline spec
-	pipelineSpecPull, err := getPipelineSpec(ctx, pipelineDefinition.Pull, component, versionInfo, gitClient, newModel, "pull")
+	pipelineSpecPull, err := getPipelineSpec(ctx, pipelineDefinition.Pull, component, versionInfo, gitClient, "pull")
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Get push pipeline spec
-	pipelineSpecPush, err := getPipelineSpec(ctx, pipelineDefinition.Push, component, versionInfo, gitClient, newModel, "push")
+	pipelineSpecPush, err := getPipelineSpec(ctx, pipelineDefinition.Push, component, versionInfo, gitClient, "push")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,7 +112,7 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigs(ctx context.Con
 
 // getPipelineSpec retrieves pipeline spec based on the pipeline definition
 // pipelineType should be "pull" or "push" for logging purposes
-func getPipelineSpec(ctx context.Context, pipelineDef *PipelineDef, component *compapiv1alpha1.Component, versionInfo *VersionInfo, gitClient gp.GitProviderClient, newModel bool, pipelineType string) (*tektonapi.PipelineSpec, error) {
+func getPipelineSpec(ctx context.Context, pipelineDef *PipelineDef, component *compv1alpha1.Component, versionInfo *VersionInfo, gitClient gp.GitProviderClient, pipelineType string) (*tektonapi.PipelineSpec, error) {
 	log := ctrllog.FromContext(ctx)
 	var pipelineSpec *tektonapi.PipelineSpec
 	var err error
@@ -121,7 +132,7 @@ func getPipelineSpec(ctx context.Context, pipelineDef *PipelineDef, component *c
 		log.Info(fmt.Sprintf("Got %s pipeline spec from GitRef for %s component, %s url, revision %s, pathInRepo %s",
 			pipelineType, component.Name, pipelineDef.PipelineRefGit.Url, pipelineDef.PipelineRefGit.Revision, pipelineDef.PipelineRefGit.PathInRepo), l.Audit, "true")
 	} else {
-		repoUrl := getGitRepoUrl(*component, newModel)
+		repoUrl := getGitRepoUrl(*component)
 		pipelineSpec = retrievePipelineSpecByName(ctx, repoUrl, versionInfo.Revision, pipelineDef.PipelineRefName, gitClient)
 		if pipelineSpec != nil {
 			log.Info(fmt.Sprintf("Got %s pipeline spec from Pipeline Name for %s component, pipeline name %s", pipelineType, component.Name, pipelineDef.PipelineRefName), l.Audit, "true")
@@ -131,10 +142,10 @@ func getPipelineSpec(ctx context.Context, pipelineDef *PipelineDef, component *c
 	return pipelineSpec, nil
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // generatePaCPipelineRunConfigsOldModel generates PipelineRun YAML configs for given component.
 // The generated PipelineRun Yaml content are returned in byte string and in the order of push and pull request.
-func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigsOldModel(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacTargetBranch string) ([]byte, []byte, error) {
+func (r *ComponentBuildReconcilerOldModel) generatePaCPipelineRunConfigsOldModel(ctx context.Context, component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, pacTargetBranch string) ([]byte, []byte, error) {
 	log := ctrllog.FromContext(ctx)
 
 	var pipelineName string
@@ -182,7 +193,7 @@ func (r *ComponentBuildReconciler) generatePaCPipelineRunConfigsOldModel(ctx con
 }
 
 // retrievePipelineSpecFromGit retrieves pipeline definition from a git repository using git resolver parameters.
-func retrievePipelineSpecFromGit(ctx context.Context, pipelineRefGit *compapiv1alpha1.PipelineRefGit, gitClient gp.GitProviderClient) (*tektonapi.PipelineSpec, error) {
+func retrievePipelineSpecFromGit(ctx context.Context, pipelineRefGit *compv1alpha1.PipelineRefGit, gitClient gp.GitProviderClient) (*tektonapi.PipelineSpec, error) {
 	log := ctrllog.FromContext(ctx)
 
 	// Check if the pipeline file exists
@@ -306,7 +317,8 @@ func (r *ComponentBuildReconciler) GetDefaultBuildPipelinesFromConfig(ctx contex
 }
 
 // GetBuildPipelineFromComponentAnnotation parses pipeline annotation on component and returns build pipeline
-func (r *ComponentBuildReconciler) GetBuildPipelineFromComponentAnnotation(ctx context.Context, component *compapiv1alpha1.Component) (*tektonapi.PipelineRef, []string, error) {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) GetBuildPipelineFromComponentAnnotation(ctx context.Context, component *compapiv1alpha1.Component) (*tektonapi.PipelineRef, []string, error) {
 	buildPipeline, err := readBuildPipelineAnnotation(component)
 	if err != nil {
 		return nil, nil, err
@@ -330,7 +342,7 @@ func (r *ComponentBuildReconciler) GetBuildPipelineFromComponentAnnotation(ctx c
 		return nil, nil, err
 	}
 
-	buildPipelineData := &pipelineConfig{}
+	buildPipelineData := &pipelineConfigOld{}
 	if err := yaml.Unmarshal([]byte(pipelinesConfigMap.Data[buildPipelineConfigName]), buildPipelineData); err != nil {
 		return nil, nil, boerrors.NewBuildOpError(boerrors.EBuildPipelineConfigNotValid, err)
 	}
@@ -364,14 +376,15 @@ func (r *ComponentBuildReconciler) GetBuildPipelineFromComponentAnnotation(ctx c
 	return pipelineRef, additionalParams, nil
 }
 
-func readBuildPipelineAnnotation(component *compapiv1alpha1.Component) (*BuildPipeline, error) {
+// TODO remove after only new model is used and old model is gone
+func readBuildPipelineAnnotation(component *compapiv1alpha1.Component) (*BuildPipelineOld, error) {
 	if component.Annotations == nil {
 		return nil, nil
 	}
 
 	requestedPipeline, requestedPipelineExists := component.Annotations[defaultBuildPipelineAnnotation]
 	if requestedPipelineExists && requestedPipeline != "" {
-		buildPipeline := &BuildPipeline{}
+		buildPipeline := &BuildPipelineOld{}
 		buildPipelineBytes := []byte(requestedPipeline)
 
 		if err := json.Unmarshal(buildPipelineBytes, buildPipeline); err != nil {
@@ -383,7 +396,8 @@ func readBuildPipelineAnnotation(component *compapiv1alpha1.Component) (*BuildPi
 }
 
 // SetDefaultBuildPipelineComponentAnnotation sets default build pipeline to component pipeline annotation
-func (r *ComponentBuildReconciler) SetDefaultBuildPipelineComponentAnnotation(ctx context.Context, component *compapiv1alpha1.Component) error {
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) SetDefaultBuildPipelineComponentAnnotation(ctx context.Context, component *compapiv1alpha1.Component) error {
 	log := ctrllog.FromContext(ctx)
 	pipelinesConfigMap := &corev1.ConfigMap{}
 
@@ -394,7 +408,7 @@ func (r *ComponentBuildReconciler) SetDefaultBuildPipelineComponentAnnotation(ct
 		return err
 	}
 
-	buildPipelineData := &pipelineConfig{}
+	buildPipelineData := &pipelineConfigOld{}
 	if err := yaml.Unmarshal([]byte(pipelinesConfigMap.Data[buildPipelineConfigName]), buildPipelineData); err != nil {
 		return boerrors.NewBuildOpError(boerrors.EBuildPipelineConfigNotValid, err)
 	}
@@ -413,17 +427,15 @@ func (r *ComponentBuildReconciler) SetDefaultBuildPipelineComponentAnnotation(ct
 	return nil
 }
 
-// TODO remove newModel handling after only new model is used
 // generatePaCPipelineRunForComponent returns pipeline run definition to build component source with.
 // Generated pipeline run contains placeholders that are expanded by Pipeline-as-Code.
 func generatePaCPipelineRunForComponent(
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	pipelineSpec *tektonapi.PipelineSpec,
 	pipelineDefinition *PipelineDef,
 	versionInfo *VersionInfo,
 	gitClient gp.GitProviderClient,
 	onPull bool) (*tektonapi.PipelineRun, error) {
-	newModel := true
 
 	if versionInfo.Revision == "" {
 		return nil, fmt.Errorf("target branch can't be empty for generating PaC PipelineRun for component %s, version %s", component.Name, versionInfo.SanitizedVersion)
@@ -432,12 +444,12 @@ func generatePaCPipelineRunForComponent(
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cel expression for pipeline: %w", err)
 	}
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 
 	annotations := map[string]string{
 		"pipelinesascode.tekton.dev/cancel-in-progress": "false",
 		"pipelinesascode.tekton.dev/max-keep-runs":      "3",
-		"build.appstudio.redhat.com/target_branch":      "{{target_branch}}",
+		gitTargetBranchAnnotationName:                   "{{target_branch}}",
 		pacCelExpressionAnnotationName:                  pipelineCelExpression,
 		gitCommitShaAnnotationName:                      "{{revision}}",
 		gitRepoAtShaAnnotationName:                      gitClient.GetBrowseRepositoryAtShaLink(repoUrl, "{{revision}}"),
@@ -454,7 +466,7 @@ func generatePaCPipelineRunForComponent(
 	var outputImageWithTag string
 	if onPull {
 		annotations["pipelinesascode.tekton.dev/cancel-in-progress"] = "true"
-		annotations["build.appstudio.redhat.com/pull_request_number"] = "{{pull_request_number}}"
+		annotations[gitPRAnnotationName] = "{{pull_request_number}}"
 		outputImageWithTag = imageRepo + ":on-pr-{{revision}}"
 	} else {
 		outputImageWithTag = imageRepo + ":{{revision}}"
@@ -505,7 +517,7 @@ func generatePaCPipelineRunForComponent(
 	}
 
 	if slices.Contains(paramsInSpec, "dockerfile") {
-		params = append(params, tektonapi.Param{Name: "dockerfile", Value: tektonapi.ParamValue{Type: "string", StringVal: versionInfo.DockerfileURI}})
+		params = append(params, tektonapi.Param{Name: "dockerfile", Value: tektonapi.ParamValue{Type: "string", StringVal: versionInfo.DockerfilePath}})
 	}
 
 	pathContext := getPathContext(versionInfo.Context, "")
@@ -569,7 +581,7 @@ func generatePaCPipelineRunForComponent(
 	return pipelineRun, nil
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // generatePaCPipelineRunForComponentOldModel returns pipeline run definition to build component source with.
 // Generated pipeline run contains placeholders that are expanded by Pipeline-as-Code.
 func generatePaCPipelineRunForComponentOldModel(
@@ -579,7 +591,6 @@ func generatePaCPipelineRunForComponentOldModel(
 	pacTargetBranch string,
 	gitClient gp.GitProviderClient,
 	onPull bool) (*tektonapi.PipelineRun, error) {
-	newModel := false
 
 	if pacTargetBranch == "" {
 		return nil, fmt.Errorf("target branch can't be empty for generating PaC PipelineRun for: %v", component)
@@ -588,29 +599,29 @@ func generatePaCPipelineRunForComponentOldModel(
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cel expression for pipeline: %w", err)
 	}
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrlOldModel(*component)
 
 	annotations := map[string]string{
 		"pipelinesascode.tekton.dev/cancel-in-progress": "false",
 		"pipelinesascode.tekton.dev/max-keep-runs":      "3",
-		"build.appstudio.redhat.com/target_branch":      "{{target_branch}}",
+		gitTargetBranchAnnotationNameOldModel:           "{{target_branch}}",
 		pacCelExpressionAnnotationName:                  pipelineCelExpression,
-		gitCommitShaAnnotationName:                      "{{revision}}",
-		gitRepoAtShaAnnotationName:                      gitClient.GetBrowseRepositoryAtShaLink(repoUrl, "{{revision}}"),
+		gitCommitShaAnnotationNameOldModel:              "{{revision}}",
+		gitRepoAtShaAnnotationNameOldModel:              gitClient.GetBrowseRepositoryAtShaLink(repoUrl, "{{revision}}"),
 	}
 	labels := map[string]string{
-		ApplicationNameLabelName:                component.Spec.Application,
-		ComponentNameLabelName:                  component.Name,
-		"pipelines.appstudio.openshift.io/type": "build",
+		ApplicationNameLabelName:         component.Spec.Application,
+		ComponentNameLabelNameOldModel:   component.Name,
+		PipelineRunTypeLabelNameOldModel: "build",
 	}
 
-	imageRepo := getContainerImageRepositoryForComponent(component)
-	pipelineName := getPipelineRunDefinitionName(component.Name, "", onPull)
+	imageRepo := getContainerImageRepositoryForComponentOldModel(component)
+	pipelineName := getPipelineRunDefinitionNameOldModel(component.Name, onPull)
 
 	var proposedImage string
 	if onPull {
 		annotations["pipelinesascode.tekton.dev/cancel-in-progress"] = "true"
-		annotations["build.appstudio.redhat.com/pull_request_number"] = "{{pull_request_number}}"
+		annotations[gitPRAnnotationNameOldModel] = "{{pull_request_number}}"
 		proposedImage = imageRepo + ":on-pr-{{revision}}"
 	} else {
 		proposedImage = imageRepo + ":{{revision}}"
@@ -752,14 +763,12 @@ func generateVolumeClaimTemplate() *corev1.PersistentVolumeClaim {
 	}
 }
 
-// TODO remove newModel handling after only new model is used
 // generateCelExpressionForPipeline generates value for pipelinesascode.tekton.dev/on-cel-expression annotation
 // in order to have better flexibility with git events filtering.
 // Examples of returned values:
 // event == "push" && target_branch == "main"
 // event == "pull_request" && target_branch == "my-branch" && ( "component-src-dir/***".pathChanged() || ".tekton/pipeline.yaml".pathChanged() || "dockerfiles/my-component/Dockerfile".pathChanged() )
-func generateCelExpressionForPipeline(component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, onPull bool) (string, error) {
-	newModel := true
+func generateCelExpressionForPipeline(component *compv1alpha1.Component, gitClient gp.GitProviderClient, versionInfo *VersionInfo, onPull bool) (string, error) {
 	eventType := "push"
 	if onPull {
 		eventType = "pull_request"
@@ -769,7 +778,7 @@ func generateCelExpressionForPipeline(component *compapiv1alpha1.Component, gitC
 	targetBranchCondition := fmt.Sprintf(`target_branch == "%s"`, versionInfo.Revision)
 	buildEnabledCondition := fmt.Sprintf(`%s == "true"`, BuildsEnabledParamName)
 
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrl(*component)
 
 	// Set path changed event filtering only for Components that are stored within a directory of the git repository.
 	pathChangedSuffix := ""
@@ -782,7 +791,7 @@ func generateCelExpressionForPipeline(component *compapiv1alpha1.Component, gitC
 		// If a Dockerfile is defined for the Component,
 		// we should rebuild the Component if the Dockerfile has been changed.
 		dockerfilePathChangedSuffix := ""
-		dockerfile := versionInfo.DockerfileURI
+		dockerfile := versionInfo.DockerfilePath
 		if dockerfile != "" {
 			// dockerfile could be relative to the context directory or repository root.
 			// To avoid unessesary builds, it's required to pass absolute path to the Dockerfile.
@@ -808,14 +817,13 @@ func generateCelExpressionForPipeline(component *compapiv1alpha1.Component, gitC
 	return fmt.Sprintf("%s && %s && %s%s", eventCondition, targetBranchCondition, buildEnabledCondition, pathChangedSuffix), nil
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // generateCelExpressionForPipelineOldModel generates value for pipelinesascode.tekton.dev/on-cel-expression annotation
 // in order to have better flexibility with git events filtering.
 // Examples of returned values:
 // event == "push" && target_branch == "main"
 // event == "pull_request" && target_branch == "my-branch" && ( "component-src-dir/***".pathChanged() || ".tekton/pipeline.yaml".pathChanged() || "dockerfiles/my-component/Dockerfile".pathChanged() )
 func generateCelExpressionForPipelineOldModel(component *compapiv1alpha1.Component, gitClient gp.GitProviderClient, targetBranch string, onPull bool) (string, error) {
-	newModel := false
 	eventType := "push"
 	if onPull {
 		eventType = "pull_request"
@@ -823,7 +831,7 @@ func generateCelExpressionForPipelineOldModel(component *compapiv1alpha1.Compone
 	eventCondition := fmt.Sprintf(`event == "%s"`, eventType)
 
 	targetBranchCondition := fmt.Sprintf(`target_branch == "%s"`, targetBranch)
-	repoUrl := getGitRepoUrl(*component, newModel)
+	repoUrl := getGitRepoUrlOldModel(*component)
 
 	// Set path changed event filtering only for Components that are stored within a directory of the git repository.
 	pathChangedSuffix := ""
@@ -857,7 +865,7 @@ func generateCelExpressionForPipelineOldModel(component *compapiv1alpha1.Compone
 			}
 		}
 
-		pipelineFileName := getPipelineRunDefinitionFileName(component.Name, "", onPull)
+		pipelineFileName := getPipelineRunDefinitionFileNameOldModel(component.Name, onPull)
 
 		pathChangedSuffix = fmt.Sprintf(` && ( "%s***".pathChanged() || ".tekton/%s".pathChanged() %s)`, contextDir, pipelineFileName, dockerfilePathChangedSuffix)
 	}
@@ -865,7 +873,15 @@ func generateCelExpressionForPipelineOldModel(component *compapiv1alpha1.Compone
 	return fmt.Sprintf("%s && %s%s", eventCondition, targetBranchCondition, pathChangedSuffix), nil
 }
 
-func getContainerImageRepositoryForComponent(component *compapiv1alpha1.Component) string {
+func getContainerImageRepositoryForComponent(component *compv1alpha1.Component) string {
+	if component.Spec.ContainerImage != "" {
+		return getContainerImageRepository(component.Spec.ContainerImage)
+	}
+	return ""
+}
+
+// TODO remove after only new model is used and old model is gone
+func getContainerImageRepositoryForComponentOldModel(component *compapiv1alpha1.Component) string {
 	if component.Spec.ContainerImage != "" {
 		return getContainerImageRepository(component.Spec.ContainerImage)
 	}
@@ -912,30 +928,40 @@ func getPipelineNameAndBundle(pipelineRef *tektonapi.PipelineRef) (string, strin
 	return name, bundle, nil
 }
 
-// TODO remove newModel handling after only new model is used
 // getPipelineRunDefinitionFileName returns pipeline run definition filename of the given Component.
 func getPipelineRunDefinitionFileName(componentName, versionName string, isPullRequest bool) string {
 	pipelineNameSuffix := pipelineRunOnPushFilename
 	if isPullRequest {
 		pipelineNameSuffix = pipelineRunOnPRFilename
 	}
-	if versionName != "" {
-		return componentName + "-" + versionName + "-" + pipelineNameSuffix
-	} else {
-		return componentName + "-" + pipelineNameSuffix
-	}
+	return componentName + "-" + versionName + "-" + pipelineNameSuffix
 }
 
-// TODO remove newModel handling after only new model is used
+// TODO remove after only new model is used and old model is gone
+// getPipelineRunDefinitionFileNameOldModel returns pipeline run definition filename of the given Component.
+func getPipelineRunDefinitionFileNameOldModel(componentName string, isPullRequest bool) string {
+	pipelineNameSuffix := pipelineRunOnPushFilename
+	if isPullRequest {
+		pipelineNameSuffix = pipelineRunOnPRFilename
+	}
+	return componentName + "-" + pipelineNameSuffix
+}
+
 // getPipelineRunDefinitionName generates the pipeline run definition name for the given component.
 func getPipelineRunDefinitionName(componentName, versionName string, isPullRequest bool) string {
 	pipelineNameSuffix := pipelineRunOnPushSuffix
 	if isPullRequest {
 		pipelineNameSuffix = pipelineRunOnPRSuffix
 	}
-	if versionName != "" {
-		return componentName + "-" + versionName + pipelineNameSuffix
-	} else {
-		return componentName + pipelineNameSuffix
+	return componentName + "-" + versionName + pipelineNameSuffix
+}
+
+// TODO remove after only new model is used and old model is gone
+// getPipelineRunDefinitionNameOldModel generates the pipeline run definition name for the given component.
+func getPipelineRunDefinitionNameOldModel(componentName string, isPullRequest bool) string {
+	pipelineNameSuffix := pipelineRunOnPushSuffix
+	if isPullRequest {
+		pipelineNameSuffix = pipelineRunOnPRSuffix
 	}
+	return componentName + pipelineNameSuffix
 }

--- a/internal/controller/component_build_controller_secrets.go
+++ b/internal/controller/component_build_controller_secrets.go
@@ -23,7 +23,8 @@ import (
 	"fmt"
 	"regexp"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,14 +40,14 @@ import (
 
 // ensureIncomingSecret is ensuring that incoming secret for PaC trigger exists
 // if secret doesn't exists it will create it and also add repository as owner
-// TODO remove newModel handling after only new model is used
 // Returns:
 // pointer to secret object
 // bool which indicates if reconcile is required (which is required when we just created secret)
-func (r *ComponentBuildReconciler) ensureIncomingSecret(ctx context.Context, component *compapiv1alpha1.Component, newModel bool) (*corev1.Secret, bool, error) {
+// nolint:dupl
+func (r *ComponentBuildReconciler) ensureIncomingSecret(ctx context.Context, component *compv1alpha1.Component) (*corev1.Secret, bool, error) {
 	log := ctrllog.FromContext(ctx)
 
-	repository, err := r.findPaCRepositoryForComponent(ctx, component, newModel)
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
 	if err != nil {
 		return nil, false, err
 	}
@@ -89,18 +90,100 @@ func (r *ComponentBuildReconciler) ensureIncomingSecret(ctx context.Context, com
 	return &secret, false, nil
 }
 
-// TODO remove newModel handling after only new model is used
-func (r *ComponentBuildReconciler) lookupPaCSecret(ctx context.Context, component *compapiv1alpha1.Component, gitProvider string, newModel bool) (*corev1.Secret, error) {
+// ensureIncomingSecret is ensuring that incoming secret for PaC trigger exists
+// if secret doesn't exists it will create it and also add repository as owner
+// TODO remove after only new model is used and old model is gone
+// Returns:
+// pointer to secret object
+// bool which indicates if reconcile is required (which is required when we just created secret)
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) ensureIncomingSecret(ctx context.Context, component *compapiv1alpha1.Component) (*corev1.Secret, bool, error) {
 	log := ctrllog.FromContext(ctx)
 
-	repoUrl := getGitRepoUrl(*component, newModel)
-	var scmComponent *git.ScmComponent
-	var err error
-	if newModel {
-		scmComponent, err = git.NewScmComponent(gitProvider, repoUrl, "", component.Name, component.Namespace)
-	} else {
-		scmComponent, err = git.NewScmComponent(gitProvider, repoUrl, component.Spec.Source.GitSource.Revision, component.Name, component.Namespace)
+	repository, err := r.findPaCRepositoryForComponent(ctx, component)
+	if err != nil {
+		return nil, false, err
 	}
+
+	incomingSecretName := getPaCIncomingSecretName(repository.Name)
+	incomingSecretPassword := generatePaCWebhookSecretString()
+	incomingSecretData := map[string]string{
+		pacIncomingSecretKey: incomingSecretPassword,
+	}
+
+	secret := corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}, &secret); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to get incoming secret", l.Action, l.ActionView)
+			return nil, false, err
+		}
+		// Create incoming secret
+		secret = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      incomingSecretName,
+				Namespace: component.Namespace,
+			},
+			Type:       corev1.SecretTypeOpaque,
+			StringData: incomingSecretData,
+		}
+
+		if err := controllerutil.SetOwnerReference(repository, &secret, r.Scheme); err != nil {
+			log.Error(err, "failed to set owner for incoming secret")
+			return nil, false, err
+		}
+
+		if err := r.Client.Create(ctx, &secret); err != nil {
+			log.Error(err, "failed to create incoming secret", l.Action, l.ActionAdd)
+			return nil, false, err
+		}
+
+		log.Info("incoming secret created")
+		return &secret, true, nil
+	}
+	return &secret, false, nil
+}
+
+func (r *ComponentBuildReconciler) lookupPaCSecret(ctx context.Context, component *compv1alpha1.Component, gitProvider string) (*corev1.Secret, error) {
+	log := ctrllog.FromContext(ctx)
+
+	repoUrl := getGitRepoUrl(*component)
+	scmComponent, err := git.NewScmComponent(gitProvider, repoUrl, "", component.Name, component.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	// find the best matching secret, starting from SSH type
+	secret, err := r.CredentialProvider.LookupSecret(ctx, scmComponent, corev1.SecretTypeSSHAuth)
+	if err != nil && !boerrors.IsBuildOpError(err, boerrors.EComponentGitSecretMissing) {
+		log.Error(err, "failed to get Pipelines as Code SSH secret", "scmComponent", scmComponent)
+		return nil, err
+	}
+	if secret != nil {
+		return secret, nil
+	}
+	// find the best matching secret, starting from BasicAuth type
+	secret, err = r.CredentialProvider.LookupSecret(ctx, scmComponent, corev1.SecretTypeBasicAuth)
+	if err != nil && !boerrors.IsBuildOpError(err, boerrors.EComponentGitSecretMissing) {
+		log.Error(err, "failed to get Pipelines as Code BasicAuth secret", "scmComponent", scmComponent)
+		return nil, err
+	}
+	if secret != nil {
+		return secret, nil
+	}
+
+	// No SCM secrets found in the component namespace, fall back to the global configuration
+	if gitProvider == "github" {
+		return r.lookupGHAppSecret(ctx)
+	} else {
+		return nil, boerrors.NewBuildOpError(boerrors.EPaCSecretNotFound, fmt.Errorf("no matching Pipelines as Code secrets found in %s namespace", component.Namespace))
+	}
+}
+
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) lookupPaCSecret(ctx context.Context, component *compapiv1alpha1.Component, gitProvider string) (*corev1.Secret, error) {
+	log := ctrllog.FromContext(ctx)
+
+	repoUrl := getGitRepoUrlOldModel(*component)
+	scmComponent, err := git.NewScmComponent(gitProvider, repoUrl, component.Spec.Source.GitSource.Revision, component.Name, component.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -147,10 +230,27 @@ func (r *ComponentBuildReconciler) lookupGHAppSecret(ctx context.Context) (*core
 	return pacSecret, nil
 }
 
-// TODO remove newModel handling after only new model is used
+// TODO remove after only new model is used and old model is gone
+func (r *ComponentBuildReconcilerOldModel) lookupGHAppSecret(ctx context.Context) (*corev1.Secret, error) {
+	pacSecret := &corev1.Secret{}
+	globalPaCSecretKey := types.NamespacedName{Namespace: common.BuildServiceNamespaceName, Name: common.PipelinesAsCodeGitHubAppSecretName}
+	if err := r.Client.Get(ctx, globalPaCSecretKey, pacSecret); err != nil {
+		if !errors.IsNotFound(err) {
+			r.EventRecorder.Eventf(pacSecret, nil, "Warning", "ErrorReadingPaCSecret", "ReadPaCSecret", err.Error())
+			return nil, fmt.Errorf("failed to get Pipelines as Code secret in %s namespace: %w", globalPaCSecretKey.Namespace, err)
+		}
+
+		r.EventRecorder.Eventf(pacSecret, nil, "Warning", "PaCSecretNotFound", "ReadPaCSecret", err.Error())
+		// Do not trigger a new reconcile. The PaC secret must be created first.
+		return nil, boerrors.NewBuildOpError(boerrors.EPaCSecretNotFound, fmt.Errorf(" Pipelines as Code secret not found in %s ", globalPaCSecretKey.Namespace))
+	}
+	return pacSecret, nil
+}
+
 // Returns webhook secret for given component.
 // Generates the webhook secret and saves it in the k8s secret if it doesn't exist.
-func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, component *compapiv1alpha1.Component, newModel bool) (string, error) {
+// nolint:dupl
+func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, component *compv1alpha1.Component) (string, error) {
 	log := ctrllog.FromContext(ctx)
 
 	webhookSecretsSecret := &corev1.Secret{}
@@ -161,7 +261,7 @@ func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, comp
 					Name:      pipelinesAsCodeWebhooksSecretName,
 					Namespace: component.Namespace,
 					Labels: map[string]string{
-						PartOfLabelName: PartOfAppStudioLabelValue,
+						PartOfLabelName: PartOfKonfluxLabelValue,
 					},
 				},
 			}
@@ -169,14 +269,14 @@ func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, comp
 				log.Error(err, "failed to create webhooks secrets secret", l.Action, l.ActionAdd)
 				return "", err
 			}
-			return r.ensureWebhookSecret(ctx, component, newModel)
+			return r.ensureWebhookSecret(ctx, component)
 		}
 
 		log.Error(err, "failed to get webhook secrets secret", l.Action, l.ActionView)
 		return "", err
 	}
 
-	componentWebhookSecretKey := getWebhookSecretKeyForComponent(*component, newModel)
+	componentWebhookSecretKey := getWebhookSecretKeyForComponent(*component)
 	if _, exists := webhookSecretsSecret.Data[componentWebhookSecretKey]; exists {
 		// The webhook secret already exists. Use single secret for the same repository.
 		return string(webhookSecretsSecret.Data[componentWebhookSecretKey]), nil
@@ -196,9 +296,66 @@ func (r *ComponentBuildReconciler) ensureWebhookSecret(ctx context.Context, comp
 	return webhookSecretString, nil
 }
 
-// TODO remove newModel handling after only new model is used
-func getWebhookSecretKeyForComponent(component compapiv1alpha1.Component, newModel bool) string {
-	gitRepoUrl := getGitRepoUrl(component, newModel)
+// TODO remove after only new model is used and old model is gone
+// Returns webhook secret for given component.
+// Generates the webhook secret and saves it in the k8s secret if it doesn't exist.
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) ensureWebhookSecret(ctx context.Context, component *compapiv1alpha1.Component) (string, error) {
+	log := ctrllog.FromContext(ctx)
+
+	webhookSecretsSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: pipelinesAsCodeWebhooksSecretName, Namespace: component.Namespace}, webhookSecretsSecret); err != nil {
+		if errors.IsNotFound(err) {
+			webhookSecretsSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pipelinesAsCodeWebhooksSecretName,
+					Namespace: component.Namespace,
+					Labels: map[string]string{
+						PartOfLabelName: PartOfKonfluxLabelValue,
+					},
+				},
+			}
+			if err := r.Client.Create(ctx, webhookSecretsSecret); err != nil {
+				log.Error(err, "failed to create webhooks secrets secret", l.Action, l.ActionAdd)
+				return "", err
+			}
+			return r.ensureWebhookSecret(ctx, component)
+		}
+
+		log.Error(err, "failed to get webhook secrets secret", l.Action, l.ActionView)
+		return "", err
+	}
+
+	componentWebhookSecretKey := getWebhookSecretKeyForComponentOldModel(*component)
+	if _, exists := webhookSecretsSecret.Data[componentWebhookSecretKey]; exists {
+		// The webhook secret already exists. Use single secret for the same repository.
+		return string(webhookSecretsSecret.Data[componentWebhookSecretKey]), nil
+	}
+
+	webhookSecretString := generatePaCWebhookSecretString()
+
+	if webhookSecretsSecret.Data == nil {
+		webhookSecretsSecret.Data = make(map[string][]byte)
+	}
+	webhookSecretsSecret.Data[componentWebhookSecretKey] = []byte(webhookSecretString)
+	if err := r.Client.Update(ctx, webhookSecretsSecret); err != nil {
+		log.Error(err, "failed to update webhook secrets secret", l.Action, l.ActionUpdate)
+		return "", err
+	}
+
+	return webhookSecretString, nil
+}
+
+func getWebhookSecretKeyForComponent(component compv1alpha1.Component) string {
+	gitRepoUrl := getGitRepoUrl(component)
+
+	notAllowedCharRegex := regexp.MustCompile("[^-._a-zA-Z0-9]{1}")
+	return notAllowedCharRegex.ReplaceAllString(gitRepoUrl, "_")
+}
+
+// TODO remove after only new model is used and old model is gone
+func getWebhookSecretKeyForComponentOldModel(component compapiv1alpha1.Component) string {
+	gitRepoUrl := getGitRepoUrlOldModel(component)
 
 	notAllowedCharRegex := regexp.MustCompile("[^-._a-zA-Z0-9]{1}")
 	return notAllowedCharRegex.ReplaceAllString(gitRepoUrl, "_")

--- a/internal/controller/component_build_controller_service_account.go
+++ b/internal/controller/component_build_controller_service_account.go
@@ -31,7 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // TODO remove after only new model is used and old model is gone
 	l "github.com/konflux-ci/build-service/pkg/logs"
 	imgcv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
 )
@@ -40,7 +41,8 @@ const (
 	BuildPipelineClusterRoleName = "appstudio-pipelines-runner"
 	buildPipelineRoleBindingName = "konflux-pipelines-runner-bindings"
 
-	commonBuildSecretLabelName = "build.appstudio.openshift.io/common-secret"
+	commonBuildSecretLabelNameOldModel = "build.appstudio.openshift.io/common-secret"
+	commonBuildSecretLabelName         = "build.konflux-ci.dev/common-secret"
 
 	imageRepositoryComponentLabelName = "appstudio.redhat.com/component"
 )
@@ -54,7 +56,8 @@ func getBuildPipelineServiceAccountName(componentName string) string {
 // EnsureBuildPipelineServiceAccount checks if dedicated Service Account for Component build pipelines and
 // corresponding Role Binding to appstudio-pipeline-runner Cluster Role exists.
 // If a resource missing, it will be created.
-func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context.Context, component *compapiv1alpha1.Component, ensureNudging bool) error {
+// nolint:dupl
+func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context.Context, component *compv1alpha1.Component) error {
 	log := ctrllog.FromContext(ctx).WithName("buildSA-provision")
 
 	// Verify build pipeline Service Account
@@ -86,7 +89,7 @@ func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context
 			return err
 		}
 	} else {
-		// TODO remove after new component model migration is done and old model is gone
+		// TODO remove after only new model is used and old model is gone
 		// Service Account already exists, add ownership if it isn't there already
 		ownershipFound := false
 		for _, owner := range buildPipelinesServiceAccount.ObjectMeta.OwnerReferences {
@@ -109,7 +112,75 @@ func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context
 		}
 	}
 
-	// TODO remove after for new component model
+	if err := r.ensureBuildPipelineServiceAccountBinding(ctx, component); err != nil {
+		log.Error(err, "failed to ensure role binding for build pipleine Service Account")
+		return err
+	}
+
+	return nil
+}
+
+// EnsureBuildPipelineServiceAccount checks if dedicated Service Account for Component build pipelines and
+// corresponding Role Binding to appstudio-pipeline-runner Cluster Role exists.
+// If a resource missing, it will be created.
+// TODO remove after only new model is used and old model is gone
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) EnsureBuildPipelineServiceAccount(ctx context.Context, component *compapiv1alpha1.Component, ensureNudging bool) error {
+	log := ctrllog.FromContext(ctx).WithName("buildSA-provision")
+
+	// Verify build pipeline Service Account
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
+	buildPipelinesServiceAccount := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, buildPipelinesServiceAccount); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, fmt.Sprintf("failed to read build pipeline Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionView)
+			return err
+		}
+
+		// Service Account for Component build pipelines doesn't exist.
+		// Create Service Account for the build pipeline.
+		buildPipelineSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      buildPipelineServiceAccountName,
+				Namespace: component.Namespace,
+			},
+		}
+		if err := controllerutil.SetOwnerReference(component, buildPipelineSA, r.Scheme); err != nil {
+			log.Error(err, "failed to add owner reference to build pipeline Service Account")
+			return err
+		}
+		if err := r.linkCommonSecretsToBuildPipelineServiceAccount(ctx, buildPipelineSA); err != nil {
+			return err
+		}
+		if err := r.Client.Create(ctx, buildPipelineSA); err != nil {
+			log.Error(err, fmt.Sprintf("failed to create Service Account %s in namespace %s", buildPipelineServiceAccountName, component.Namespace), l.Action, l.ActionAdd)
+			return err
+		}
+	} else {
+		// TODO remove after only new model is used and old model is gone
+		// Service Account already exists, add ownership if it isn't there already
+		ownershipFound := false
+		for _, owner := range buildPipelinesServiceAccount.ObjectMeta.OwnerReferences {
+			if owner.UID == component.UID {
+				ownershipFound = true
+				break
+			}
+		}
+		if !ownershipFound {
+			if err := controllerutil.SetOwnerReference(component, buildPipelinesServiceAccount, r.Scheme); err != nil {
+				log.Error(err, "failed to add owner reference to build pipeline Service Account")
+				return err
+			}
+
+			if err := r.Client.Update(ctx, buildPipelinesServiceAccount); err != nil {
+				log.Error(err, "failed to update build pipeline Service Account", l.Action, l.ActionUpdate)
+				return err
+			}
+			log.Info("Updated Service Account ownership")
+		}
+	}
+
+	// TODO remove after only new model is used and old model is gone
 	if ensureNudging {
 		if err := r.ensureNudgingPullSecrets(ctx, component); err != nil {
 			log.Error(err, "failed to ensure nudge secrets linked")
@@ -128,35 +199,67 @@ func (r *ComponentBuildReconciler) EnsureBuildPipelineServiceAccount(ctx context
 // linkCommonSecretsToBuildPipelineServiceAccount searches for common build Secrets in Component namespace
 // marked with corresponding label and adds them into secrets section of the given Service Account.
 func (r *ComponentBuildReconciler) linkCommonSecretsToBuildPipelineServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount) error {
-	// Get all secrets with common for all Component label
-	commonSecretsList := &corev1.SecretList{}
+	seenSecrets := map[string]bool{}
 
-	commonBuildSecretRequirement, err := labels.NewRequirement(commonBuildSecretLabelName, selection.Equals, []string{"true"})
-	if err != nil {
-		return err
-	}
-	commonBuildSecretsSelector := labels.NewSelector().Add(*commonBuildSecretRequirement)
-	commonBuildSecretsListOptions := client.ListOptions{
-		LabelSelector: commonBuildSecretsSelector,
-		Namespace:     serviceAccount.Namespace,
-	}
-	if err := r.Client.List(ctx, commonSecretsList, &commonBuildSecretsListOptions); err != nil {
-		return err
-	}
-
-	// Add found secrets to the Service Account Secrets section
-	for _, commonSecret := range commonSecretsList.Items {
-		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: commonSecret.Name})
+	// TODO remove after only new model is used and old model is gone (user secrets has to be updated with new label)
+	// filtering by commonBuildSecretLabelName and commonBuildSecretLabelNameOldModel
+	for _, labelName := range []string{commonBuildSecretLabelName, commonBuildSecretLabelNameOldModel} {
+		commonSecretsList := &corev1.SecretList{}
+		req, err := labels.NewRequirement(labelName, selection.Equals, []string{"true"})
+		if err != nil {
+			return err
+		}
+		if err := r.Client.List(ctx, commonSecretsList, &client.ListOptions{
+			LabelSelector: labels.NewSelector().Add(*req),
+			Namespace:     serviceAccount.Namespace,
+		}); err != nil {
+			return err
+		}
+		for _, secret := range commonSecretsList.Items {
+			if !seenSecrets[secret.Name] {
+				seenSecrets[secret.Name] = true
+				serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: secret.Name})
+			}
+		}
 	}
 
 	return nil
 }
 
-// TODO remove after for new component model
+// TODO remove after only new model is used and old model is gone
+// linkCommonSecretsToBuildPipelineServiceAccount searches for common build Secrets in Component namespace
+// marked with corresponding label and adds them into secrets section of the given Service Account.
+func (r *ComponentBuildReconcilerOldModel) linkCommonSecretsToBuildPipelineServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount) error {
+	seenSecrets := map[string]bool{}
+
+	for _, labelName := range []string{commonBuildSecretLabelName, commonBuildSecretLabelNameOldModel} {
+		commonSecretsList := &corev1.SecretList{}
+		req, err := labels.NewRequirement(labelName, selection.Equals, []string{"true"})
+		if err != nil {
+			return err
+		}
+		if err := r.Client.List(ctx, commonSecretsList, &client.ListOptions{
+			LabelSelector: labels.NewSelector().Add(*req),
+			Namespace:     serviceAccount.Namespace,
+		}); err != nil {
+			return err
+		}
+		for _, secret := range commonSecretsList.Items {
+			if !seenSecrets[secret.Name] {
+				seenSecrets[secret.Name] = true
+				serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: secret.Name})
+			}
+		}
+	}
+
+	return nil
+}
+
+// TODO remove after only new model is used and old model is gone
 // ensureNudgingPullSecrets makes sure that Component build pipeline Service Account
 // has pull secrets for image repositories of Components that nudge current Component linked.
 // Note, they must be linked into Secrets section (not imagePullSecrets).
-func (r *ComponentBuildReconciler) ensureNudgingPullSecrets(ctx context.Context, component *compapiv1alpha1.Component) error {
+func (r *ComponentBuildReconcilerOldModel) ensureNudgingPullSecrets(ctx context.Context, component *compapiv1alpha1.Component) error {
 	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	log := ctrllog.FromContext(ctx).WithValues("ServiceAccountName", buildPipelineServiceAccountName)
 
@@ -222,9 +325,10 @@ func (r *ComponentBuildReconciler) ensureNudgingPullSecrets(ctx context.Context,
 	return nil
 }
 
+// TODO remove after only new model is used and old model is gone
 // cleanUpNudgingPullSecrets removes the current Component pull secret from the linked secrets list
 // of the nudged Components build pipeline Service Account.
-func (r *ComponentBuildReconciler) cleanUpNudgingPullSecrets(ctx context.Context, component *compapiv1alpha1.Component) error {
+func (r *ComponentBuildReconcilerOldModel) cleanUpNudgingPullSecrets(ctx context.Context, component *compapiv1alpha1.Component) error {
 	if len(component.Spec.BuildNudgesRef) == 0 {
 		// No nudge relations, nothing to do.
 		return nil
@@ -273,9 +377,10 @@ func (r *ComponentBuildReconciler) cleanUpNudgingPullSecrets(ctx context.Context
 	return nil
 }
 
+// TODO remove after only new model is used and old model is gone
 // getComponentImageRepository retreives related to the given Component Image Repository.
 // Returns nil if the Component doesn't have related Image Repository.
-func (r *ComponentBuildReconciler) getComponentImageRepository(ctx context.Context, componentName, namespace string) (*imgcv1alpha1.ImageRepository, error) {
+func (r *ComponentBuildReconcilerOldModel) getComponentImageRepository(ctx context.Context, componentName, namespace string) (*imgcv1alpha1.ImageRepository, error) {
 	log := ctrllog.FromContext(ctx)
 
 	imageRepositoryList := &imgcv1alpha1.ImageRepositoryList{}
@@ -301,7 +406,75 @@ func (r *ComponentBuildReconciler) getComponentImageRepository(ctx context.Conte
 
 // ensureBuildPipelineServiceAccountBinding makes sure that a common for all build pipelines Service Accounts
 // Role Binding exists and contains a subject record for the given component.
-func (r *ComponentBuildReconciler) ensureBuildPipelineServiceAccountBinding(ctx context.Context, component *compapiv1alpha1.Component) error {
+// nolint:dupl
+func (r *ComponentBuildReconciler) ensureBuildPipelineServiceAccountBinding(ctx context.Context, component *compv1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
+
+	// Verify Role Binding for build pipeline Service Account
+	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: component.Namespace}, buildPipelinesRoleBinding); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to read common build pipelines Role Binding", l.Action, l.ActionView)
+			return err
+		}
+
+		// This is the first Component in the namespace being onboarded.
+		// Create common Role Binding to appstudio-pipelines-runner Cluster Role for all build pipeline Service Accounts.
+		// Add only one subject for the given Component.
+		buildPipelinesRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      buildPipelineRoleBindingName,
+				Namespace: component.Namespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     BuildPipelineClusterRoleName,
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      buildPipelineServiceAccountName,
+					Namespace: component.Namespace,
+				},
+			},
+		}
+		if err := r.Client.Create(ctx, buildPipelinesRoleBinding); err != nil {
+			// errors.IsNotFound(err) will always be false because appstudio-pipelines-runner Cluster Role exists.
+			log.Error(err, "failed to create common build pipelines Role Binding", l.Action, l.ActionAdd)
+			return err
+		}
+		return nil
+	}
+
+	// Common Role Binding to appstudio-pipelines-runner Cluster Role for all build pipeline Service Accounts exists.
+	// Make sure it contains a subject record for the given Component.
+	if getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName) != -1 {
+		// Up to date, nothing to do.
+		return nil
+	}
+	// Add record for the Component build pipeline Service Account and update common Role Binding.
+	buildPipelinesRoleBinding.Subjects = append(buildPipelinesRoleBinding.Subjects, rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      buildPipelineServiceAccountName,
+		Namespace: component.Namespace,
+	})
+	if err := r.Client.Update(ctx, buildPipelinesRoleBinding); err != nil {
+		log.Error(err, "failed to add a subject to common build pipelines Role Binding", l.Action, l.ActionUpdate)
+		return err
+	}
+	log.Info("Added Service Account to common build pipelines Role Binding", "ServiceAccountName", buildPipelineServiceAccountName, l.Action, l.ActionUpdate)
+
+	return nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// Role Binding exists and contains a subject record for the given component.
+// nolint:dupl
+// ensureBuildPipelineServiceAccountBinding makes sure that a common for all build pipelines Service Accounts
+func (r *ComponentBuildReconcilerOldModel) ensureBuildPipelineServiceAccountBinding(ctx context.Context, component *compapiv1alpha1.Component) error {
 	log := ctrllog.FromContext(ctx)
 
 	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
@@ -379,9 +552,22 @@ func getRoleBindingSaSubjectIndex(roleBinding *rbacv1.RoleBinding, serviceAccoun
 // removeBuildPipelineServiceAccountBinding deletes subject record for build pipleine Service Account
 // of the given Component from the common build pipelines Role Binding.
 // Deletes the common Role Binding if no subjects are left.
-func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx context.Context, component *compapiv1alpha1.Component) error {
+// nolint:dupl
+func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx context.Context, component *compv1alpha1.Component) error {
 	log := ctrllog.FromContext(ctx)
 	log.Info("requested to remove build pipeline Service Account binding")
+
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
+	buildPipelineSA := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, buildPipelineSA); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to read build pipeline Service Account", l.Action, l.ActionView)
+			return err
+		}
+	} else if saHasOtherOwner(buildPipelineSA, component.UID) {
+		log.Info("build pipeline Service Account has other owners, skipping Role Binding removal", "ServiceAccount", buildPipelineServiceAccountName)
+		return nil
+	}
 
 	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: component.Namespace}, buildPipelinesRoleBinding); err != nil {
@@ -395,7 +581,6 @@ func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx 
 
 	subjectsNumberBefore := len(buildPipelinesRoleBinding.Subjects)
 
-	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
 	subjectIndex := getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName)
 	if subjectIndex != -1 {
 		if len(buildPipelinesRoleBinding.Subjects) == 1 {
@@ -439,6 +624,94 @@ func (r *ComponentBuildReconciler) removeBuildPipelineServiceAccountBinding(ctx 
 	}
 
 	return nil
+}
+
+// TODO remove after only new model is used and old model is gone
+// removeBuildPipelineServiceAccountBinding deletes subject record for build pipleine Service Account
+// of the given Component from the common build pipelines Role Binding.
+// Deletes the common Role Binding if no subjects are left.
+// nolint:dupl
+func (r *ComponentBuildReconcilerOldModel) removeBuildPipelineServiceAccountBinding(ctx context.Context, component *compapiv1alpha1.Component) error {
+	log := ctrllog.FromContext(ctx)
+	log.Info("requested to remove build pipeline Service Account binding")
+
+	buildPipelineServiceAccountName := getBuildPipelineServiceAccountName(component.Name)
+	buildPipelineSA := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: component.Namespace}, buildPipelineSA); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to read build pipeline Service Account", l.Action, l.ActionView)
+			return err
+		}
+	} else if saHasOtherOwner(buildPipelineSA, component.UID) {
+		log.Info("build pipeline Service Account has other owners, skipping Role Binding removal", "ServiceAccount", buildPipelineServiceAccountName)
+		return nil
+	}
+
+	buildPipelinesRoleBinding := &rbacv1.RoleBinding{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineRoleBindingName, Namespace: component.Namespace}, buildPipelinesRoleBinding); err != nil {
+		if errors.IsNotFound(err) {
+			// Nothing to do
+			return nil
+		}
+		log.Error(err, "failed to read common build pipelines Role Binding", l.Action, l.ActionView)
+		return err
+	}
+
+	subjectsNumberBefore := len(buildPipelinesRoleBinding.Subjects)
+
+	subjectIndex := getRoleBindingSaSubjectIndex(buildPipelinesRoleBinding, buildPipelineServiceAccountName)
+	if subjectIndex != -1 {
+		if len(buildPipelinesRoleBinding.Subjects) == 1 {
+			// Remove the last subject
+			buildPipelinesRoleBinding.Subjects = nil
+		} else {
+			// Remove subject by its index
+			oldSubjects := buildPipelinesRoleBinding.Subjects
+			newSubjects := append(oldSubjects[:subjectIndex], oldSubjects[subjectIndex+1:]...) //nolint:gocritic
+			buildPipelinesRoleBinding.Subjects = newSubjects
+		}
+	}
+
+	// This is nice to have action to clean up records for already deleted Service Accounts.
+	// That might happen when a user creates a Component and deletes it before PaC provision.
+	if len(buildPipelinesRoleBinding.Subjects) != 0 {
+		saList := &corev1.ServiceAccountList{}
+		if err := r.Client.List(ctx, saList, client.InNamespace(buildPipelinesRoleBinding.Namespace)); err == nil {
+			buildPipelinesRoleBinding = removeInvalidServiceAccountSubjects(buildPipelinesRoleBinding, saList.Items)
+		} else {
+			// Do not break flow because of optional cleanup
+			log.Error(err, "failed to list Service Accounts, skipping additional build pipeline Role Binding cleanup")
+		}
+	}
+
+	if len(buildPipelinesRoleBinding.Subjects) != 0 {
+		if len(buildPipelinesRoleBinding.Subjects) != subjectsNumberBefore {
+			if err := r.Client.Update(ctx, buildPipelinesRoleBinding); err != nil {
+				log.Error(err, "failed to remove subject from common build pipelines Role Binding")
+				return err
+			}
+			log.Info("removed subject from common build pipelines Role Binding")
+		}
+	} else {
+		// No subjects left, remove whole Role Binding
+		if err := r.Client.Delete(ctx, buildPipelinesRoleBinding); err != nil {
+			log.Error(err, "failed to delete common build pipelines Role Binding", l.Action, l.ActionDelete)
+			return err
+		}
+		log.Info("deleted common build pipelines Role Binding")
+	}
+
+	return nil
+}
+
+// saHasOtherOwner returns true if the Service Account has any owner reference with a UID other than the given component UID.
+func saHasOtherOwner(sa *corev1.ServiceAccount, componentUID types.UID) bool {
+	for _, owner := range sa.OwnerReferences {
+		if owner.UID != componentUID {
+			return true
+		}
+	}
+	return false
 }
 
 // removeInvalidServiceAccountSubjects removes unexisting Service Accounts from the given Role Binding.

--- a/internal/controller/component_build_controller_test.go
+++ b/internal/controller/component_build_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO remove whole file after only new model is used
+// TODO remove whole file after only new model is used and old model is gone
 package controllers
 
 import (
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/build-service/pkg/boerrors"
 	. "github.com/konflux-ci/build-service/pkg/common"
@@ -71,7 +72,6 @@ func verifyBodyJsonParams(req *http.Request, repository, branch, namespace, pipe
 	return true, nil
 }
 
-// TODO remove after only new model is used
 var _ = Describe("Component build controller", func() {
 
 	const (
@@ -89,7 +89,6 @@ var _ = Describe("Component build controller", func() {
 		createNamespace(BuildServiceNamespaceName)
 	})
 
-	// TODO remove after only new model is used
 	Context("Test build pipeline Service Account", func() {
 		var (
 			namespace           = "sa-test-old"
@@ -114,8 +113,8 @@ var _ = Describe("Component build controller", func() {
 		})
 
 		_ = AfterEach(func() {
-			deleteComponent(component1Key)
-			deleteComponent(component2Key)
+			deleteComponentOldModel(component1Key)
+			deleteComponentOldModel(component2Key)
 
 			deleteRoleBinding(buildRoleBindingKey)
 			deleteServiceAccount(getComponentServiceAccountKey(component1Key))
@@ -153,7 +152,7 @@ var _ = Describe("Component build controller", func() {
 		It("should remove build pipeline dedicated service account for each component and common role binding when the last service account removed", func() {
 			component1Config := getComponentDataOldModel(componentConfigOldModel{componentKey: component1Key})
 			// Simulate PaC provision was done
-			component1Config.Finalizers = append(component1Config.Finalizers, PaCProvisionFinalizer)
+			component1Config.Finalizers = append(component1Config.Finalizers, PaCProvisionFinalizerOldModel)
 			Expect(k8sClient.Create(ctx, component1Config)).To(Succeed())
 
 			component1SAKey := getComponentServiceAccountKey(component1Key)
@@ -168,7 +167,7 @@ var _ = Describe("Component build controller", func() {
 
 			component2Config := getComponentDataOldModel(componentConfigOldModel{componentKey: component2Key})
 			// Simulate PaC provision was done
-			component2Config.Finalizers = append(component1Config.Finalizers, PaCProvisionFinalizer)
+			component2Config.Finalizers = append(component2Config.Finalizers, PaCProvisionFinalizerOldModel)
 			Expect(k8sClient.Create(ctx, component2Config)).To(Succeed())
 
 			component2SAKey := getComponentServiceAccountKey(component2Key)
@@ -182,7 +181,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(roleBinding.RoleRef.Name).To(Equal(BuildPipelineClusterRoleName))
 			Expect(roleBinding.Subjects).To(HaveLen(2))
 
-			deleteComponent(component1Key)
+			deleteComponentOldModel(component1Key)
 
 			roleBinding = waitServiceAccountNotInRoleBinding(buildRoleBindingKey, component1SAKey.Name)
 			Expect(roleBinding.RoleRef.Kind).To(Equal("ClusterRole"))
@@ -191,7 +190,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(roleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
 			Expect(roleBinding.Subjects[0].Name).To(Equal(component2SAKey.Name))
 
-			deleteComponent(component2Key)
+			deleteComponentOldModel(component2Key)
 
 			waitRoleBindingGone(buildRoleBindingKey)
 		})
@@ -199,7 +198,7 @@ var _ = Describe("Component build controller", func() {
 		It("should clean up dangling role binding subjects and delete role binding", func() {
 			createCustomComponentWithoutBuildRequest(componentConfigOldModel{
 				componentKey: component1Key,
-				finalizers:   []string{PaCProvisionFinalizer}, // simulate PaC provision was done
+				finalizers:   []string{PaCProvisionFinalizerOldModel}, // simulate PaC provision was done
 			})
 
 			component1SAKey := getComponentServiceAccountKey(component1Key)
@@ -226,7 +225,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(roleBinding.RoleRef.Name).To(Equal(BuildPipelineClusterRoleName))
 			Expect(roleBinding.Subjects).To(HaveLen(2))
 
-			deleteComponent(component2Key)
+			deleteComponentOldModel(component2Key)
 			// Simulate owner reference is working
 			deleteServiceAccount(component2SAKey)
 
@@ -246,7 +245,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(roleBinding.Subjects).To(HaveLen(3))
 
 			// Upon deletion of a provisioned Component, all dangling references should be cleaned up
-			deleteComponent(component1Key)
+			deleteComponentOldModel(component1Key)
 			// Since no subjects left, the role binding should be deleted too
 			waitRoleBindingGone(buildRoleBindingKey)
 		})
@@ -254,7 +253,7 @@ var _ = Describe("Component build controller", func() {
 		It("should clean up dangling role binding subjects and keep role binding", func() {
 			createCustomComponentWithoutBuildRequest(componentConfigOldModel{
 				componentKey: component1Key,
-				finalizers:   []string{PaCProvisionFinalizer}, // simulate PaC provision was done
+				finalizers:   []string{PaCProvisionFinalizerOldModel}, // simulate PaC provision was done
 			})
 
 			component1SAKey := getComponentServiceAccountKey(component1Key)
@@ -270,7 +269,7 @@ var _ = Describe("Component build controller", func() {
 
 			createCustomComponentWithoutBuildRequest(componentConfigOldModel{
 				componentKey: component2Key,
-				finalizers:   []string{PaCProvisionFinalizer}, // simulate PaC provision was done
+				finalizers:   []string{PaCProvisionFinalizerOldModel}, // simulate PaC provision was done
 			})
 
 			component2SAKey := getComponentServiceAccountKey(component2Key)
@@ -291,7 +290,7 @@ var _ = Describe("Component build controller", func() {
 			})
 			Expect(k8sClient.Update(ctx, &roleBinding)).To(Succeed())
 
-			deleteComponent(component2Key)
+			deleteComponentOldModel(component2Key)
 			// Simulate owner reference is working
 			deleteServiceAccount(component2SAKey)
 
@@ -311,7 +310,7 @@ var _ = Describe("Component build controller", func() {
 			deleteServiceAccount(component1SAKey)
 
 			// trigger a reconcile
-			component1 := getComponent(component1Key)
+			component1 := getComponentOldModel(component1Key)
 			component1.Annotations["test-change"] = "reconcile"
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 
@@ -339,11 +338,11 @@ var _ = Describe("Component build controller", func() {
 			deleteRoleBinding(buildRoleBindingKey)
 
 			// trigger a reconcile for component 1
-			component1 := getComponent(component1Key)
+			component1 := getComponentOldModel(component1Key)
 			component1.Annotations["test-change"] = "reconcile"
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 			// trigger a reconcile for component 2
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			component2.Annotations["test-change"] = "reconcile"
 			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
@@ -385,7 +384,7 @@ var _ = Describe("Component build controller", func() {
 			nudgedComponentSAKey := getComponentServiceAccountKey(nudgedComponentKey)
 
 			createComponentOldModel(nudgedComponentKey)
-			defer deleteComponent(nudgedComponentKey)
+			defer deleteComponentOldModel(nudgedComponentKey)
 			nudgedComponentImageRepo := createImageRepositoryForComponent(nudgedComponentKey)
 			defer deleteImageRepository(nudgedComponentKey)
 
@@ -397,7 +396,7 @@ var _ = Describe("Component build controller", func() {
 			component1SAKey := getComponentServiceAccountKey(component1Key)
 			createCustomComponentWithoutBuildRequest(componentConfigOldModel{
 				componentKey: component1Key,
-				finalizers:   []string{PaCProvisionFinalizer}, // Simulate PaC provision done
+				finalizers:   []string{PaCProvisionFinalizerOldModel}, // Simulate PaC provision done
 			})
 			component1ImageRepo := createImageRepositoryForComponent(component1Key)
 			defer deleteImageRepository(component1Key)
@@ -405,7 +404,7 @@ var _ = Describe("Component build controller", func() {
 			// Create a component with nudge reference
 			component2SAKey := getComponentServiceAccountKey(component2Key)
 			component2 := getSampleComponentDataOldModel(component2Key)
-			component2.Finalizers = append(component2.Finalizers, PaCProvisionFinalizer) // Simulate PaC provision done
+			component2.Finalizers = append(component2.Finalizers, PaCProvisionFinalizerOldModel) // Simulate PaC provision done
 			component2.Spec.BuildNudgesRef = []string{
 				nudgedComponentKey.Name,
 			}
@@ -421,7 +420,7 @@ var _ = Describe("Component build controller", func() {
 			waitServiceAccountLinkedSecretGone(component2SAKey, component2ImageRepo.Status.Credentials.PullSecretName, false)
 
 			// Add a nudge from Component 1 after its creation
-			component1 := getComponent(component1Key)
+			component1 := getComponentOldModel(component1Key)
 			component1.Spec.BuildNudgesRef = []string{
 				nudgedComponentKey.Name,
 			}
@@ -429,7 +428,7 @@ var _ = Describe("Component build controller", func() {
 
 			// Trigger a reconcile for nudged Component.
 			// In real environment it should be done by update of BuildNudgedBy field in the nudged Component status
-			nudgedComponent := getComponent(nudgedComponentKey)
+			nudgedComponent := getComponentOldModel(nudgedComponentKey)
 			nudgedComponent.Annotations["build-nudged-by"] = "component1"
 			Expect(k8sClient.Update(ctx, nudgedComponent)).To(Succeed())
 
@@ -445,12 +444,12 @@ var _ = Describe("Component build controller", func() {
 			waitServiceAccountLinkedSecretGone(component2SAKey, component2ImageRepo.Status.Credentials.PullSecretName, false)
 
 			// Delete a nudging Component and check unlinking
-			deleteComponent(component2Key)
+			deleteComponentOldModel(component2Key)
 			waitServiceAccountLinkedSecretGone(nudgedComponentSAKey, component2ImageRepo.Status.Credentials.PullSecretName, false)
 			// Check that the pull secret from still nudging Component is preserved
 			waitServiceAccountLinkedSecret(nudgedComponentSAKey, component1ImageRepo.Status.Credentials.PullSecretName, false)
 
-			deleteComponent(component1Key)
+			deleteComponentOldModel(component1Key)
 			waitServiceAccountLinkedSecretGone(nudgedComponentSAKey, component1ImageRepo.Status.Credentials.PullSecretName, false)
 
 			// Ensure that the push secret of the nudged Component is not removed
@@ -458,7 +457,6 @@ var _ = Describe("Component build controller", func() {
 		})
 	})
 
-	// TODO remove after only new model is used
 	Context("Test Pipelines as Code build preparation", func() {
 		var (
 			namespace             = "pac-preparation"
@@ -475,7 +473,7 @@ var _ = Describe("Component build controller", func() {
 			contextNamespace := &corev1.Namespace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, contextNamespace)).Should(Succeed())
 			contextNamespace.SetLabels(map[string]string{
-				appstudioWorkspaceNameLabel: "build",
+				appstudioWorkspaceNameLabelOldModel: "build-old",
 			})
 			Expect(k8sClient.Update(ctx, contextNamespace)).Should(Succeed())
 
@@ -493,7 +491,7 @@ var _ = Describe("Component build controller", func() {
 		})
 
 		_ = AfterEach(func() {
-			deleteComponent(resourcePacPrepKey)
+			deleteComponentOldModel(resourcePacPrepKey)
 			deleteRoleBinding(buildRoleBindingKey)
 			deleteServiceAccount(getComponentServiceAccountKey(resourcePacPrepKey))
 			deletePaCRepository(repositoryNameKey)
@@ -542,9 +540,9 @@ var _ = Describe("Component build controller", func() {
 			for _, param := range *pacRepo.Spec.Params {
 				existingParams[param.Name] = param.Value
 			}
-			val, ok := existingParams[pacCustomParamAppstudioWorkspace]
+			val, ok := existingParams[pacCustomParamKonfluxWorkspaceOldModel]
 			Expect(ok).Should(BeTrue())
-			Expect(val).Should(Equal("build"))
+			Expect(val).Should(Equal("build-old"))
 
 			waitPaCFinalizerOnComponent(resourcePacPrepKey)
 			Eventually(func() bool {
@@ -591,9 +589,9 @@ var _ = Describe("Component build controller", func() {
 			for _, param := range *pacRepo.Spec.Params {
 				existingParams[param.Name] = param.Value
 			}
-			val, ok := existingParams[pacCustomParamAppstudioWorkspace]
+			val, ok := existingParams[pacCustomParamKonfluxWorkspaceOldModel]
 			Expect(ok).Should(BeTrue())
-			Expect(val).Should(Equal("build"))
+			Expect(val).Should(Equal("build-old"))
 
 			waitPaCFinalizerOnComponent(resourcePacPrepKey)
 			Eventually(func() bool {
@@ -641,9 +639,9 @@ var _ = Describe("Component build controller", func() {
 			for _, param := range *pacRepo.Spec.Params {
 				existingParams[param.Name] = param.Value
 			}
-			val, ok := existingParams[pacCustomParamAppstudioWorkspace]
+			val, ok := existingParams[pacCustomParamKonfluxWorkspaceOldModel]
 			Expect(ok).Should(BeTrue())
-			Expect(val).Should(Equal("build"))
+			Expect(val).Should(Equal("build-old"))
 
 			waitPaCFinalizerOnComponent(resourcePacPrepKey)
 			Eventually(func() bool {
@@ -692,9 +690,9 @@ var _ = Describe("Component build controller", func() {
 			for _, param := range *pacRepo.Spec.Params {
 				existingParams[param.Name] = param.Value
 			}
-			val, ok := existingParams[pacCustomParamAppstudioWorkspace]
+			val, ok := existingParams[pacCustomParamKonfluxWorkspaceOldModel]
 			Expect(ok).Should(BeTrue())
-			Expect(val).Should(Equal("build"))
+			Expect(val).Should(Equal("build-old"))
 
 			waitPaCFinalizerOnComponent(resourcePacPrepKey)
 			Eventually(func() bool {
@@ -714,7 +712,7 @@ var _ = Describe("Component build controller", func() {
 
 			expectError := boerrors.NewBuildOpError(boerrors.EFailedToParsePipelineAnnotation, nil)
 
-			buildStatus := readBuildStatus(getComponent(resourcePacPrepKey))
+			buildStatus := readBuildStatus(getComponentOldModel(resourcePacPrepKey))
 			Expect(buildStatus).ToNot(BeNil())
 			errorMessage := fmt.Sprintf("%d: %s", expectError.GetErrorId(), expectError.ShortError())
 			Expect(buildStatus.Message).To(ContainSubstring(errorMessage))
@@ -731,7 +729,7 @@ var _ = Describe("Component build controller", func() {
 
 			expectError := boerrors.NewBuildOpError(boerrors.EBuildPipelineInvalid, nil)
 
-			buildStatus := readBuildStatus(getComponent(resourcePacPrepKey))
+			buildStatus := readBuildStatus(getComponentOldModel(resourcePacPrepKey))
 			Expect(buildStatus).ToNot(BeNil())
 			errorMessage := fmt.Sprintf("%d: %s", expectError.GetErrorId(), expectError.ShortError())
 			Expect(buildStatus.Message).To(ContainSubstring(errorMessage))
@@ -748,7 +746,7 @@ var _ = Describe("Component build controller", func() {
 
 			expectError := boerrors.NewBuildOpError(boerrors.EWrongPipelineAnnotation, nil)
 
-			buildStatus := readBuildStatus(getComponent(resourcePacPrepKey))
+			buildStatus := readBuildStatus(getComponentOldModel(resourcePacPrepKey))
 			Expect(buildStatus).ToNot(BeNil())
 			errorMessage := fmt.Sprintf("%d: %s", expectError.GetErrorId(), expectError.ShortError())
 			Expect(buildStatus.Message).To(ContainSubstring(errorMessage))
@@ -984,7 +982,7 @@ var _ = Describe("Component build controller", func() {
 				gitRevision:  "main",
 			}, BuildRequestConfigurePaCAnnotationValue)
 
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			waitComponentAnnotationGone(component1Key, BuildRequestAnnotationName)
 			waitComponentAnnotationGone(component2Key, BuildRequestAnnotationName)
@@ -1031,7 +1029,7 @@ var _ = Describe("Component build controller", func() {
 			repositoryNameComp2Key := types.NamespacedName{Name: repositoryNameComp2, Namespace: namespace}
 
 			defer deletePaCRepository(repositoryNameComp2Key)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			waitSecretCreated(namespacePaCSecretKey)
 			waitSecretCreated(webhookSecretKey)
@@ -1053,7 +1051,7 @@ var _ = Describe("Component build controller", func() {
 			}, "non-existing-build-request")
 			waitComponentAnnotationGone(resourcePacPrepKey, BuildRequestAnnotationName)
 
-			buildStatus := readBuildStatus(getComponent(resourcePacPrepKey))
+			buildStatus := readBuildStatus(getComponentOldModel(resourcePacPrepKey))
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.Message).To(ContainSubstring("unexpected build request"))
 		})
@@ -1125,15 +1123,12 @@ var _ = Describe("Component build controller", func() {
 		})
 	})
 
-	// TODO remove after only new model is used
 	Context("Test Pipelines as Code build clean up", func() {
 		var (
 			namespace             = "build-cleanup"
 			resourceCleanupKey    = types.NamespacedName{Name: HASCompName + "-cleanup", Namespace: namespace}
 			namespacePaCSecretKey = types.NamespacedName{Name: PipelinesAsCodeGitHubAppSecretName, Namespace: namespace}
 			webhookSecretKey      = types.NamespacedName{Name: pipelinesAsCodeWebhooksSecretName, Namespace: namespace}
-			repositoryName, _     = generatePaCRepositoryNameFromGitUrl(SampleRepoLink + "-" + resourceCleanupKey.Name)
-			repositoryNameKey     = types.NamespacedName{Name: repositoryName, Namespace: namespace}
 		)
 
 		_ = BeforeEach(func() {
@@ -1152,7 +1147,7 @@ var _ = Describe("Component build controller", func() {
 
 			deleteSecret(pacSecretKey)
 			deleteRoute(pacRouteKey)
-			deleteComponent(resourceCleanupKey)
+			deleteComponentOldModel(resourceCleanupKey)
 		})
 
 		It("should successfully unconfigure PaC even when it isn't able to get PaC webhook", func() {
@@ -1199,7 +1194,7 @@ var _ = Describe("Component build controller", func() {
 			expectPacBuildStatusOldModel(resourceCleanupKey, "disabled", 0, "", "")
 		})
 
-		It("should successfully submit PR with PaC definitions removal using GitHub application, remove all incomings and incoming secret (only current component is using)", func() {
+		It("should successfully submit PR with PaC definitions removal using GitHub application upon unprovision", func() {
 			mergeUrl := "merge-url"
 			isRemovePaCPullRequestInvoked := false
 			UndoPaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (webUrl string, err error) {
@@ -1237,23 +1232,6 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
 
-			repository := waitPaCRepositoryCreated(repositoryNameKey)
-			incomingSecretName := getPaCIncomingSecretName(repository.Name)
-
-			// update repository with multiple incomings
-			incoming := []pacv1alpha1.Incoming{{Type: "webhook-url", Secret: pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey}, Targets: []string{"main"}}}
-			repository.Spec.Incomings = &incoming
-			Expect(k8sClient.Update(ctx, repository)).Should(Succeed())
-
-			// create incoming secret
-			component := getComponent(resourceCleanupKey)
-			incomingSecretData := map[string]string{
-				pacIncomingSecretKey: "secret password",
-			}
-			incomingSecretResourceKey := types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}
-			createSecret(incomingSecretResourceKey, incomingSecretData)
-			defer deleteSecret(incomingSecretResourceKey)
-
 			// unprovision
 			setComponentBuildRequestOldModel(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
 
@@ -1263,14 +1241,9 @@ var _ = Describe("Component build controller", func() {
 
 			expectPacBuildStatusOldModel(resourceCleanupKey, "disabled", 0, "", mergeUrl)
 			waitComponentAnnotationGone(resourceCleanupKey, BuildRequestAnnotationName)
-			waitSecretGone(incomingSecretResourceKey)
-
-			repository = waitPaCRepositoryCreated(repositoryNameKey)
-			Expect(repository.Spec.Incomings).To(BeNil())
 		})
 
-		It("should successfully submit PR with PaC definitions removal, remove 1 incoming and keep secret for another component", func() {
-			// tests multiple entries in incomings for components (when incomings are manually updated)
+		It("should clean up repository incomings recalculating targets on each component deletion", func() {
 			mergeUrl := "merge-url"
 			UndoPaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (webUrl string, err error) {
 				return mergeUrl, nil
@@ -1285,60 +1258,237 @@ var _ = Describe("Component build controller", func() {
 			}
 			createSecret(pacSecretKey, pacSecretData)
 
-			// provision 1st component
-			createComponentAndProcessBuildRequest(componentConfigOldModel{
-				componentKey: resourceCleanupKey,
-				annotations:  defaultPipelineAnnotations,
-			}, BuildRequestConfigurePaCAnnotationValue)
-			waitPaCFinalizerOnComponent(resourceCleanupKey)
-			expectPacBuildStatusOldModel(resourceCleanupKey, "enabled", 0, "", mergeUrl)
+			sharedGitURL := SampleRepoLink + "-shared"
 
-			// provision 2nd component
+			// Provision 1st component with revision "main"
+			component1Key := types.NamespacedName{Name: "component1", Namespace: namespace}
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: component1Key,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       sharedGitURL,
+				gitRevision:  "main",
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(component1Key)
+
+			// Provision 2nd component with revision "dev"
 			component2Key := types.NamespacedName{Name: "component2", Namespace: namespace}
 			createComponentAndProcessBuildRequest(componentConfigOldModel{
 				componentKey: component2Key,
 				annotations:  defaultPipelineAnnotations,
-				gitURL:       SampleRepoLink + "-" + resourceCleanupKey.Name,
-				gitRevision:  "another",
+				gitURL:       sharedGitURL,
+				gitRevision:  "dev",
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
-			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
 
-			component := getComponent(resourceCleanupKey)
-			repository := waitPaCRepositoryCreated(repositoryNameKey)
-			incomingSecretName := getPaCIncomingSecretName(repository.Name)
+			// Provision 3rd component with revision "feature"
+			component3Key := types.NamespacedName{Name: "component3", Namespace: namespace}
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: component3Key,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       sharedGitURL,
+				gitRevision:  "feature",
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(component3Key)
 
-			// update repository with multiple incomings
-			incoming := []pacv1alpha1.Incoming{
-				// 2 components using same repository and different branches
-				{Type: "webhook-url", Secret: pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey}, Targets: []string{"main"}},
-				{Type: "webhook-url", Secret: pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey}, Targets: []string{"another"}}}
-			repository.Spec.Incomings = &incoming
-			Expect(k8sClient.Update(ctx, repository)).Should(Succeed())
+			// Get Repository
+			repositoryName, err := generatePaCRepositoryNameFromGitUrl(sharedGitURL)
+			Expect(err).NotTo(HaveOccurred())
+			repositoryKey := types.NamespacedName{Name: repositoryName, Namespace: namespace}
+			repository := waitPaCRepositoryCreated(repositoryKey)
 
-			// create incoming secret
-			incomingSecretData := map[string]string{
-				pacIncomingSecretKey: "secret password",
+			// Manually add incomings to Repository with all three revisions
+			incomingSecretName := getPaCIncomingSecretName(repositoryName)
+			incomings := []pacv1alpha1.Incoming{{
+				Type:    "webhook-url",
+				Secret:  pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey},
+				Targets: []string{"main", "dev", "feature"},
+				Params:  []string{"source_url"},
+			}}
+			repository.Spec.Incomings = &incomings
+			Expect(k8sClient.Update(ctx, repository)).To(Succeed())
+
+			// Create incoming secret
+			incomingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      incomingSecretName,
+					Namespace: namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					pacIncomingSecretKey: "test-webhook-url",
+				},
 			}
-			incomingSecretResourceKey := types.NamespacedName{Namespace: component.Namespace, Name: incomingSecretName}
-			createSecret(incomingSecretResourceKey, incomingSecretData)
-			defer deleteSecret(incomingSecretResourceKey)
+			Expect(k8sClient.Create(ctx, incomingSecret)).To(Succeed())
 
-			// unprovision 1st component
-			setComponentBuildRequestOldModel(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
-			expectPacBuildStatusOldModel(resourceCleanupKey, "disabled", 0, "", mergeUrl)
-			waitComponentAnnotationGone(resourceCleanupKey, BuildRequestAnnotationName)
+			// Get repository generation before cleanup update
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen := repository.Generation
 
-			// secret will still be there for another component
-			waitSecretCreated(incomingSecretResourceKey)
+			// Phase 1: Delete first component - "main" removed from targets, "dev" and "feature" remain
+			deleteComponentOldModel(component1Key)
 
-			repository = waitPaCRepositoryCreated(repositoryNameKey)
-			Expect(repository.Spec.Incomings).ToNot(BeNil())
-			Expect(*repository.Spec.Incomings).To(HaveLen(1))
-			Expect((*repository.Spec.Incomings)[0].Secret.Name).To(Equal(incomingSecretName))
-			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
-			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"another"}))
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "main" (first component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"dev", "feature"})
+
+			// Phase 2: Delete second component - "dev" removed from targets, "feature" remain
+			deleteComponentOldModel(component2Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "dev" (second component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"feature"})
+
+			// Phase 3: Delete third component - "feature" removed from targets, nothing remain
+			deleteComponentOldModel(component3Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "feature" (third component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			validatePaCRepositoryIncomings(repository, []string{})
+		})
+
+		It("should clean up repository incomings for dual-group components", func() {
+			mergeUrl := "merge-url"
+			UndoPaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (webUrl string, err error) {
+				return mergeUrl, nil
+			}
+			EnsurePaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (string, error) {
+				return mergeUrl, nil
+			}
+
+			pacSecretData := map[string]string{
+				"github-application-id": "12345",
+				"github-private-key":    githubAppPrivateKey,
+			}
+			createSecret(pacSecretKey, pacSecretData)
+
+			sharedGitURL := SampleRepoLink + "-dual-group"
+
+			// Create 1st new model component with revision "main"
+			newModelComponent1Key := types.NamespacedName{Name: "newmodel-component1", Namespace: namespace}
+			createComponent(getComponentData(componentConfig{
+				componentKey: newModelComponent1Key,
+				gitURL:       sharedGitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "main"},
+				},
+			}))
+			_ = waitForComponentStatusVersions(newModelComponent1Key, 1)
+
+			// Create 2nd new model component with revision "dev"
+			newModelComponent2Key := types.NamespacedName{Name: "newmodel-component2", Namespace: namespace}
+			createComponent(getComponentData(componentConfig{
+				componentKey: newModelComponent2Key,
+				gitURL:       sharedGitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "dev"},
+				},
+			}))
+			_ = waitForComponentStatusVersions(newModelComponent2Key, 1)
+
+			// Create old model component with revision "feature"
+			oldModelComponentKey := types.NamespacedName{Name: "oldmodel-component", Namespace: namespace}
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: oldModelComponentKey,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       sharedGitURL,
+				gitRevision:  "feature",
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(oldModelComponentKey)
+
+			// Get Repository
+			repositoryName, err := generatePaCRepositoryNameFromGitUrl(sharedGitURL)
+			Expect(err).NotTo(HaveOccurred())
+			repositoryKey := types.NamespacedName{Namespace: namespace, Name: repositoryName}
+			repository := waitPaCRepositoryCreated(repositoryKey)
+
+			// Manually add incomings to Repository with all three revisions
+			incomingSecretName := getPaCIncomingSecretName(repositoryName)
+			incomings := []pacv1alpha1.Incoming{{
+				Type:    "webhook-url",
+				Secret:  pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey},
+				Targets: []string{"main", "dev", "feature"},
+				Params:  []string{"source_url"},
+			}}
+			repository.Spec.Incomings = &incomings
+			Expect(k8sClient.Update(ctx, repository)).To(Succeed())
+
+			// Create incoming secret
+			incomingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      incomingSecretName,
+					Namespace: namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					pacIncomingSecretKey: "test-webhook-url",
+				},
+			}
+			Expect(k8sClient.Create(ctx, incomingSecret)).To(Succeed())
+
+			// Get repository generation before cleanup update
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen := repository.Generation
+
+			// Phase 1: Delete first new model component - "main" removed from targets, "dev" and "feature" remain
+			deleteComponent(newModelComponent1Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "main" (first new model component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"dev", "feature"})
+
+			// Phase 2: Delete second new model component - "dev" removed from targets, "feature" remain
+			deleteComponent(newModelComponent2Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "dev" (second old component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"feature"})
+
+			// Phase 3: Delete old model component - "feature" removed from targets, nothing remain
+			deleteComponentOldModel(oldModelComponentKey)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "feature" (new component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			validatePaCRepositoryIncomings(repository, []string{})
 		})
 
 		It("should successfully submit PR with PaC definitions removal on component deletion", func() {
@@ -1377,7 +1527,7 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
 
-			deleteComponent(resourceCleanupKey)
+			deleteComponentOldModel(resourceCleanupKey)
 
 			Eventually(func() bool {
 				return isRemovePaCPullRequestInvoked
@@ -1428,17 +1578,26 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(secondComponentKey)
 
-			// shouldn't remove webhook because another component exists for the same repo
-			setComponentBuildRequestOldModel(resourceCleanupKey, BuildRequestUnconfigurePaCAnnotationValue)
+			// delete first old model component, shouldn't remove webhook because another component exists for the same repo
+			deleteComponentOldModel(resourceCleanupKey)
 
 			Eventually(func() bool {
 				return isRemovePaCPullRequestInvoked
 			}, timeout, interval).Should(BeTrue())
 
-			expectPacBuildStatusOldModel(resourceCleanupKey, "disabled", 0, "", mergeUrl)
-			// delete component so there will be just 1 component using the repository
-			deleteComponent(resourceCleanupKey)
+			// Create new model component with same Git URL to test dual-group webhook protection
+			newModelComponentKey := types.NamespacedName{Name: HASCompName + "-cleanup-newmodel", Namespace: namespace}
+			createComponent(getComponentData(componentConfig{
+				componentKey: newModelComponentKey,
+				gitURL:       SampleRepoLink + "-samerepo",
+			}))
+			_ = waitForComponentStatusVersions(newModelComponentKey, 1)
 
+			// Delete new model component - webhook should NOT be deleted (existing DeletePaCWebhookFunc will fail if attempted)
+			// because secondComponentKey (old model) still exists
+			deleteComponent(newModelComponentKey)
+
+			// Now delete the last (old model) component and verify webhook IS deleted
 			isRemovePaCPullRequestInvoked = false
 			isDeletePaCWebhookInvoked := false
 			DeletePaCWebhookFunc = func(repoUrl string, webhookUrl string) error {
@@ -1448,8 +1607,8 @@ var _ = Describe("Component build controller", func() {
 				return nil
 			}
 
-			// should remove webhook because there isn't another component which uses the same repo
-			setComponentBuildRequestOldModel(secondComponentKey, BuildRequestUnconfigurePaCAnnotationValue)
+			// delete second old model component, should remove webhook because there isn't another component which uses the same repo
+			deleteComponentOldModel(secondComponentKey)
 
 			Eventually(func() bool {
 				return isRemovePaCPullRequestInvoked
@@ -1457,8 +1616,6 @@ var _ = Describe("Component build controller", func() {
 			Eventually(func() bool {
 				return isDeletePaCWebhookInvoked
 			}, timeout, interval).Should(BeTrue())
-
-			expectPacBuildStatusOldModel(secondComponentKey, "disabled", 0, "", mergeUrl)
 		})
 
 		It("should not block component deletion if PaC definitions removal failed", func() {
@@ -1478,8 +1635,8 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
 
-			// deleteComponent waits until the component is gone
-			deleteComponent(resourceCleanupKey)
+			// deleteComponentOldModel waits until the component is gone
+			deleteComponentOldModel(resourceCleanupKey)
 		})
 
 		var assertCloseUnmergedMergeRequest = func(expectedBaseBranch string, sourceBranchExists bool) {
@@ -1529,7 +1686,7 @@ var _ = Describe("Component build controller", func() {
 			waitComponentAnnotationGone(resourceCleanupKey, BuildRequestAnnotationName)
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
 
-			deleteComponent(resourceCleanupKey)
+			deleteComponentOldModel(resourceCleanupKey)
 
 			Eventually(func() bool {
 				return isFindOnboardingMergeRequestInvoked
@@ -1590,7 +1747,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 			}, BuildRequestConfigurePaCAnnotationValue)
 
-			component := getComponent(resourceCleanupKey)
+			component := getComponentOldModel(resourceCleanupKey)
 			component.Spec.Source.GitSource.URL = "wrong"
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
 			waitPaCFinalizerOnComponent(resourceCleanupKey)
@@ -1611,7 +1768,7 @@ var _ = Describe("Component build controller", func() {
 			createSecret(pacSecretKey, pacSecretData)
 			createCustomComponentWithoutBuildRequest(componentConfigOldModel{
 				componentKey: resourceCleanupKey,
-				finalizers:   []string{PaCProvisionFinalizer}, // simulate PaC provision was done
+				finalizers:   []string{PaCProvisionFinalizerOldModel}, // simulate PaC provision was done
 				annotations: map[string]string{
 					defaultBuildPipelineAnnotation: defaultPipelineAnnotationValue,
 					// simulate PaC provision was done, so it won't update component after provision, which would race with removal of SA, and it could be created again
@@ -1633,7 +1790,7 @@ var _ = Describe("Component build controller", func() {
 
 			Expect(isRemovePaCPullRequestInvoked).To(BeFalse())
 			// Clean up for the component should not recreate pipeline service account
-			deleteComponent(resourceCleanupKey)
+			deleteComponentOldModel(resourceCleanupKey)
 			// Wait for method to be actually called, because we remove finalizer immediately,
 			// so removal of PR might not be called yet while component is already gone
 			Eventually(func() bool { return isRemovePaCPullRequestInvoked }, timeout, interval).Should(BeTrue())
@@ -1644,7 +1801,6 @@ var _ = Describe("Component build controller", func() {
 		})
 	})
 
-	// TODO remove after only new model is used
 	Context("Test Pipelines as Code multi component git repository", func() {
 		const (
 			multiComponentGitRepositoryUrl = "https://github.com/samples/multi-component-repository"
@@ -1683,7 +1839,7 @@ var _ = Describe("Component build controller", func() {
 		_ = AfterEach(func() {
 			ResetTestGitProviderClient()
 			deleteComponentPipelineRuns(anotherComponentKey)
-			deleteComponent(anotherComponentKey)
+			deleteComponentOldModel(anotherComponentKey)
 			deleteSecret(pacSecretKey)
 			deleteRoute(pacRouteKey)
 			deletePaCRepository(repositoryNameKey)
@@ -1722,7 +1878,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 				gitURL:       multiComponentGitRepositoryUrl,
 			}, BuildRequestConfigurePaCAnnotationValue)
-			defer deleteComponent(component1Key)
+			defer deleteComponentOldModel(component1Key)
 			waitComponentAnnotationGone(component1Key, BuildRequestAnnotationName)
 			Eventually(func() bool { return component1PaCMergeRequestCreated }, timeout, interval).Should(BeTrue())
 			waitPaCRepositoryCreated(repositoryNameComp1Key)
@@ -1739,7 +1895,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 				gitURL:       multiComponentGitRepositoryUrl,
 			}, BuildRequestConfigurePaCAnnotationValue)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 			waitComponentAnnotationGone(component2Key, BuildRequestAnnotationName)
 			Eventually(func() bool { return component2PaCMergeRequestCreated }, timeout, interval).Should(BeTrue())
 			Expect(k8sClient.Get(ctx, repositoryNameComp1Key, pacRepository)).To(Succeed())
@@ -1753,7 +1909,7 @@ var _ = Describe("Component build controller", func() {
 		})
 
 		It("when 2 components are created with the same url, Pac Repository will be reused, when 1st component is removed and created with new URL, new repository is created", func() {
-			deleteComponent(anotherComponentKey)
+			deleteComponentOldModel(anotherComponentKey)
 			deletePaCRepository(repositoryNameKey)
 			component1Key := types.NamespacedName{Name: "test-multi-component1", Namespace: namespace}
 			component2Key := types.NamespacedName{Name: "test-multi-component2", Namespace: namespace}
@@ -1804,7 +1960,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 				gitURL:       multiComponentGitRepositoryUrl,
 			}, BuildRequestConfigurePaCAnnotationValue)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 			waitComponentAnnotationGone(component2Key, BuildRequestAnnotationName)
 			Eventually(func() bool { return component2PaCMergeRequestCreated }, timeout, interval).Should(BeTrue())
 
@@ -1818,7 +1974,7 @@ var _ = Describe("Component build controller", func() {
 			Expect(pacRepositoriesList.Items).To(HaveLen(1))
 
 			// remove 1st component
-			deleteComponent(component1Key)
+			deleteComponentOldModel(component1Key)
 			Expect(k8sClient.Get(ctx, repositoryNameComp1Key, pacRepository)).To(Succeed())
 
 			// create 1st component again, but with different URL, which will create new Pac repository and not use any existing one
@@ -1828,7 +1984,7 @@ var _ = Describe("Component build controller", func() {
 				annotations:  defaultPipelineAnnotations,
 				gitURL:       differentGitRepositoryUrl,
 			}, BuildRequestConfigurePaCAnnotationValue)
-			defer deleteComponent(component1Key)
+			defer deleteComponentOldModel(component1Key)
 			waitComponentAnnotationGone(component1Key, BuildRequestAnnotationName)
 			Eventually(func() bool { return component1PaCMergeRequestCreated }, timeout, interval).Should(BeTrue())
 			repositoryNameComp1New, _ := generatePaCRepositoryNameFromGitUrl(differentGitRepositoryUrl)
@@ -1862,7 +2018,6 @@ var _ = Describe("Component build controller", func() {
 
 	})
 
-	// TODO remove after only new model is used
 	Context("Test Pipelines as Code trigger build", func() {
 		var (
 			namespace             = "trigger-build"
@@ -1892,7 +2047,7 @@ var _ = Describe("Component build controller", func() {
 		})
 
 		_ = AfterEach(func() {
-			deleteComponent(resourcePacTriggerKey)
+			deleteComponentOldModel(resourcePacTriggerKey)
 			deletePaCRepository(repositoryNameKey)
 
 			deleteSecret(webhookSecretKey)
@@ -1918,7 +2073,7 @@ var _ = Describe("Component build controller", func() {
 			expectPacBuildStatusOldModel(resourcePacTriggerKey, "enabled", 0, "", mergeUrl)
 
 			repository := waitPaCRepositoryCreated(repositoryNameKey)
-			component := getComponent(resourcePacTriggerKey)
+			component := getComponentOldModel(resourcePacTriggerKey)
 
 			pipelineRunName := component.Name + pipelineRunOnPushSuffix
 
@@ -2047,7 +2202,7 @@ var _ = Describe("Component build controller", func() {
 			expectPacBuildStatusOldModel(resourcePacTriggerKey, "enabled", 0, "", mergeUrl)
 
 			repository := waitPaCRepositoryCreated(repositoryNameKey)
-			component := getComponent(resourcePacTriggerKey)
+			component := getComponentOldModel(resourcePacTriggerKey)
 
 			pipelineRunName := component.Name + pipelineRunOnPushSuffix
 
@@ -2142,11 +2297,11 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			incomingSecretName := getPaCIncomingSecretName(repository.Name)
 
-			component1 := getComponent(resourcePacTriggerKey)
+			component1 := getComponentOldModel(resourcePacTriggerKey)
 			pipelineRunName1 := component1.Name + pipelineRunOnPushSuffix
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
@@ -2185,7 +2340,7 @@ var _ = Describe("Component build controller", func() {
 			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
 			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"main"}))
 
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
 			req2 := gock.New(internalPaCEndpoint).
@@ -2239,11 +2394,11 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			incomingSecretName := getPaCIncomingSecretName(repository.Name)
 
-			component1 := getComponent(resourcePacTriggerKey)
+			component1 := getComponentOldModel(resourcePacTriggerKey)
 			pipelineRunName1 := component1.Name + pipelineRunOnPushSuffix
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
@@ -2282,7 +2437,7 @@ var _ = Describe("Component build controller", func() {
 			Expect((*repository.Spec.Incomings)[0].Secret.Key).To(Equal(pacIncomingSecretKey))
 			Expect((*repository.Spec.Incomings)[0].Targets).To(Equal([]string{"main"}))
 
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
 			req2 := gock.New(internalPaCEndpoint).
@@ -2349,7 +2504,7 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 			gock.InterceptClient(client)
@@ -2361,7 +2516,7 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
 			req := gock.New(internalPaCEndpoint).
@@ -2433,7 +2588,7 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 			gock.InterceptClient(client)
@@ -2445,7 +2600,7 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
 			req := gock.New(internalPaCEndpoint).
@@ -2511,7 +2666,7 @@ var _ = Describe("Component build controller", func() {
 			}, BuildRequestConfigurePaCAnnotationValue)
 			waitPaCFinalizerOnComponent(component2Key)
 			expectPacBuildStatusOldModel(component2Key, "enabled", 0, "", mergeUrl)
-			defer deleteComponent(component2Key)
+			defer deleteComponentOldModel(component2Key)
 
 			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 			gock.InterceptClient(client)
@@ -2523,7 +2678,7 @@ var _ = Describe("Component build controller", func() {
 
 			defer gock.Off()
 
-			component2 := getComponent(component2Key)
+			component2 := getComponentOldModel(component2Key)
 			pipelineRunName2 := component2.Name + pipelineRunOnPushSuffix
 
 			req := gock.New(internalPaCEndpoint).

--- a/internal/controller/component_build_controller_unit_test.go
+++ b/internal/controller/component_build_controller_unit_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/konflux-ci/build-service/pkg/bometrics"
 	. "github.com/konflux-ci/build-service/pkg/common"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
@@ -52,21 +52,19 @@ func TestGetProvisionTimeMetricsBuckets(t *testing.T) {
 }
 
 func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
-	component := &compapiv1alpha1.Component{
+	component := &compv1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-component",
 			Namespace: "my-namespace",
 		},
-		Spec: compapiv1alpha1.ComponentSpec{
+		Spec: compv1alpha1.ComponentSpec{
 			ContainerImage: "registry.io/username/image:tag",
-			Source: compapiv1alpha1.ComponentSource{
-				ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-					GitURL: "https://githost.com/user/repo.git",
-				},
+			Source: compv1alpha1.ComponentSource{
+				GitURL: "https://githost.com/user/repo.git",
 			},
 		},
 	}
-	versionInfo := &VersionInfo{Revision: "custom-branch", OriginalVersion: "version1", SanitizedVersion: "version1", Context: "./base_context", DockerfileURI: "containerFile"}
+	versionInfo := &VersionInfo{Revision: "custom-branch", OriginalVersion: "version1", SanitizedVersion: "version1", Context: "./base_context", DockerfilePath: "containerFile"}
 	param1_value := "param1_value"
 	param2_value := []string{"param2_value1", "param2_value2"}
 	pipelineSpec := &tektonapi.PipelineSpec{
@@ -105,8 +103,8 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	if pipelineRun.Labels[ComponentNameLabelName] != "my-component" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", ComponentNameLabelName)
 	}
-	if pipelineRun.Labels["pipelines.appstudio.openshift.io/type"] != "build" {
-		t.Error("generatePaCPipelineRunForComponent(): wrong pipelines.appstudio.openshift.io/type label value")
+	if pipelineRun.Labels[PipelineRunTypeLabelName] != "build" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s label value", PipelineRunTypeLabelName)
 	}
 
 	onCel := fmt.Sprintf(`event == "pull_request" && target_branch == "custom-branch" && %s == "true" && ( "./base_context/***".pathChanged() || ".tekton/my-component-version1-pull-request.yaml".pathChanged() )`, BuildsEnabledParamName)
@@ -120,8 +118,8 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	if pipelineRun.Annotations["pipelinesascode.tekton.dev/cancel-in-progress"] != "true" {
 		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/cancel-in-progress annotation value")
 	}
-	if pipelineRun.Annotations["build.appstudio.redhat.com/target_branch"] != "{{target_branch}}" {
-		t.Error("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/target_branch annotation value")
+	if pipelineRun.Annotations[gitTargetBranchAnnotationName] != "{{target_branch}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitTargetBranchAnnotationName)
 	}
 	if pipelineRun.Annotations[gitCommitShaAnnotationName] != "{{revision}}" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitCommitShaAnnotationName)
@@ -129,8 +127,8 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	if pipelineRun.Annotations[gitRepoAtShaAnnotationName] != "https://githost.com/user/repo?rev={{revision}}" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitRepoAtShaAnnotationName)
 	}
-	if pipelineRun.Annotations["build.appstudio.redhat.com/pull_request_number"] != "{{pull_request_number}}" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/pull_request_number annotation value")
+	if pipelineRun.Annotations[gitPRAnnotationName] != "{{pull_request_number}}" {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitPRAnnotationName)
 	}
 	if pipelineRun.Annotations[VersionAnnotationName] != versionInfo.OriginalVersion {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", VersionAnnotationName)
@@ -254,7 +252,7 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 }
 
 func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSet(t *testing.T) {
-	_, err := generatePaCPipelineRunForComponent(&compapiv1alpha1.Component{ObjectMeta: metav1.ObjectMeta{Name: "my-component", Namespace: "my-namespace"}},
+	_, err := generatePaCPipelineRunForComponent(&compv1alpha1.Component{ObjectMeta: metav1.ObjectMeta{Name: "my-component", Namespace: "my-namespace"}},
 		nil, nil, &VersionInfo{}, nil, true)
 	if err == nil {
 		t.Errorf("generatePaCPipelineRunForComponent(): expected error")
@@ -293,7 +291,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 			},
 			wantOnPull:  fmt.Sprintf(`event == "pull_request" && target_branch == "my-branch" && %s == "true" && ( "component-dir/***".pathChanged() || ".tekton/comp1-version1-pull-request.yaml".pathChanged() )`, BuildsEnabledParamName),
 			wantOnPush:  fmt.Sprintf(`event == "push" && target_branch == "my-branch" && %s == "true" && ( "component-dir/***".pathChanged() || ".tekton/comp1-version1-push.yaml".pathChanged() )`, BuildsEnabledParamName),
-			versionInfo: &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfileURI: "dockerfile/Dockerfile", SanitizedVersion: "version1"},
+			versionInfo: &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfilePath: "dockerfile/Dockerfile", SanitizedVersion: "version1"},
 		},
 		{
 			name: "should generate cel expression for component with context directory and its dockerfile outside context directory",
@@ -302,7 +300,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 			},
 			wantOnPull:  fmt.Sprintf(`event == "pull_request" && target_branch == "my-branch" && %s == "true" && ( "component-dir/***".pathChanged() || ".tekton/comp1-version1-pull-request.yaml".pathChanged() || "docker-root-dir/Dockerfile".pathChanged() )`, BuildsEnabledParamName),
 			wantOnPush:  fmt.Sprintf(`event == "push" && target_branch == "my-branch" && %s == "true" && ( "component-dir/***".pathChanged() || ".tekton/comp1-version1-push.yaml".pathChanged() || "docker-root-dir/Dockerfile".pathChanged() )`, BuildsEnabledParamName),
-			versionInfo: &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfileURI: "docker-root-dir/Dockerfile", SanitizedVersion: "version1"},
+			versionInfo: &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfilePath: "docker-root-dir/Dockerfile", SanitizedVersion: "version1"},
 		},
 		{
 			name: "should fail to generate cel expression for component if isFileExist fails",
@@ -311,7 +309,7 @@ func TestGenerateCelExpressionForPipeline(t *testing.T) {
 			},
 			wantOnPullError: true,
 			wantOnPushError: true,
-			versionInfo:     &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfileURI: "non-existing/Dockerfile", SanitizedVersion: "version1"},
+			versionInfo:     &VersionInfo{Revision: "my-branch", Context: "component-dir", DockerfilePath: "non-existing/Dockerfile", SanitizedVersion: "version1"},
 		},
 	}
 
@@ -786,18 +784,16 @@ func TestCreateWorkspaceBinding(t *testing.T) {
 }
 
 func TestGeneratePACRepository(t *testing.T) {
-	getComponent := func(repoUrl string, annotations map[string]string, repoSettings *compapiv1alpha1.RepositorySettings) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(repoUrl string, annotations map[string]string, repoSettings *compv1alpha1.RepositorySettings) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "testcomponent",
 				Namespace:   "workspace-name",
 				Annotations: annotations,
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL: repoUrl,
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL: repoUrl,
 				},
 			},
 		}
@@ -813,7 +809,7 @@ func TestGeneratePACRepository(t *testing.T) {
 		componentAnnotations             map[string]string
 		pacConfig                        map[string][]byte
 		expectedGitProviderConfig        *pacv1alpha1.GitProvider
-		repoSettings                     *compapiv1alpha1.RepositorySettings
+		repoSettings                     *compv1alpha1.RepositorySettings
 		expectedGithubAppTokenScopeRepos *[]string
 		expectedCommentStrategy          string
 		skipBuildsMap                    map[string]bool
@@ -861,7 +857,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.com/user/test-component-repository", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.com/user/test-component-repository", nil, nil)),
 				},
 				URL:  "",
 				Type: "github",
@@ -902,7 +898,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://github.self-hosted.com",
 				Type: "github",
@@ -928,7 +924,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://github.self-hosted.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://github.self-hosted-proxy.com",
 				Type: "github",
@@ -950,7 +946,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "",
 				Type: "gitlab",
@@ -974,7 +970,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository", nil, nil)),
 				},
 				Type: "gitlab",
 			},
@@ -998,7 +994,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://gitlab.self-hosted.com",
 				Type: "gitlab",
@@ -1024,7 +1020,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://gitlab.self-hosted-proxy.com",
 				Type: "gitlab",
@@ -1050,7 +1046,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitlab.self-hosted.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://gitlab.self-hosted-proxy.com",
 				Type: "gitlab",
@@ -1075,7 +1071,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://forgejo.example.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://forgejo.example.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://forgejo.example.com",
 				Type: "forgejo",
@@ -1100,7 +1096,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitea.example.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitea.example.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://gitea.example.com",
 				Type: "forgejo",
@@ -1122,7 +1118,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: pipelinesAsCodeWebhooksSecretName,
-					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitea.example.com/user/test-component-repository/", nil, nil), true),
+					Key:  getWebhookSecretKeyForComponent(getComponent("https://gitea.example.com/user/test-component-repository/", nil, nil)),
 				},
 				URL:  "https://gitea.example.com",
 				Type: "forgejo",
@@ -1139,7 +1135,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				PipelinesAsCodeGithubPrivateKey: []byte("private-key"),
 			},
 			expectedGitProviderConfig:        nil,
-			repoSettings:                     &compapiv1alpha1.RepositorySettings{CommentStrategy: "disable_all"},
+			repoSettings:                     &compv1alpha1.RepositorySettings{CommentStrategy: "disable_all"},
 			expectedGithubAppTokenScopeRepos: nil,
 			expectedCommentStrategy:          "disable_all",
 		},
@@ -1151,7 +1147,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				PipelinesAsCodeGithubPrivateKey: []byte("private-key"),
 			},
 			expectedGitProviderConfig:        nil,
-			repoSettings:                     &compapiv1alpha1.RepositorySettings{GithubAppTokenScopeRepos: []string{"scope1", "scope2"}},
+			repoSettings:                     &compv1alpha1.RepositorySettings{GithubAppTokenScopeRepos: []string{"scope1", "scope2"}},
 			expectedGithubAppTokenScopeRepos: &[]string{"scope1", "scope2"},
 			expectedCommentStrategy:          "",
 		},
@@ -1163,7 +1159,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				PipelinesAsCodeGithubPrivateKey: []byte("private-key"),
 			},
 			expectedGitProviderConfig: nil,
-			repoSettings: &compapiv1alpha1.RepositorySettings{
+			repoSettings: &compv1alpha1.RepositorySettings{
 				CommentStrategy:          "disable_all",
 				GithubAppTokenScopeRepos: []string{"scope1", "scope2"}},
 			expectedGithubAppTokenScopeRepos: &[]string{"scope1", "scope2"},
@@ -1185,7 +1181,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				Data: tt.pacConfig,
 			}
-			pacRepo, err := generatePACRepository(component, secret, &component.Spec.RepositorySettings, tt.skipBuildsMap, true)
+			pacRepo, err := generatePACRepository(component, secret, &component.Spec.RepositorySettings, tt.skipBuildsMap)
 
 			if err != nil {
 				t.Errorf("Failed to generate PaC repository object. Cause: %v", err)
@@ -1260,16 +1256,14 @@ func TestPaCRepoAddParamWorkspace(t *testing.T) {
 		Data: pacConfig,
 	}
 
-	component := &compapiv1alpha1.Component{
+	component := &compv1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-component",
 			Namespace: "my-namespace",
 		},
-		Spec: compapiv1alpha1.ComponentSpec{
-			Source: compapiv1alpha1.ComponentSource{
-				ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-					GitURL: "https://github.com/user/repo.git",
-				},
+		Spec: compv1alpha1.ComponentSpec{
+			Source: compv1alpha1.ComponentSource{
+				GitURL: "https://github.com/user/repo.git",
 			},
 		},
 	}
@@ -1283,20 +1277,20 @@ func TestPaCRepoAddParamWorkspace(t *testing.T) {
 	}
 
 	t.Run("add to Spec.Params", func(t *testing.T) {
-		repository, _ := generatePACRepository(*component, secret, nil, nil, true)
+		repository, _ := generatePACRepository(*component, secret, nil, nil)
 		pacRepoAddParamWorkspaceName(repository, workspaceName)
 
 		params := convertCustomParamsToMap(repository)
-		param, ok := params[pacCustomParamAppstudioWorkspace]
+		param, ok := params[pacCustomParamKonfluxWorkspace]
 		assert.Assert(t, ok)
 		assert.Equal(t, workspaceName, param.Value)
 	})
 
 	t.Run("override existing workspace parameter, unset other fields btw", func(t *testing.T) {
-		repository, _ := generatePACRepository(*component, secret, nil, nil, true)
+		repository, _ := generatePACRepository(*component, secret, nil, nil)
 		params := []pacv1alpha1.Params{
 			{
-				Name:      pacCustomParamAppstudioWorkspace,
+				Name:      pacCustomParamKonfluxWorkspace,
 				Value:     "another_workspace",
 				Filter:    "pac.event_type == \"pull_request\"",
 				SecretRef: &pacv1alpha1.Secret{},
@@ -1307,7 +1301,7 @@ func TestPaCRepoAddParamWorkspace(t *testing.T) {
 		pacRepoAddParamWorkspaceName(repository, workspaceName)
 
 		existingParams := convertCustomParamsToMap(repository)
-		param, ok := existingParams[pacCustomParamAppstudioWorkspace]
+		param, ok := existingParams[pacCustomParamKonfluxWorkspace]
 		assert.Assert(t, ok)
 		assert.Equal(t, workspaceName, param.Value)
 
@@ -1317,17 +1311,15 @@ func TestPaCRepoAddParamWorkspace(t *testing.T) {
 }
 
 func TestGetGitProvider(t *testing.T) {
-	getComponent := func(repoUrl, annotationValue string) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(repoUrl, annotationValue string) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testcomponent",
 				Namespace: "workspace-name",
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL: repoUrl,
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL: repoUrl,
 				},
 			},
 		}
@@ -1486,7 +1478,7 @@ func TestGetGitProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			component := getComponent(tt.componentRepoUrl, tt.componentGitProviderAnnotation)
-			got, err := getGitProvider(component, true)
+			got, err := getGitProvider(component)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("Detecting git provider for component with '%s' url and '%s' annotation value should fail", tt.componentRepoUrl, tt.componentGitProviderAnnotation)
@@ -1502,7 +1494,7 @@ func TestGetGitProvider(t *testing.T) {
 	t.Run("should return error if git source is nil", func(t *testing.T) {
 		component := getComponent("", "")
 		component.Spec.Source.GitURL = ""
-		_, err := getGitProvider(component, true)
+		_, err := getGitProvider(component)
 		if err == nil {
 			t.Error("Expected error for nil source URL")
 		}

--- a/internal/controller/component_build_controller_v2.go
+++ b/internal/controller/component_build_controller_v2.go
@@ -28,23 +28,53 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	"github.com/konflux-ci/build-service/pkg/boerrors"
 	"github.com/konflux-ci/build-service/pkg/bometrics"
 	"github.com/konflux-ci/build-service/pkg/git/gitprovider"
+	"github.com/konflux-ci/build-service/pkg/k8s"
 	l "github.com/konflux-ci/build-service/pkg/logs"
+	pacwebhook "github.com/konflux-ci/build-service/pkg/pacwebhook"
+)
+
+const (
+	PaCProvisionFinalizer = "konflux-ci.dev/component-finalizer"
+
+	ComponentNameLabelName = "build.konflux-ci.dev/component"
+	// PipelineRunTypeLabelName contains the type of the PipelineRunType
+	PipelineRunTypeLabelName = "pipelines.konflux-ci.dev/type"
+	PartOfLabelName          = "app.kubernetes.io/part-of"
+	PartOfKonfluxLabelValue  = "konflux"
+
+	gitCommitShaAnnotationName    = "build.konflux-ci.dev/commit_sha"
+	gitRepoAtShaAnnotationName    = "build.konflux-ci.dev/repo"
+	gitPRAnnotationName           = "build.konflux-ci.dev/pull_request_number"
+	gitTargetBranchAnnotationName = "build.konflux-ci.dev/target_branch"
+	ContextAnnotationName         = "build.konflux-ci.dev/context"
+	VersionAnnotationName         = "build.konflux-ci.dev/version"
+
+	buildPipelineConfigMapResourceName = "build-pipeline-config"
+	buildPipelineConfigName            = "config.yaml"
+
+	waitForContainerImageMessage = "waiting for spec.containerImage to be set by ImageRepository with annotation image-controller.appstudio.redhat.com/update-component-image"
 )
 
 // PipelineDef represents a single pipeline definition with pointer fields
 type PipelineDef struct {
-	PipelineRefGit         *compapiv1alpha1.PipelineRefGit
+	PipelineRefGit         *compv1alpha1.PipelineRefGit
 	PipelineRefName        string
-	PipelineSpecFromBundle *compapiv1alpha1.PipelineSpecFromBundle
+	PipelineSpecFromBundle *compv1alpha1.PipelineSpecFromBundle
 	AdditionalParams       []string
 }
 
@@ -56,10 +86,10 @@ type VersionPipelineDefinition struct {
 
 // VersionInfo holds detailed information about a version
 type VersionInfo struct {
-	Context       string
-	DockerfileURI string
-	Revision      string
-	SkipBuilds    bool
+	Context        string
+	DockerfilePath string
+	Revision       string
+	SkipBuilds     bool
 
 	OriginalVersion  string
 	SanitizedVersion string
@@ -71,26 +101,61 @@ type onboardedVersionInfo struct {
 	mrUrl string
 }
 
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories/status,verbs=get;list;watch
+// ComponentBuildReconciler watches Component objects in order to
+// provision Pipelines as Code configuration for the Component.
+type ComponentBuildReconciler struct {
+	Client             client.Client
+	Scheme             *runtime.Scheme
+	EventRecorder      events.EventRecorder
+	CredentialProvider *k8s.GitCredentialProvider
+	PaCWebhookMapping  *pacwebhook.PaCWebhookMapping
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&compv1alpha1.Component{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return true
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				// OCP bumps generation when a component is deleted, which already triggers this predicate.
+				// This explicit check is a safeguard for environments that may not bump generation on deletion.
+				if !e.ObjectNew.GetDeletionTimestamp().IsZero() {
+					return true
+				}
+				// only reconcile when spec changes (Generation increments), not on status-only updates
+				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		})).
+		Named("ComponentBuildReconciler").
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=konflux-ci.dev,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=konflux-ci.dev,resources=components/status,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch;update;delete
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
-func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx).WithName("ComponentOnboardingNewModel")
 	ctx = ctrllog.IntoContext(ctx, log)
 	reconcileStartTime := time.Now()
 
 	// Fetch the Component instance
-	var component compapiv1alpha1.Component
+	var component compv1alpha1.Component
 	err := r.Client.Get(ctx, req.NamespacedName, &component)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -109,7 +174,7 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 	if component.ObjectMeta.DeletionTimestamp.IsZero() {
 		// We need to make sure the Service Account exists before checking the Component image,
 		// because Image Controller operator expects the Service Account to exist to link push secret to it.
-		if err := r.EnsureBuildPipelineServiceAccount(ctx, &component, false); err != nil {
+		if err := r.EnsureBuildPipelineServiceAccount(ctx, &component); err != nil {
 			log.Error(err, "Failed to ensure build pipeline service account")
 			return ctrl.Result{}, err
 		}
@@ -244,7 +309,7 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 
 		// Ensure PaC Repository exists and is properly configured
 		var pacRepositoryName string
-		if pacRepositoryName, err = r.ensurePaCRepository(ctx, &component, pacSecret, &component.Spec.RepositorySettings, skipBuildsMap, true); err != nil {
+		if pacRepositoryName, err = r.ensurePaCRepository(ctx, &component, pacSecret, &component.Spec.RepositorySettings, skipBuildsMap); err != nil {
 			return ctrl.Result{}, r.handlePersistentError(ctx, &component, err, "Failed to ensure PaC repository")
 		}
 		log.Info("Using PaC repository", "PaCRepositoryName", pacRepositoryName)
@@ -568,7 +633,6 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 		r.WaitForCacheUpdateRes(ctx, types.NamespacedName{Namespace: component.Namespace, Name: component.Name}, &component)
 	}
 
-	// TODO handle skip builds !!!! if it is already working in PaC
 	log.Info("New model reconciliation completed successfully", l.Action, l.ActionView)
 
 	return ctrl.Result{}, nil
@@ -587,7 +651,7 @@ func (r *ComponentBuildReconciler) ReconcileNewModel(ctx context.Context, req ct
 // we need to wait for status updates to propagate before the new reconcile starts.
 // Without this wait for ResourceVersion, the newly triggered reconcile might fetch a stale component,
 // leading to conflicts when it tries to re-apply the same status change.
-func (r *ComponentBuildReconciler) waitForCacheUpdate(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component, checkGeneration bool) {
+func (r *ComponentBuildReconciler) waitForCacheUpdate(ctx context.Context, namespace types.NamespacedName, component *compv1alpha1.Component, checkGeneration bool) {
 	log := ctrllog.FromContext(ctx)
 
 	var failureMessage string
@@ -605,7 +669,7 @@ func (r *ComponentBuildReconciler) waitForCacheUpdate(ctx context.Context, names
 	isComponentInCacheUpToDate := false
 	for i := 0; i < 20; i++ {
 		// Use a temporary component to avoid overwriting the caller's component variable with stale cache data
-		cachedComponent := &compapiv1alpha1.Component{}
+		cachedComponent := &compv1alpha1.Component{}
 		if err := r.Client.Get(ctx, namespace, cachedComponent); err == nil {
 			var upToDate bool
 			if checkGeneration {
@@ -637,13 +701,13 @@ func (r *ComponentBuildReconciler) waitForCacheUpdate(ctx context.Context, names
 
 // WaitForCacheUpdateGen waits for the controller cache to contain the component with the latest Generation.
 // This should be called after spec updates to ensure the cache has propagated before the reconcile completes.
-func (r *ComponentBuildReconciler) WaitForCacheUpdateGen(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component) {
+func (r *ComponentBuildReconciler) WaitForCacheUpdateGen(ctx context.Context, namespace types.NamespacedName, component *compv1alpha1.Component) {
 	r.waitForCacheUpdate(ctx, namespace, component, true)
 }
 
 // WaitForCacheUpdateRes waits for the controller cache to contain the component with the latest ResourceVersion.
 // This should be called after status updates when the current reconcile previously updated the spec (which triggered a new reconcile).
-func (r *ComponentBuildReconciler) WaitForCacheUpdateRes(ctx context.Context, namespace types.NamespacedName, component *compapiv1alpha1.Component) {
+func (r *ComponentBuildReconciler) WaitForCacheUpdateRes(ctx context.Context, namespace types.NamespacedName, component *compv1alpha1.Component) {
 	r.waitForCacheUpdate(ctx, namespace, component, false)
 }
 
@@ -673,7 +737,7 @@ func (r *ComponentBuildReconciler) observeActionMetrics(action string, reconcile
 // by logging and setting the component status message.
 // Returns error, where error is from setStatusMessage if it's a persistent error,
 // or the original error if not persistent.
-func (r *ComponentBuildReconciler) handlePersistentError(ctx context.Context, component *compapiv1alpha1.Component, err error, errorContext string) error {
+func (r *ComponentBuildReconciler) handlePersistentError(ctx context.Context, component *compv1alpha1.Component, err error, errorContext string) error {
 	log := ctrllog.FromContext(ctx)
 
 	var boErr *boerrors.BuildOpError
@@ -697,7 +761,7 @@ func (r *ComponentBuildReconciler) handlePersistentError(ctx context.Context, co
 // It removes PaC webhook if not used by other components, deletes PaC configurations from repository
 // for each version (unless skipped), and cleans up repository incomings.
 // All errors are logged but not returned, as the component finalizer has already been removed.
-func (r *ComponentBuildReconciler) cleanupComponentPaCResources(ctx context.Context, component *compapiv1alpha1.Component) {
+func (r *ComponentBuildReconciler) cleanupComponentPaCResources(ctx context.Context, component *compv1alpha1.Component) {
 	log := ctrllog.FromContext(ctx)
 
 	// Generate version info from status for offboarding
@@ -742,7 +806,7 @@ func (r *ComponentBuildReconciler) cleanupComponentPaCResources(ctx context.Cont
 // When fromStatus is true, builds from component.Status.Versions (for offboarding).
 // When fromStatus is false, builds from component.Spec.Source.Versions (for onboarding/builds).
 // Returns a map of version names to VersionInfo pointers.
-func buildVersionInfoMap(component *compapiv1alpha1.Component, fromStatus bool) map[string]*VersionInfo {
+func buildVersionInfoMap(component *compv1alpha1.Component, fromStatus bool) map[string]*VersionInfo {
 	versionInfoMap := make(map[string]*VersionInfo)
 
 	if fromStatus {
@@ -757,19 +821,19 @@ func buildVersionInfoMap(component *compapiv1alpha1.Component, fromStatus bool) 
 	} else {
 		// Build from spec - includes all fields
 		for _, version := range component.Spec.Source.Versions {
-			dockerfileURI := version.DockerfileURI
-			if dockerfileURI == "" {
-				dockerfileURI = component.Spec.Source.DockerfileURI
+			dockerfilePath := version.DockerfilePath
+			if dockerfilePath == "" {
+				dockerfilePath = component.Spec.Source.DockerfilePath
 			}
-			if dockerfileURI == "" {
-				dockerfileURI = "Dockerfile"
+			if dockerfilePath == "" {
+				dockerfilePath = "Dockerfile"
 			}
 
 			versionInfoMap[version.Name] = &VersionInfo{
 				OriginalVersion:  version.Name,
 				SanitizedVersion: sanitizeVersionName(version.Name),
 				Context:          version.Context,
-				DockerfileURI:    dockerfileURI,
+				DockerfilePath:   dockerfilePath,
 				Revision:         version.Revision,
 				SkipBuilds:       version.SkipBuilds,
 			}
@@ -786,7 +850,7 @@ func buildVersionInfoMap(component *compapiv1alpha1.Component, fromStatus bool) 
 // Returns:
 //   - skipBuildsMap: map of revision to their SkipBuilds values (aggregated by revision)
 //   - hasChanges: true if any version is missing from status or has different SkipBuilds value in status
-func buildSkipBuildsMapAndCheckChanges(component *compapiv1alpha1.Component, existingSpecVersions map[string]*VersionInfo) (map[string]bool, bool) {
+func buildSkipBuildsMapAndCheckChanges(component *compv1alpha1.Component, existingSpecVersions map[string]*VersionInfo) (map[string]bool, bool) {
 	skipBuildsMap := make(map[string]bool)
 	skipBuildsChanged := false
 
@@ -913,7 +977,7 @@ func getUniqueVersionsFromVersionFields(allVersions bool, singleVersion string, 
 // - invalidVersionsToOnboardWithPR: invalid versions (not in spec) that should be removed from actions
 func (r *ComponentBuildReconciler) determineVersionsToCreateConfigurationFor(
 	ctx context.Context,
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	existingSpecVersions map[string]*VersionInfo,
 ) (versionsToOnboardWithPR []string, invalidVersionsToOnboardWithPR []string) {
 	log := ctrllog.FromContext(ctx)
@@ -961,7 +1025,7 @@ func (r *ComponentBuildReconciler) resolvePipelinesForCreateConfiguration(
 // equalRepositorySettings compares two RepositorySettings structs for equality.
 // Returns true if the settings are equal, false otherwise.
 // GithubAppTokenScopeRepos are compared as mathematical sets (order and duplicates don't matter).
-func equalRepositorySettings(a, b compapiv1alpha1.RepositorySettings) bool {
+func equalRepositorySettings(a, b compv1alpha1.RepositorySettings) bool {
 	if a.CommentStrategy != b.CommentStrategy {
 		return false
 	}
@@ -984,7 +1048,7 @@ func equalRepositorySettings(a, b compapiv1alpha1.RepositorySettings) bool {
 // Returns two slices: versions to onboard and versions to offboard.
 func (r *ComponentBuildReconciler) determineVersionsToOnboardAndOffboard(
 	ctx context.Context,
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	existingSpecVersions map[string]*VersionInfo,
 ) (versionsToOnboard []string, versionsToOffboard []string) {
 	log := ctrllog.FromContext(ctx)
@@ -1029,7 +1093,7 @@ func (r *ComponentBuildReconciler) determineVersionsToOnboardAndOffboard(
 // - invalidVersionsToTriggerBuild: all versions (invalid + being onboarded) that should be removed from trigger build actions
 func (r *ComponentBuildReconciler) determineVersionsToTriggerBuildFor(
 	ctx context.Context,
-	component *compapiv1alpha1.Component,
+	component *compv1alpha1.Component,
 	existingSpecVersions map[string]*VersionInfo,
 	versionsToOnboardWithoutPR []string,
 	versionsToOnboardWithPR []string,
@@ -1084,7 +1148,7 @@ func (r *ComponentBuildReconciler) determineVersionsToTriggerBuildFor(
 // preserves existing ConfigurationMergeURL, and sets Message to errorMessage if provided.
 //
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) updateVersionsStatus(ctx context.Context, component *compapiv1alpha1.Component, versions []onboardedVersionInfo, existingSpecVersions map[string]*VersionInfo, success bool, errorMessage string) error {
+func (r *ComponentBuildReconciler) updateVersionsStatus(ctx context.Context, component *compv1alpha1.Component, versions []onboardedVersionInfo, existingSpecVersions map[string]*VersionInfo, success bool, errorMessage string) error {
 	log := ctrllog.FromContext(ctx)
 
 	if len(versions) == 0 {
@@ -1100,7 +1164,7 @@ func (r *ComponentBuildReconciler) updateVersionsStatus(ctx context.Context, com
 	// Update or add version status for each version
 	for _, version := range versions {
 		versionInfo := existingSpecVersions[version.name]
-		versionStatus := compapiv1alpha1.ComponentVersionStatus{
+		versionStatus := compv1alpha1.ComponentVersionStatus{
 			Name:       version.name,
 			Revision:   versionInfo.Revision,
 			SkipBuilds: versionInfo.SkipBuilds,
@@ -1152,7 +1216,7 @@ func (r *ComponentBuildReconciler) updateVersionsStatus(ctx context.Context, com
 
 // setStatusMessage sets provided message in the status and updates component's status.
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) setStatusMessage(ctx context.Context, component *compapiv1alpha1.Component, msg string) error {
+func (r *ComponentBuildReconciler) setStatusMessage(ctx context.Context, component *compv1alpha1.Component, msg string) error {
 	log := ctrllog.FromContext(ctx)
 
 	if component.Status.Message == msg {
@@ -1169,7 +1233,7 @@ func (r *ComponentBuildReconciler) setStatusMessage(ctx context.Context, compone
 
 // setStatusPacRepository updates the PaC repository name and settings in component status.
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) setStatusPacRepository(ctx context.Context, component *compapiv1alpha1.Component, repositoryName string, repositorySettings *compapiv1alpha1.RepositorySettings) error {
+func (r *ComponentBuildReconciler) setStatusPacRepository(ctx context.Context, component *compv1alpha1.Component, repositoryName string, repositorySettings *compv1alpha1.RepositorySettings) error {
 	log := ctrllog.FromContext(ctx)
 
 	if component.Status.PacRepository == repositoryName && reflect.DeepEqual(component.Status.RepositorySettings, *repositorySettings) {
@@ -1206,7 +1270,7 @@ func (r *ComponentBuildReconciler) setStatusPacRepository(ctx context.Context, c
 //   - Works the same regardless of removingInvalidVersions flag
 //
 // Returns an error if the component update fails.
-func (r *ComponentBuildReconciler) removeCreateConfigurationActions(ctx context.Context, component *compapiv1alpha1.Component, versionsToRemove []string, removingInvalidVersions bool, versionsToCreatePRFor []string) error {
+func (r *ComponentBuildReconciler) removeCreateConfigurationActions(ctx context.Context, component *compv1alpha1.Component, versionsToRemove []string, removingInvalidVersions bool, versionsToCreatePRFor []string) error {
 	log := ctrllog.FromContext(ctx)
 
 	if len(versionsToRemove) == 0 {
@@ -1281,7 +1345,7 @@ func (r *ComponentBuildReconciler) removeCreateConfigurationActions(ctx context.
 
 // removeTriggerBuildActions removes specified versions from component's TriggerBuild and TriggerBuilds actions.
 // Returns an error if the component update fails.
-func (r *ComponentBuildReconciler) removeTriggerBuildActions(ctx context.Context, component *compapiv1alpha1.Component, versionsToRemove []string) error {
+func (r *ComponentBuildReconciler) removeTriggerBuildActions(ctx context.Context, component *compv1alpha1.Component, versionsToRemove []string) error {
 	log := ctrllog.FromContext(ctx)
 
 	if len(versionsToRemove) == 0 {
@@ -1326,7 +1390,7 @@ func (r *ComponentBuildReconciler) removeTriggerBuildActions(ctx context.Context
 
 // removeVersionsFromStatus removes specified versions from component.Status.Versions.
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) removeVersionsFromStatus(ctx context.Context, component *compapiv1alpha1.Component, versionsToRemove []string) error {
+func (r *ComponentBuildReconciler) removeVersionsFromStatus(ctx context.Context, component *compv1alpha1.Component, versionsToRemove []string) error {
 	log := ctrllog.FromContext(ctx)
 
 	if len(versionsToRemove) == 0 {
@@ -1334,7 +1398,7 @@ func (r *ComponentBuildReconciler) removeVersionsFromStatus(ctx context.Context,
 	}
 
 	// Filter out versions to remove
-	newVersions := make([]compapiv1alpha1.ComponentVersionStatus, 0, len(component.Status.Versions))
+	newVersions := make([]compv1alpha1.ComponentVersionStatus, 0, len(component.Status.Versions))
 	for _, version := range component.Status.Versions {
 		if !slices.Contains(versionsToRemove, version.Name) {
 			newVersions = append(newVersions, version)
@@ -1362,7 +1426,7 @@ func (r *ComponentBuildReconciler) removeVersionsFromStatus(ctx context.Context,
 // updateVersionsSkipBuilds updates the SkipBuilds field for versions in component.Status.Versions
 // based on the values in existingSpecVersions. Only updates status if there are actual changes.
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) updateVersionsSkipBuilds(ctx context.Context, component *compapiv1alpha1.Component, existingSpecVersions map[string]*VersionInfo) error {
+func (r *ComponentBuildReconciler) updateVersionsSkipBuilds(ctx context.Context, component *compv1alpha1.Component, existingSpecVersions map[string]*VersionInfo) error {
 	log := ctrllog.FromContext(ctx)
 
 	hasChanges := false
@@ -1394,7 +1458,7 @@ func (r *ComponentBuildReconciler) updateVersionsSkipBuilds(ctx context.Context,
 
 // setVersionStatusMessage sets the message field for a specific version in component.Status.Versions.
 // Returns an error if the status update fails.
-func (r *ComponentBuildReconciler) setVersionStatusMessage(ctx context.Context, component *compapiv1alpha1.Component, versionName string, message string) error {
+func (r *ComponentBuildReconciler) setVersionStatusMessage(ctx context.Context, component *compv1alpha1.Component, versionName string, message string) error {
 	log := ctrllog.FromContext(ctx)
 
 	// Find the version in status

--- a/internal/controller/component_build_controller_v2_test.go
+++ b/internal/controller/component_build_controller_v2_test.go
@@ -30,11 +30,12 @@ import (
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	"github.com/konflux-ci/build-service/pkg/boerrors"
 	. "github.com/konflux-ci/build-service/pkg/common"
 	gp "github.com/konflux-ci/build-service/pkg/git/gitprovider"
@@ -274,11 +275,11 @@ var _ = Describe("Component build controller new model", func() {
 
 			component := getComponentData(componentConfig{
 				componentKey: component1Key,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						AllVersions: true,
 					},
 				},
@@ -307,40 +308,10 @@ var _ = Describe("Component build controller new model", func() {
 			deleteComponent(componentKey)
 		})
 
-		It("should set error status when version name is empty", func() {
-			component := getComponentData(componentConfig{
-				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
-					{Name: "", Revision: "main"},
-				},
-			})
-			createComponent(component)
-
-			component = waitForComponentStatusMessage(componentKey, false)
-
-			Expect(component.Status.Message).To(ContainSubstring("validation failed"))
-			Expect(component.Status.Message).To(ContainSubstring("name is required"))
-		})
-
-		It("should set error status when version revision is empty", func() {
-			component := getComponentData(componentConfig{
-				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
-					{Name: "v1.0", Revision: ""},
-				},
-			})
-			createComponent(component)
-
-			component = waitForComponentStatusMessage(componentKey, false)
-
-			Expect(component.Status.Message).To(ContainSubstring("validation failed"))
-			Expect(component.Status.Message).To(ContainSubstring("revision is required"))
-		})
-
 		It("should set error status for duplicate sanitized version names", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1.0", Revision: "main"},    // becomes "v1-0" after sanitization
 					{Name: "v1_0", Revision: "develop"}, // becomes "v1-0" after sanitization
 				},
@@ -351,16 +322,6 @@ var _ = Describe("Component build controller new model", func() {
 
 			Expect(component.Status.Message).To(ContainSubstring("validation failed"))
 			Expect(component.Status.Message).To(ContainSubstring("conflicts with version"))
-		})
-
-		It("should set error status when git source URL is missing", func() {
-			component := getSampleComponentData(componentKey)
-			component.Spec.Source.GitURL = ""
-			createComponent(component)
-
-			component = waitForComponentStatusMessage(componentKey, false)
-
-			Expect(component.Status.Message).To(ContainSubstring("Nothing to do for component without git source"))
 		})
 
 		It("should set error status when container image is missing", func() {
@@ -377,7 +338,7 @@ var _ = Describe("Component build controller new model", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
 				gitURL:       "https://gitlab.com/test-org/test-repo",
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
 			})
@@ -418,19 +379,19 @@ var _ = Describe("Component build controller new model", func() {
 		It("should set error status when PullAndPush is used with Pull/Push", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						AllVersions: true,
 					},
 				},
-				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-					PullAndPush: &compapiv1alpha1.PipelineDefinition{
+				defaultPipeline: &compv1alpha1.ComponentBuildPipeline{
+					PullAndPush: &compv1alpha1.PipelineDefinition{
 						PipelineRefName: "docker-build",
 					},
-					Pull: &compapiv1alpha1.PipelineDefinition{
+					Pull: &compv1alpha1.PipelineDefinition{
 						PipelineRefName: "docker-build",
 					},
 				},
@@ -441,35 +402,6 @@ var _ = Describe("Component build controller new model", func() {
 
 			Expect(component.Status.Message).To(ContainSubstring("validation failed"))
 			Expect(component.Status.Message).To(ContainSubstring("cannot specify pull-and-push together with pull or push"))
-		})
-
-		It("should set error status for missing PipelineRefGit required fields", func() {
-			component := getComponentData(componentConfig{
-				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
-					{Name: "v1", Revision: "main"},
-				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
-						AllVersions: true,
-					},
-				},
-				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-					Pull: &compapiv1alpha1.PipelineDefinition{
-						PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
-							Url: "https://github.com/test/pipelines",
-							// Missing PathInRepo and Revision
-						},
-					},
-				},
-			})
-			createComponent(component)
-
-			component = waitForComponentStatusMessage(componentKey, false)
-
-			Expect(component.Status.Message).To(ContainSubstring("validation failed"))
-			Expect(component.Status.Message).To(ContainSubstring("pathInRepo is required"))
-			Expect(component.Status.Message).To(ContainSubstring("revision is required"))
 		})
 	})
 
@@ -485,7 +417,7 @@ var _ = Describe("Component build controller new model", func() {
 			contextNamespace := &corev1.Namespace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, contextNamespace)).Should(Succeed())
 			contextNamespace.SetLabels(map[string]string{
-				appstudioWorkspaceNameLabel: "build",
+				konfluxWorkspaceNameLabel: "build",
 			})
 			Expect(k8sClient.Update(ctx, contextNamespace)).Should(Succeed())
 
@@ -518,7 +450,7 @@ var _ = Describe("Component build controller new model", func() {
 			pacRepo := waitPaCRepositoryCreated(pacRepoKey)
 			Expect(pacRepo.Spec.Params).ShouldNot(BeNil())
 			Expect(*pacRepo.Spec.Params).Should(ContainElement(And(
-				HaveField("Name", "appstudio_workspace"),
+				HaveField("Name", pacCustomParamKonfluxWorkspace),
 				HaveField("Value", "build"),
 			)))
 		})
@@ -556,10 +488,10 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with initial settings
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
-				repositorySettings: compapiv1alpha1.RepositorySettings{
+				repositorySettings: compv1alpha1.RepositorySettings{
 					CommentStrategy:          "disable_all",
 					GithubAppTokenScopeRepos: []string{"owner/repo1", "owner/repo2"},
 				},
@@ -617,10 +549,10 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with initial repo list
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
-				repositorySettings: compapiv1alpha1.RepositorySettings{
+				repositorySettings: compv1alpha1.RepositorySettings{
 					GithubAppTokenScopeRepos: []string{"owner/repo1", "owner/repo2"},
 				},
 			})
@@ -676,11 +608,11 @@ var _ = Describe("Component build controller new model", func() {
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Versions: []string{versionName, "nonexistent"},
 					},
 				},
@@ -701,7 +633,7 @@ var _ = Describe("Component build controller new model", func() {
 			// First onboard v1
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -768,7 +700,7 @@ var _ = Describe("Component build controller new model", func() {
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 					{Name: "v2", Revision: "develop"},
 				},
@@ -779,7 +711,7 @@ var _ = Describe("Component build controller new model", func() {
 			component = waitForComponentStatusVersions(componentKey, 2)
 
 			// Verify both versions are onboarded with correct status fields
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -806,7 +738,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with one version
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
 			})
@@ -817,14 +749,14 @@ var _ = Describe("Component build controller new model", func() {
 
 			// Add v2
 			component.Spec.Source.Versions = append(component.Spec.Source.Versions,
-				compapiv1alpha1.ComponentVersion{Name: "v2", Revision: "develop", SkipBuilds: true})
+				compv1alpha1.ComponentVersion{Name: "v2", Revision: "develop", SkipBuilds: true})
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
 
 			// Wait for v2 to be onboarded
 			component = waitForComponentStatusVersions(componentKey, 2)
 
 			// Verify both versions are in status with correct status fields
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -864,7 +796,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with two versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop", SkipBuilds: true},
 				},
@@ -881,7 +813,7 @@ var _ = Describe("Component build controller new model", func() {
 			verifyComponentVersionStatus(component.Status.Versions[1], version2Name, "develop", "succeeded", "", "", true)
 
 			// Remove v2
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "main"},
 			}
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
@@ -923,7 +855,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create default component with default git URL
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main", SkipBuilds: true},
 				},
 			})
@@ -944,7 +876,7 @@ var _ = Describe("Component build controller new model", func() {
 			component1 := getComponentData(componentConfig{
 				componentKey: component1Key,
 				gitURL:       sharedGitURL,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main", SkipBuilds: true},
 				},
 			})
@@ -971,7 +903,7 @@ var _ = Describe("Component build controller new model", func() {
 			component2 := getComponentData(componentConfig{
 				componentKey: component2Key,
 				gitURL:       sharedGitURL,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -1051,7 +983,7 @@ var _ = Describe("Component build controller new model", func() {
 		It("should handle component with no versions defined", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions:     []compapiv1alpha1.ComponentVersion{},
+				versions:     []compv1alpha1.ComponentVersion{},
 			})
 			component = createComponent(component)
 
@@ -1065,7 +997,7 @@ var _ = Describe("Component build controller new model", func() {
 		It("should handle version names with special characters", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1.0-beta+build.123", Revision: "main"},
 				},
 			})
@@ -1085,7 +1017,7 @@ var _ = Describe("Component build controller new model", func() {
 		It("should handle updating version revision", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
 			})
@@ -1120,7 +1052,7 @@ var _ = Describe("Component build controller new model", func() {
 		It("should handle updating version skip builds", func() {
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
 			})
@@ -1206,7 +1138,7 @@ var _ = Describe("Component build controller new model", func() {
 			// 2 versions with the same revision, but one has skip builds, it will result in not skipping builds for that revision
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main", SkipBuilds: true},
 					{Name: "v2", Revision: "main"},
 				},
@@ -1300,8 +1232,9 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with invalid spec
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
-					{Name: "", Revision: "main"},
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "main"},
+					{Name: "v1", Revision: "develop"},
 				},
 			})
 			createComponent(component)
@@ -1310,15 +1243,16 @@ var _ = Describe("Component build controller new model", func() {
 			component = waitForComponentStatusMessage(componentKey, false)
 
 			// Fix the spec
-			component.Spec.Source.Versions[0].Name = "v1"
+			component.Spec.Source.Versions[1].Name = "v2"
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
 
 			// Error should be cleared
 			component = waitForComponentStatusMessage(componentKey, true)
 
 			// Version should be onboarded
-			Expect(component.Status.Versions).To(HaveLen(1))
+			Expect(component.Status.Versions).To(HaveLen(2))
 			verifyComponentVersionStatus(component.Status.Versions[0], "v1", "main", "succeeded", "", "", false)
+			verifyComponentVersionStatus(component.Status.Versions[1], "v2", "develop", "succeeded", "", "", false)
 
 			Expect(component.Finalizers).To(ContainElement(PaCProvisionFinalizer))
 
@@ -1333,7 +1267,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with one version
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: "v1", Revision: "main"},
 				},
 			})
@@ -1386,7 +1320,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with two versions (SkipOffboardingPr=true)
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main", SkipBuilds: true},
 					{Name: version2Name, Revision: "develop"},
 				},
@@ -1404,7 +1338,7 @@ var _ = Describe("Component build controller new model", func() {
 			validatePaCRepository(component, "", "", skipBuildsMap)
 
 			// Remove v2 from spec and remove skip builds from v1
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "main"},
 			}
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
@@ -1483,7 +1417,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with two versions without SkipOffboardingPr
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
@@ -1495,7 +1429,7 @@ var _ = Describe("Component build controller new model", func() {
 			component = waitForComponentStatusVersions(componentKey, 2)
 
 			// Remove v2 from spec (trigger offboarding with purge PR)
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "main"},
 			}
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
@@ -1561,7 +1495,7 @@ var _ = Describe("Component build controller new model", func() {
 			// Create component with three versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "branch-v1"},
 					{Name: version2Name, Revision: "branch-v2"},
 					{Name: version3Name, Revision: "branch-v3"},
@@ -1573,7 +1507,7 @@ var _ = Describe("Component build controller new model", func() {
 			component = waitForComponentStatusVersions(componentKey, 3)
 
 			// Remove v2 and v3 versions from spec (trigger offboarding for both)
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "branch-v1"},
 			}
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
@@ -1601,7 +1535,7 @@ var _ = Describe("Component build controller new model", func() {
 			Expect(v3PurgePRAttempted).To(BeTrue(), "v3 version offboarding should have been attempted")
 
 			// Verify version states
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -1727,12 +1661,12 @@ var _ = Describe("Component build controller new model", func() {
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						AllVersions: true,
 					},
 				},
@@ -1756,7 +1690,7 @@ var _ = Describe("Component build controller new model", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify both versions are onboarded with correct PR URLs
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -1847,19 +1781,19 @@ spec:
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{
 						Name:     versionName,
 						Revision: "main",
-						BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-							Pull: &compapiv1alpha1.PipelineDefinition{
+						BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+							Pull: &compv1alpha1.PipelineDefinition{
 								PipelineRefName: "custom-pull-pipeline",
 							},
 						},
 					},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Version: versionName,
 					},
 				},
@@ -1980,13 +1914,13 @@ spec:
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{
 						Name:     versionName,
 						Revision: "main",
-						BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-							Push: &compapiv1alpha1.PipelineDefinition{
-								PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+						BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+							Push: &compv1alpha1.PipelineDefinition{
+								PipelineRefGit: &compv1alpha1.PipelineRefGit{
 									Url:        "https://github.com/custom-pipelines/pipelines.git",
 									Revision:   "main",
 									PathInRepo: "pipelines/push.yaml",
@@ -1995,8 +1929,8 @@ spec:
 						},
 					},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Versions: []string{versionName},
 					},
 				},
@@ -2079,20 +2013,20 @@ spec:
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
-				defaultPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-					PullAndPush: &compapiv1alpha1.PipelineDefinition{
-						PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+				defaultPipeline: &compv1alpha1.ComponentBuildPipeline{
+					PullAndPush: &compv1alpha1.PipelineDefinition{
+						PipelineSpecFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 							Bundle: "latest",
 							Name:   defaultPipelineName,
 						},
 					},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Versions: []string{version1Name},
 					},
 				},
@@ -2123,7 +2057,7 @@ spec:
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify both versions with correct status
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2208,7 +2142,7 @@ spec:
 			// Create component without any actions initially
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
@@ -2219,7 +2153,7 @@ spec:
 			component = waitForComponentStatusVersions(componentKey, 2)
 
 			// Verify both versions are onboarded without PR URLs
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2257,7 +2191,7 @@ spec:
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify both versions with correct status
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2294,7 +2228,7 @@ spec:
 				return len(component.Status.Versions) == 2
 			}, timeout, interval).Should(BeTrue())
 
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2383,7 +2317,7 @@ spec:
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "non-existing-branch"},
 					{Name: version3Name, Revision: "develop"},
@@ -2431,7 +2365,7 @@ spec:
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify all three versions in status with correct states
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2533,7 +2467,7 @@ spec:
 
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 					{Name: version3Name, Revision: "release"},
@@ -2575,7 +2509,7 @@ spec:
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify all three versions in status with correct states
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -2656,7 +2590,7 @@ spec:
 			// First onboard versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
@@ -2752,7 +2686,7 @@ spec:
 					"git-provider": "gitlab",
 				},
 				gitURL: gitRepoUrl,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 				},
 			})
@@ -2821,7 +2755,7 @@ spec:
 			// First onboard versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 					{Name: version3Name, Revision: "release"},
@@ -2912,7 +2846,7 @@ spec:
 			// First onboard versions - all using same revision
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "main"},
 					{Name: version3Name, Revision: "main"},
@@ -3003,7 +2937,7 @@ spec:
 			// First onboard versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 					{Name: version3Name, Revision: "release"},
@@ -3020,7 +2954,7 @@ spec:
 
 			// Now add trigger build action and offboard v1 at the same time
 			component.Spec.Actions.TriggerBuilds = []string{version1Name, version2Name}
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version2Name, Revision: "develop"},
 				{Name: version3Name, Revision: "release"},
 			}
@@ -3060,7 +2994,7 @@ spec:
 			}, timeout, interval).Should(BeTrue())
 
 			// Verify only v2 and v3 remain
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -3117,7 +3051,7 @@ spec:
 			// First onboard both versions
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
@@ -3249,7 +3183,7 @@ spec:
 			component1 := getComponentData(componentConfig{
 				componentKey: component1Key,
 				gitURL:       sameGitURL,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -3266,7 +3200,7 @@ spec:
 			Expect(k8sClient.Get(ctx, webhookSecretKey, webhookSecret)).To(Succeed())
 
 			// Get expected key using the same function as the controller
-			expectedKey := getWebhookSecretKeyForComponent(*component1, true)
+			expectedKey := getWebhookSecretKeyForComponent(*component1)
 			Expect(webhookSecret.Data).To(HaveKey(expectedKey))
 			firstSecretValue := string(webhookSecret.Data[expectedKey])
 			Expect(firstSecretValue).NotTo(BeEmpty())
@@ -3276,7 +3210,7 @@ spec:
 			component2 := getComponentData(componentConfig{
 				componentKey: component2Key,
 				gitURL:       sameGitURL,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "develop"},
 				},
 			})
@@ -3321,7 +3255,7 @@ spec:
 			component1 := getComponentData(componentConfig{
 				componentKey: component1Key,
 				gitURL:       gitURL1,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -3338,7 +3272,7 @@ spec:
 			webhookSecret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, webhookSecretKey, webhookSecret)).To(Succeed())
 
-			expectedKey1 := getWebhookSecretKeyForComponent(*component1, true)
+			expectedKey1 := getWebhookSecretKeyForComponent(*component1)
 			Expect(webhookSecret.Data).To(HaveKey(expectedKey1))
 			secretValue1 := string(webhookSecret.Data[expectedKey1])
 			Expect(secretValue1).NotTo(BeEmpty())
@@ -3348,7 +3282,7 @@ spec:
 			component2 := getComponentData(componentConfig{
 				componentKey: component2Key,
 				gitURL:       gitURL2,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -3361,7 +3295,7 @@ spec:
 			Expect(k8sClient.Get(ctx, webhookSecretKey, webhookSecret)).To(Succeed())
 			Expect(webhookSecret.Data).To(HaveLen(2), "Should have two webhook secret keys for different repos")
 
-			expectedKey2 := getWebhookSecretKeyForComponent(*component2, true)
+			expectedKey2 := getWebhookSecretKeyForComponent(*component2)
 			Expect(webhookSecret.Data).To(HaveKey(expectedKey1))
 			Expect(webhookSecret.Data).To(HaveKey(expectedKey2))
 
@@ -3405,7 +3339,7 @@ spec:
 		createTokenBasedAuthContextRun := func(data TokenBasedAuthScenario) {
 			Context(data.name, func() {
 				var (
-					component        *compapiv1alpha1.Component
+					component        *compv1alpha1.Component
 					namespace        = data.namespace
 					componentKey     = types.NamespacedName{Name: "test-component", Namespace: namespace}
 					scmSecretKey     = types.NamespacedName{Name: data.scmSecretName, Namespace: namespace}
@@ -3441,7 +3375,7 @@ spec:
 					componentCfg := componentConfig{
 						componentKey: componentKey,
 						gitURL:       gitURL,
-						versions: []compapiv1alpha1.ComponentVersion{
+						versions: []compv1alpha1.ComponentVersion{
 							{Name: "v1", Revision: "main"},
 						},
 					}
@@ -3468,7 +3402,7 @@ spec:
 					webhookSecret := &corev1.Secret{}
 					Expect(k8sClient.Get(ctx, webhookSecretKey, webhookSecret)).To(Succeed())
 
-					expectedKey := getWebhookSecretKeyForComponent(*component, true)
+					expectedKey := getWebhookSecretKeyForComponent(*component)
 					Expect(webhookSecret.Data).To(HaveKey(expectedKey))
 					Expect(string(webhookSecret.Data[expectedKey])).NotTo(BeEmpty())
 
@@ -3499,7 +3433,7 @@ spec:
 					Expect(component.Status.Versions).To(HaveLen(1), "Component should be onboarded")
 
 					// Set CreateConfiguration action
-					component.Spec.Actions.CreateConfiguration = compapiv1alpha1.ComponentCreatePipelineConfiguration{
+					component.Spec.Actions.CreateConfiguration = compv1alpha1.ComponentCreatePipelineConfiguration{
 						AllVersions: true,
 					}
 					Expect(k8sClient.Update(ctx, component)).To(Succeed())
@@ -3613,79 +3547,243 @@ spec:
 			Expect(errors.IsNotFound(err)).To(BeTrue(), "Service account should not be recreated during component deletion")
 		})
 
-		It("should remove incomings from Repository on deletion", func() {
-			versionName := "v1"
+		It("should clean up repository incomings recalculating targets on each component deletion", func() {
+			// Create 3 new model components with different revisions for the same repository
+			comp1Key := types.NamespacedName{Name: "comp1-incoming-cleanup", Namespace: namespace}
+			comp2Key := types.NamespacedName{Name: "comp2-incoming-cleanup", Namespace: namespace}
+			comp3Key := types.NamespacedName{Name: "comp3-incoming-cleanup", Namespace: namespace}
 
-			component := getComponentData(componentConfig{
-				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
-					{Name: versionName, Revision: "main"},
+			gitURL := "https://github.com/test-org/test-repo-incoming-cleanup"
+
+			// Create first component with revision "main"
+			comp1 := getComponentData(componentConfig{
+				componentKey: comp1Key,
+				gitURL:       gitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "main"},
 				},
 			})
-			component = createComponent(component)
+			createComponent(comp1)
+			waitForComponentStatusVersions(comp1Key, 1)
 
-			// Wait for onboarding to complete
-			Eventually(func() bool {
-				component = getComponent(componentKey)
-				return len(component.Status.Versions) == 1 && len(component.Finalizers) == 1
-			}, timeout, interval).Should(BeTrue())
+			// Create second component with revision "dev"
+			comp2 := getComponentData(componentConfig{
+				componentKey: comp2Key,
+				gitURL:       gitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "dev"},
+				},
+			})
+			createComponent(comp2)
+			waitForComponentStatusVersions(comp2Key, 1)
 
-			// Verify component version status
-			verifyComponentVersionStatus(component.Status.Versions[0], versionName, "main", "succeeded", "", "", false)
+			// Create third component with revision "feature"
+			comp3 := getComponentData(componentConfig{
+				componentKey: comp3Key,
+				gitURL:       gitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "feature"},
+				},
+			})
+			createComponent(comp3)
+			waitForComponentStatusVersions(comp3Key, 1)
 
-			// Verify resources were created
-			repositoryName, err := generatePaCRepositoryNameFromGitUrl(component.Spec.Source.GitURL)
+			// Get Repository
+			repositoryName, err := generatePaCRepositoryNameFromGitUrl(gitURL)
 			Expect(err).NotTo(HaveOccurred())
-			repositoryKey := types.NamespacedName{Namespace: component.Namespace, Name: repositoryName}
-
-			// Repository CR should exist
+			repositoryKey := types.NamespacedName{Namespace: namespace, Name: repositoryName}
 			repository := waitPaCRepositoryCreated(repositoryKey)
-			Expect(repository).NotTo(BeNil())
 
-			// Manually add incomings to Repository to test cleanup
-			// (Incomings are normally created during TriggerBuild, but we add them manually here
-			// to test that component deletion properly removes them)
+			// Manually add incomings to Repository with all three revisions
 			incomingSecretName := getPaCIncomingSecretName(repositoryName)
 			incomings := []pacv1alpha1.Incoming{{
 				Type:    "webhook-url",
 				Secret:  pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey},
-				Targets: []string{"main"},
+				Targets: []string{"main", "dev", "feature"},
 				Params:  []string{"source_url"},
 			}}
 			repository.Spec.Incomings = &incomings
 			Expect(k8sClient.Update(ctx, repository)).To(Succeed())
 
-			// Verify Repository has incomings
+			// Create incoming secret
+			incomingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      incomingSecretName,
+					Namespace: namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					pacIncomingSecretKey: "test-webhook-url",
+				},
+			}
+			Expect(k8sClient.Create(ctx, incomingSecret)).To(Succeed())
+
+			// Get repository generation before cleanup update
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen := repository.Generation
+
+			// Phase 1: Delete first component - "main" removed from targets, "dev" and "feature" remain
+			deleteComponent(comp1Key)
+
+			// Wait for Repository to be updated
 			Eventually(func() bool {
-				var repo pacv1alpha1.Repository
-				if err := k8sClient.Get(ctx, repositoryKey, &repo); err != nil {
-					return false
-				}
-				return repo.Spec.Incomings != nil && len(*repo.Spec.Incomings) > 0
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
 			}, timeout, interval).Should(BeTrue())
 
-			// Now delete the component
-			deleteComponent(componentKey)
+			// Targets should be updated to remove "main" (first component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"dev", "feature"})
 
-			// Incomings should be removed or cleared from Repository
+			// Phase 2: Delete second component - "dev" removed from targets, "feature" remain
+			deleteComponent(comp2Key)
+
+			// Wait for Repository to be updated
 			Eventually(func() bool {
-				var repo pacv1alpha1.Repository
-				if err := k8sClient.Get(ctx, repositoryKey, &repo); err != nil {
-					return false
-				}
-				if repo.Spec.Incomings == nil {
-					return true
-				}
-				// Check that incoming secret for this component is removed or has empty targets
-				for _, incoming := range *repo.Spec.Incomings {
-					if incoming.Secret.Name == incomingSecretName {
-						// Incoming entry exists, check if targets are empty (cleanup completed)
-						return len(incoming.Targets) == 0
-					}
-				}
-				// Incoming entry not found (also acceptable)
-				return true
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
 			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "dev" (second component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"feature"})
+
+			// Phase 3: Delete third component - "feature" removed from targets, nothing remain
+			deleteComponent(comp3Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "feature" (third component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			validatePaCRepositoryIncomings(repository, []string{})
+
+			deleteComponentAndOwnedResources(comp1Key)
+			deleteComponentAndOwnedResources(comp2Key)
+			deleteComponentAndOwnedResources(comp3Key)
+		})
+
+		// TODO: remove after old model removal
+		It("should clean up repository incomings for dual-group components", func() {
+			// Create 2 old model components and 1 new model component with different revisions for the same repository
+			oldComp1Key := types.NamespacedName{Name: "old-comp1-dual-cleanup", Namespace: namespace}
+			oldComp2Key := types.NamespacedName{Name: "old-comp2-dual-cleanup", Namespace: namespace}
+			newCompKey := types.NamespacedName{Name: "new-comp-dual-cleanup", Namespace: namespace}
+
+			gitURL := "https://github.com/test-org/test-repo-dual-cleanup"
+
+			// Create first old model component with revision "main"
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: oldComp1Key,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       gitURL,
+				gitRevision:  "main",
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(oldComp1Key)
+
+			// Create second old model component with revision "dev"
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: oldComp2Key,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       gitURL,
+				gitRevision:  "dev",
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(oldComp2Key)
+
+			// Create new model component with revision "feature"
+			newComp := getComponentData(componentConfig{
+				componentKey: newCompKey,
+				gitURL:       gitURL,
+				versions: []compv1alpha1.ComponentVersion{
+					{Name: "v1", Revision: "feature"},
+				},
+			})
+			createComponent(newComp)
+			waitForComponentStatusVersions(newCompKey, 1)
+
+			// Get Repository
+			repositoryName, err := generatePaCRepositoryNameFromGitUrl(gitURL)
+			Expect(err).NotTo(HaveOccurred())
+			repositoryKey := types.NamespacedName{Namespace: namespace, Name: repositoryName}
+			repository := waitPaCRepositoryCreated(repositoryKey)
+
+			// Manually add incomings to Repository with all three revisions
+			incomingSecretName := getPaCIncomingSecretName(repositoryName)
+			incomings := []pacv1alpha1.Incoming{{
+				Type:    "webhook-url",
+				Secret:  pacv1alpha1.Secret{Name: incomingSecretName, Key: pacIncomingSecretKey},
+				Targets: []string{"main", "dev", "feature"},
+				Params:  []string{"source_url"},
+			}}
+			repository.Spec.Incomings = &incomings
+			Expect(k8sClient.Update(ctx, repository)).To(Succeed())
+
+			// Create incoming secret
+			incomingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      incomingSecretName,
+					Namespace: namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					pacIncomingSecretKey: "test-webhook-url",
+				},
+			}
+			Expect(k8sClient.Create(ctx, incomingSecret)).To(Succeed())
+
+			// Get repository generation before cleanup update
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen := repository.Generation
+
+			// Phase 1: Delete first old model component - "main" removed from targets, "dev" and "feature" remain
+			deleteComponentOldModel(oldComp1Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "main" (first old model component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"dev", "feature"})
+
+			// Phase 2: Delete second old model component - "dev" removed from targets, "feature" remain
+			deleteComponentOldModel(oldComp2Key)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "dev" (second old component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			repositoryGen = repository.Generation
+			validatePaCRepositoryIncomings(repository, []string{"feature"})
+
+			// Phase 3: Delete new model component - "feature" removed from targets, nothing remain
+			deleteComponent(newCompKey)
+
+			// Wait for Repository to be updated
+			Eventually(func() bool {
+				repo := waitPaCRepositoryCreated(repositoryKey)
+				return repo.Generation != repositoryGen
+			}, timeout, interval).Should(BeTrue())
+
+			// Targets should be updated to remove "feature" (new component's revision)
+			repository = waitPaCRepositoryCreated(repositoryKey)
+			validatePaCRepositoryIncomings(repository, []string{})
+
+			deleteComponentAndOwnedResources(oldComp1Key)
+			deleteComponentAndOwnedResources(oldComp2Key)
+			deleteComponentAndOwnedResources(newCompKey)
 		})
 
 		It("should call DeletePaCWebhook on deletion with token auth", func() {
@@ -3706,7 +3804,7 @@ spec:
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
 				gitURL:       "https://gitlab.com/test-org/test-repo",
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: versionName, Revision: "main"},
 				},
 			})
@@ -3734,6 +3832,126 @@ spec:
 			deleteComponent(componentKey)
 
 			// DeletePaCWebhook should be called with token-based auth
+			Eventually(func() bool {
+				return isDeletePaCWebhookCalled
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should not delete webhook when multiple components use same repository", func() {
+			sharedGitURL := "https://gitlab.com/test-org/shared-repo"
+			component1Key := types.NamespacedName{Name: "test-component-1", Namespace: namespace}
+			component2Key := types.NamespacedName{Name: "test-component-2", Namespace: namespace}
+
+			// Create SCM secret for webhook authentication
+			scmSecretKey := types.NamespacedName{Name: "gitlab-token-secret", Namespace: namespace}
+			scmSecretData := map[string]string{
+				"password": "test-token",
+			}
+			labels := map[string]string{
+				"appstudio.redhat.com/credentials": "scm",
+				"appstudio.redhat.com/scm.host":    "gitlab.com",
+			}
+			createSCMSecret(scmSecretKey, scmSecretData, corev1.SecretTypeBasicAuth, nil, labels)
+			defer deleteSecret(scmSecretKey)
+
+			// Create first component with shared Git URL
+			createComponent(getComponentData(componentConfig{
+				componentKey: component1Key,
+				gitURL:       sharedGitURL,
+			}))
+			_ = waitForComponentStatusVersions(component1Key, 1)
+
+			// Create second component with same shared Git URL
+			createComponent(getComponentData(componentConfig{
+				componentKey: component2Key,
+				gitURL:       sharedGitURL,
+			}))
+			_ = waitForComponentStatusVersions(component2Key, 1)
+
+			// Set up DeletePaCWebhook mock to fail if called - webhook should NOT be deleted
+			DeletePaCWebhookFunc = func(repoUrl string, webhookUrl string) error {
+				defer GinkgoRecover()
+				Fail("Should not delete webhook because another component is still using the same repository")
+				return nil
+			}
+
+			// Delete first component - webhook should NOT be deleted (deleteComponent waits for deletion to complete)
+			deleteComponent(component1Key)
+
+			// Now delete the second (last) component - webhook SHOULD be deleted
+			isDeletePaCWebhookCalled := false
+			DeletePaCWebhookFunc = func(repoUrl string, webhookUrl string) error {
+				defer GinkgoRecover()
+				isDeletePaCWebhookCalled = true
+				Expect(repoUrl).To(Equal(sharedGitURL))
+				Expect(webhookUrl).To(Equal("https://" + pacHost))
+				return nil
+			}
+
+			deleteComponent(component2Key)
+
+			// DeletePaCWebhook should be called when deleting the last component
+			Eventually(func() bool {
+				return isDeletePaCWebhookCalled
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		// TODO: remove after old model removal
+		It("should not delete webhook when new and old model components use same repository", func() {
+			sharedGitURL := "https://gitlab.com/test-org/dual-group-repo"
+			newModelComponentKey := types.NamespacedName{Name: "test-component-newmodel", Namespace: namespace}
+			oldModelComponentKey := types.NamespacedName{Name: "test-component-oldmodel", Namespace: namespace}
+
+			// Create SCM secret for webhook authentication
+			scmSecretKey := types.NamespacedName{Name: "gitlab-token-secret", Namespace: namespace}
+			scmSecretData := map[string]string{
+				"password": "test-token",
+			}
+			labels := map[string]string{
+				"appstudio.redhat.com/credentials": "scm",
+				"appstudio.redhat.com/scm.host":    "gitlab.com",
+			}
+			createSCMSecret(scmSecretKey, scmSecretData, corev1.SecretTypeBasicAuth, nil, labels)
+			defer deleteSecret(scmSecretKey)
+
+			// Create new model component with shared Git URL
+			createComponent(getComponentData(componentConfig{
+				componentKey: newModelComponentKey,
+				gitURL:       sharedGitURL,
+			}))
+			_ = waitForComponentStatusVersions(newModelComponentKey, 1)
+
+			// Create old model component with same shared Git URL
+			createComponentAndProcessBuildRequest(componentConfigOldModel{
+				componentKey: oldModelComponentKey,
+				annotations:  defaultPipelineAnnotations,
+				gitURL:       sharedGitURL,
+			}, BuildRequestConfigurePaCAnnotationValue)
+			waitPaCFinalizerOnComponent(oldModelComponentKey)
+
+			// Set up DeletePaCWebhook mock to fail if called - webhook should NOT be deleted
+			DeletePaCWebhookFunc = func(repoUrl string, webhookUrl string) error {
+				defer GinkgoRecover()
+				Fail("Should not delete webhook because component from other API group is still using the same repository")
+				return nil
+			}
+
+			// Delete old model component - webhook should NOT be deleted (new model component still exists)
+			deleteComponentOldModel(oldModelComponentKey)
+
+			// Now delete the new model component (last component) - webhook SHOULD be deleted
+			isDeletePaCWebhookCalled := false
+			DeletePaCWebhookFunc = func(repoUrl string, webhookUrl string) error {
+				defer GinkgoRecover()
+				isDeletePaCWebhookCalled = true
+				Expect(repoUrl).To(Equal(sharedGitURL))
+				Expect(webhookUrl).To(Equal("https://" + pacHost))
+				return nil
+			}
+
+			deleteComponent(newModelComponentKey)
+
+			// DeletePaCWebhook should be called when deleting the last component
 			Eventually(func() bool {
 				return isDeletePaCWebhookCalled
 			}, timeout, interval).Should(BeTrue())
@@ -3916,12 +4134,12 @@ spec:
 			// v2 will onboard without config
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Versions: []string{version1Name, "nonexistent-v1"},
 					},
 				},
@@ -3940,7 +4158,7 @@ spec:
 			component = waitForComponentSpecActionEmpty(componentKey, "create-pr", "versions")
 
 			// Verify both versions in status
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -3965,10 +4183,10 @@ spec:
 			// PHASE 2: Add v3 with CreateConfiguration, add v4 without config, trigger v2 with invalid version
 			component = getComponent(componentKey)
 			component.Spec.Source.Versions = append(component.Spec.Source.Versions,
-				compapiv1alpha1.ComponentVersion{Name: version3Name, Revision: "feature"},
-				compapiv1alpha1.ComponentVersion{Name: version4Name, Revision: "release"},
+				compv1alpha1.ComponentVersion{Name: version3Name, Revision: "feature"},
+				compv1alpha1.ComponentVersion{Name: version4Name, Revision: "release"},
 			)
-			component.Spec.Actions.CreateConfiguration = compapiv1alpha1.ComponentCreatePipelineConfiguration{
+			component.Spec.Actions.CreateConfiguration = compv1alpha1.ComponentCreatePipelineConfiguration{
 				Versions: []string{version3Name},
 			}
 			component.Spec.Actions.TriggerBuilds = []string{version2Name, "nonexistent-v2"}
@@ -4020,7 +4238,7 @@ spec:
 			verifyPacWebhookIncomingPostData(v2Data, repositoryName, secretValue, v2PipelineRunName, namespace, "develop", component.Spec.Source.GitURL)
 
 			// Verify all 4 versions in status
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -4039,7 +4257,7 @@ spec:
 
 			// PHASE 3: Offboard v4, onboard v5 without config, trigger v1 with invalid version
 			component = getComponent(componentKey)
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "main"},
 				{Name: version2Name, Revision: "develop"},
 				{Name: version3Name, Revision: "feature"},
@@ -4088,7 +4306,7 @@ spec:
 			verifyPacWebhookIncomingPostData(v1Data, repositoryName, secretValue, v1PipelineRunName, namespace, "main", component.Spec.Source.GitURL)
 
 			// Verify all 4 versions in status (v1, v2, v3, v5)
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -4273,12 +4491,12 @@ spec:
 			component := getComponentData(componentConfig{
 				componentKey: componentKey,
 				gitURL:       gitURL,
-				versions: []compapiv1alpha1.ComponentVersion{
+				versions: []compv1alpha1.ComponentVersion{
 					{Name: version1Name, Revision: "main"},
 					{Name: version2Name, Revision: "develop"},
 				},
-				actions: compapiv1alpha1.ComponentActions{
-					CreateConfiguration: compapiv1alpha1.ComponentCreatePipelineConfiguration{
+				actions: compv1alpha1.ComponentActions{
+					CreateConfiguration: compv1alpha1.ComponentCreatePipelineConfiguration{
 						Versions: []string{version1Name, "nonexistent-v1"},
 					},
 				},
@@ -4298,7 +4516,7 @@ spec:
 				if err := k8sClient.Get(ctx, webhookSecretKey, webhookSecret); err != nil {
 					return false
 				}
-				expectedKey := getWebhookSecretKeyForComponent(*component, true)
+				expectedKey := getWebhookSecretKeyForComponent(*component)
 				return len(webhookSecret.Data[expectedKey]) > 0
 			}, timeout, interval).Should(BeTrue())
 
@@ -4314,7 +4532,7 @@ spec:
 			component = waitForComponentSpecActionEmpty(componentKey, "create-pr", "versions")
 
 			// Verify both versions in status
-			versionMap := make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap := make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -4339,10 +4557,10 @@ spec:
 			// PHASE 2: Add v3 with CreateConfiguration, add v4 without config, trigger v2 with invalid version
 			component = getComponent(componentKey)
 			component.Spec.Source.Versions = append(component.Spec.Source.Versions,
-				compapiv1alpha1.ComponentVersion{Name: version3Name, Revision: "feature"},
-				compapiv1alpha1.ComponentVersion{Name: version4Name, Revision: "release"},
+				compv1alpha1.ComponentVersion{Name: version3Name, Revision: "feature"},
+				compv1alpha1.ComponentVersion{Name: version4Name, Revision: "release"},
 			)
-			component.Spec.Actions.CreateConfiguration = compapiv1alpha1.ComponentCreatePipelineConfiguration{
+			component.Spec.Actions.CreateConfiguration = compv1alpha1.ComponentCreatePipelineConfiguration{
 				Versions: []string{version3Name},
 			}
 			component.Spec.Actions.TriggerBuilds = []string{version2Name, "nonexistent-v2"}
@@ -4394,7 +4612,7 @@ spec:
 			verifyPacWebhookIncomingPostData(v2Data, repositoryName, secretValue, v2PipelineRunName, namespace, "develop", component.Spec.Source.GitURL)
 
 			// Verify all 4 versions in status
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}
@@ -4419,7 +4637,7 @@ spec:
 			// PHASE 3: Offboard v4, onboard v5 without config, trigger v1 with invalid version
 			// Webhook should NOT be deleted when offboarding a version
 			component = getComponent(componentKey)
-			component.Spec.Source.Versions = []compapiv1alpha1.ComponentVersion{
+			component.Spec.Source.Versions = []compv1alpha1.ComponentVersion{
 				{Name: version1Name, Revision: "main"},
 				{Name: version2Name, Revision: "develop"},
 				{Name: version3Name, Revision: "feature"},
@@ -4468,7 +4686,7 @@ spec:
 			verifyPacWebhookIncomingPostData(v1Data, repositoryName, secretValue, v1PipelineRunName, namespace, "main", component.Spec.Source.GitURL)
 
 			// Verify all 4 versions in status (v1, v2, v3, v5)
-			versionMap = make(map[string]compapiv1alpha1.ComponentVersionStatus)
+			versionMap = make(map[string]compv1alpha1.ComponentVersionStatus)
 			for _, v := range component.Status.Versions {
 				versionMap[v.Name] = v
 			}

--- a/internal/controller/component_build_controller_v2_validations.go
+++ b/internal/controller/component_build_controller_v2_validations.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"strings"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	"github.com/konflux-ci/build-service/pkg/boerrors"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -44,7 +44,7 @@ func sanitizeVersionName(name string) string {
 // validateVersions performs validation checks on version definitions.
 // Returns a slice of validation error messages describing any issues found,
 // or an empty slice if all validations pass.
-func validateVersions(component *compapiv1alpha1.Component) (validationErrors []string) {
+func validateVersions(component *compv1alpha1.Component) (validationErrors []string) {
 	// Track sanitized version names for uniqueness check
 	sanitizedNames := make(map[string]string) // map[sanitized]original
 
@@ -78,7 +78,7 @@ func validateVersions(component *compapiv1alpha1.Component) (validationErrors []
 
 // hasPipelineRefGit checks if any PipelineRefGit field is set.
 // Returns true if any field is non-empty, false otherwise.
-func hasPipelineRefGit(refGit *compapiv1alpha1.PipelineRefGit) bool {
+func hasPipelineRefGit(refGit *compv1alpha1.PipelineRefGit) bool {
 	return refGit != nil && (refGit.Url != "" || refGit.PathInRepo != "" || refGit.Revision != "")
 }
 
@@ -90,14 +90,14 @@ func hasPipelineRefName(refName string) bool {
 
 // hasPipelineSpecFromBundle checks if any PipelineSpecFromBundle field is set.
 // Returns true if any field is non-empty, false otherwise.
-func hasPipelineSpecFromBundle(specFromBundle *compapiv1alpha1.PipelineSpecFromBundle) bool {
+func hasPipelineSpecFromBundle(specFromBundle *compv1alpha1.PipelineSpecFromBundle) bool {
 	return specFromBundle != nil && (specFromBundle.Bundle != "" || specFromBundle.Name != "")
 }
 
 // validatePipelineRefGitFields validates that all PipelineRefGit fields are set.
 // Returns a slice of validation error messages for any missing required fields,
 // or an empty slice if all fields are present.
-func validatePipelineRefGitFields(refGit *compapiv1alpha1.PipelineRefGit, errorPrefix string) (errors []string) {
+func validatePipelineRefGitFields(refGit *compv1alpha1.PipelineRefGit, errorPrefix string) (errors []string) {
 	if refGit == nil {
 		return nil
 	}
@@ -116,7 +116,7 @@ func validatePipelineRefGitFields(refGit *compapiv1alpha1.PipelineRefGit, errorP
 // validatePipelineSpecFromBundleFields validates that all PipelineSpecFromBundle fields are set.
 // Returns a slice of validation error messages for any missing required fields,
 // or an empty slice if all fields are present.
-func validatePipelineSpecFromBundleFields(specFromBundle *compapiv1alpha1.PipelineSpecFromBundle, errorPrefix string) (errors []string) {
+func validatePipelineSpecFromBundleFields(specFromBundle *compv1alpha1.PipelineSpecFromBundle, errorPrefix string) (errors []string) {
 	if specFromBundle == nil {
 		return nil
 	}
@@ -131,7 +131,7 @@ func validatePipelineSpecFromBundleFields(specFromBundle *compapiv1alpha1.Pipeli
 
 // hasPipelineDefConfig checks if a pipeline definition has any configuration.
 // Returns true if any pipeline configuration is present, false otherwise.
-func hasPipelineDefConfig(pipelineDef *compapiv1alpha1.PipelineDefinition) bool {
+func hasPipelineDefConfig(pipelineDef *compv1alpha1.PipelineDefinition) bool {
 	if pipelineDef == nil {
 		return false
 	}
@@ -142,7 +142,7 @@ func hasPipelineDefConfig(pipelineDef *compapiv1alpha1.PipelineDefinition) bool 
 
 // hasPipelineConfig checks if any pipeline configuration is set.
 // Returns true if any pipeline configuration (PullAndPush, Pull, or Push) is present, false otherwise.
-func hasPipelineConfig(pipeline *compapiv1alpha1.ComponentBuildPipeline) bool {
+func hasPipelineConfig(pipeline *compv1alpha1.ComponentBuildPipeline) bool {
 	if pipeline == nil {
 		return false
 	}
@@ -156,7 +156,7 @@ func hasPipelineConfig(pipeline *compapiv1alpha1.ComponentBuildPipeline) bool {
 // extractPipelineDef extracts a PipelineDef from a PipelineDefinition.
 // Returns a pointer to the extracted PipelineDef structure.
 // Deep-copies pointer fields to prevent aliasing with the original Component spec.
-func extractPipelineDef(pipelineDef *compapiv1alpha1.PipelineDefinition) *PipelineDef {
+func extractPipelineDef(pipelineDef *compv1alpha1.PipelineDefinition) *PipelineDef {
 	if pipelineDef == nil {
 		return nil
 	}
@@ -193,7 +193,7 @@ func extractPipelineDef(pipelineDef *compapiv1alpha1.PipelineDefinition) *Pipeli
 // - Validates that all required fields are set for PipelineRefGit and PipelineSpecFromBundle when used
 // Returns a slice of validation error messages describing any issues found,
 // or an empty slice if all validations pass.
-func validatePipelineConfiguration(pipeline *compapiv1alpha1.ComponentBuildPipeline, versionName string) (validationErrors []string) {
+func validatePipelineConfiguration(pipeline *compv1alpha1.ComponentBuildPipeline, versionName string) (validationErrors []string) {
 	if pipeline == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func validatePipelineConfiguration(pipeline *compapiv1alpha1.ComponentBuildPipel
 	}
 
 	// Validate each pipeline definition section
-	checkPipelineDef := func(pipelineDef *compapiv1alpha1.PipelineDefinition, pipelineType string) {
+	checkPipelineDef := func(pipelineDef *compv1alpha1.PipelineDefinition, pipelineType string) {
 		if !hasPipelineDefConfig(pipelineDef) {
 			return // Skip validation if no configuration is set
 		}
@@ -264,7 +264,7 @@ func validatePipelineConfiguration(pipeline *compapiv1alpha1.ComponentBuildPipel
 
 // validatePipelines performs validation checks on pipeline configurations and extracts pipeline definitions.
 // Returns a slice of validation error messages and a map of version names to their pipeline definitions.
-func validatePipelines(component *compapiv1alpha1.Component) ([]string, map[string]*VersionPipelineDefinition) {
+func validatePipelines(component *compv1alpha1.Component) ([]string, map[string]*VersionPipelineDefinition) {
 	var validationErrors []string
 	versionPipelines := make(map[string]*VersionPipelineDefinition)
 
@@ -456,7 +456,7 @@ func resolvePipelineDefinitions(versionPipelines map[string]*VersionPipelineDefi
 			def.PipelineSpecFromBundle = &sfb
 		} else {
 			// Fall back to Name & Bundle
-			def.PipelineSpecFromBundle = &compapiv1alpha1.PipelineSpecFromBundle{
+			def.PipelineSpecFromBundle = &compv1alpha1.PipelineSpecFromBundle{
 				Name:   defaultPipeline.Name,
 				Bundle: defaultPipeline.Bundle,
 			}

--- a/internal/controller/component_build_controller_v2_validations_unit_test.go
+++ b/internal/controller/component_build_controller_v2_validations_unit_test.go
@@ -26,7 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 )
 
 func TestSanitizeVersionName(t *testing.T) {
@@ -81,17 +81,15 @@ func TestSanitizeVersionName(t *testing.T) {
 }
 
 func TestValidateVersions(t *testing.T) {
-	getComponent := func(versions []compapiv1alpha1.ComponentVersion) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(versions []compv1alpha1.ComponentVersion) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testcomponent",
 				Namespace: "workspace-name",
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL: "https://github.com/user/repo.git",
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL: "https://github.com/user/repo.git",
 				},
 			},
 		}
@@ -105,11 +103,11 @@ func TestValidateVersions(t *testing.T) {
 		name        string
 		expectError bool
 		errorSubstr string
-		versions    []compapiv1alpha1.ComponentVersion
+		versions    []compv1alpha1.ComponentVersion
 	}{
 		{
 			name: "should accept valid versions",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "v1.0", Revision: "main"},
 				{Name: "v2.0", Revision: "develop"},
 			},
@@ -117,7 +115,7 @@ func TestValidateVersions(t *testing.T) {
 		},
 		{
 			name: "should validate version names are required",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "", Revision: "main"},
 			},
 			expectError: true,
@@ -125,7 +123,7 @@ func TestValidateVersions(t *testing.T) {
 		},
 		{
 			name: "should validate version revisions are required",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "v1.0", Revision: ""},
 			},
 			expectError: true,
@@ -133,7 +131,7 @@ func TestValidateVersions(t *testing.T) {
 		},
 		{
 			name: "should detect duplicate sanitized version names",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "v1.0", Revision: "main"},
 				{Name: "v1_0", Revision: "develop"},
 			},
@@ -142,7 +140,7 @@ func TestValidateVersions(t *testing.T) {
 		},
 		{
 			name: "should detect empty sanitized version name",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "___", Revision: "main"},
 			},
 			expectError: true,
@@ -150,7 +148,7 @@ func TestValidateVersions(t *testing.T) {
 		},
 		{
 			name: "should validate version revisions are required, while 2 versions are valid",
-			versions: []compapiv1alpha1.ComponentVersion{
+			versions: []compv1alpha1.ComponentVersion{
 				{Name: "v1.0", Revision: "main"},
 				{Name: "v2.0", Revision: "develop"},
 				{Name: "v3.0", Revision: ""},
@@ -184,18 +182,18 @@ func TestValidateVersions(t *testing.T) {
 func TestValidatePipelineConfiguration(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipeline    *compapiv1alpha1.ComponentBuildPipeline
+		pipeline    *compv1alpha1.ComponentBuildPipeline
 		versionName string
 		wantErrors  int
 		errorSubstr string
 	}{
 		{
 			name: "should validate that PullAndPush cannot be used with Pull or Push",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Pull: &compapiv1alpha1.PipelineDefinition{
+				Pull: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -205,11 +203,11 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate that PullAndPush cannot be used with Push",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Push: &compapiv1alpha1.PipelineDefinition{
+				Push: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -219,9 +217,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineRefGit required fields - missing pathInRepo",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Pull: &compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Pull: &compv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compv1alpha1.PipelineRefGit{
 						Url:      "https://github.com/test/pipelines",
 						Revision: "main",
 					},
@@ -233,9 +231,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineRefGit required fields - missing url and revision",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Pull: &compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Pull: &compv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compv1alpha1.PipelineRefGit{
 						PathInRepo: ".tekton/pipeline.yaml",
 					},
 				},
@@ -246,9 +244,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate PipelineSpecFromBundle required fields",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Push: &compapiv1alpha1.PipelineDefinition{
-					PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Push: &compv1alpha1.PipelineDefinition{
+					PipelineSpecFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 						Bundle: "quay.io/repo/bundle:latest",
 					},
 				},
@@ -259,10 +257,10 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should validate multiple definition types cannot be used together",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Pull: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Pull: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
-					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+					PipelineRefGit: &compv1alpha1.PipelineRefGit{
 						Url:        "https://github.com/test/pipelines",
 						PathInRepo: ".tekton/pipeline.yaml",
 						Revision:   "main",
@@ -281,17 +279,17 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name:        "should accept empty pipeline configuration",
-			pipeline:    &compapiv1alpha1.ComponentBuildPipeline{},
+			pipeline:    &compv1alpha1.ComponentBuildPipeline{},
 			versionName: "test-version",
 			wantErrors:  0,
 		},
 		{
 			name: "should accept valid pipeline with PipelineRefName",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Pull: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Pull: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
-				Push: &compapiv1alpha1.PipelineDefinition{
+				Push: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -300,9 +298,9 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 		},
 		{
 			name: "should accept valid pipeline with PullAndPush using PipelineRefGit",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: &compapiv1alpha1.PipelineDefinition{
-					PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compv1alpha1.PipelineDefinition{
+					PipelineRefGit: &compv1alpha1.PipelineRefGit{
 						Url:        "https://github.com/test/pipelines",
 						PathInRepo: ".tekton/pipeline.yaml",
 						Revision:   "main",
@@ -335,21 +333,19 @@ func TestValidatePipelineConfiguration(t *testing.T) {
 func TestBuildVersionInfoMap(t *testing.T) {
 	tests := []struct {
 		name       string
-		component  *compapiv1alpha1.Component
+		component  *compv1alpha1.Component
 		fromStatus bool
 		validate   func(t *testing.T, result map[string]*VersionInfo)
 	}{
 		{
 			name: "should build version info map from spec with all fields",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							DockerfileURI: "Dockerfile.default",
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{Name: "v1.0", Revision: "main", Context: "app1"},
-								{Name: "v2.0", Revision: "develop", DockerfileURI: "Dockerfile.custom"},
-							},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					Source: compv1alpha1.ComponentSource{
+						DockerfilePath: "Dockerfile.default",
+						Versions: []compv1alpha1.ComponentVersion{
+							{Name: "v1.0", Revision: "main", Context: "app1"},
+							{Name: "v2.0", Revision: "develop", DockerfilePath: "Dockerfile.custom"},
 						},
 					},
 				},
@@ -361,22 +357,20 @@ func TestBuildVersionInfoMap(t *testing.T) {
 				assert.Equal(t, "v1-0", result["v1.0"].SanitizedVersion)
 				assert.Equal(t, "main", result["v1.0"].Revision)
 				assert.Equal(t, "app1", result["v1.0"].Context)
-				assert.Equal(t, "Dockerfile.default", result["v1.0"].DockerfileURI)
+				assert.Equal(t, "Dockerfile.default", result["v1.0"].DockerfilePath)
 
 				assert.Equal(t, "v2.0", result["v2.0"].OriginalVersion)
-				assert.Equal(t, "Dockerfile.custom", result["v2.0"].DockerfileURI)
+				assert.Equal(t, "Dockerfile.custom", result["v2.0"].DockerfilePath)
 			},
 		},
 		{
-			name: "should build version info map from spec without DockerfileURI and default to Dockerfile",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{Name: "v1.0", Revision: "main"},
-								{Name: "v2.0", Revision: "develop", Context: "app2"},
-							},
+			name: "should build version info map from spec without DockerfilePath and default to Dockerfile",
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{Name: "v1.0", Revision: "main"},
+							{Name: "v2.0", Revision: "develop", Context: "app2"},
 						},
 					},
 				},
@@ -387,18 +381,18 @@ func TestBuildVersionInfoMap(t *testing.T) {
 				assert.Equal(t, "v1.0", result["v1.0"].OriginalVersion)
 				assert.Equal(t, "v1-0", result["v1.0"].SanitizedVersion)
 				assert.Equal(t, "main", result["v1.0"].Revision)
-				assert.Equal(t, "Dockerfile", result["v1.0"].DockerfileURI)
+				assert.Equal(t, "Dockerfile", result["v1.0"].DockerfilePath)
 
 				assert.Equal(t, "v2.0", result["v2.0"].OriginalVersion)
-				assert.Equal(t, "Dockerfile", result["v2.0"].DockerfileURI)
+				assert.Equal(t, "Dockerfile", result["v2.0"].DockerfilePath)
 				assert.Equal(t, "app2", result["v2.0"].Context)
 			},
 		},
 		{
 			name: "should build version info map from status",
-			component: &compapiv1alpha1.Component{
-				Status: compapiv1alpha1.ComponentStatus{
-					Versions: []compapiv1alpha1.ComponentVersionStatus{
+			component: &compv1alpha1.Component{
+				Status: compv1alpha1.ComponentStatus{
+					Versions: []compv1alpha1.ComponentVersionStatus{
 						{Name: "v1.0", Revision: "main"},
 						{Name: "v2.0", Revision: "develop"},
 					},
@@ -410,9 +404,9 @@ func TestBuildVersionInfoMap(t *testing.T) {
 				assert.Equal(t, "v1.0", result["v1.0"].OriginalVersion)
 				assert.Equal(t, "v1-0", result["v1.0"].SanitizedVersion)
 				assert.Equal(t, "main", result["v1.0"].Revision)
-				// Status-based map should not include Context or DockerfileURI
+				// Status-based map should not include Context or DockerfilePath
 				assert.Equal(t, "", result["v1.0"].Context)
-				assert.Equal(t, "", result["v1.0"].DockerfileURI)
+				assert.Equal(t, "", result["v1.0"].DockerfilePath)
 			},
 		},
 	}
@@ -428,67 +422,67 @@ func TestBuildVersionInfoMap(t *testing.T) {
 func TestEqualRepositorySettings(t *testing.T) {
 	tests := []struct {
 		name      string
-		settings1 compapiv1alpha1.RepositorySettings
-		settings2 compapiv1alpha1.RepositorySettings
+		settings1 compv1alpha1.RepositorySettings
+		settings2 compv1alpha1.RepositorySettings
 		expected  bool
 	}{
 		{
 			name: "should detect different comment strategies",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				CommentStrategy: "",
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				CommentStrategy: "disable_all",
 			},
 			expected: false,
 		},
 		{
 			name: "should detect different GitHub app token scope repos",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1", "repo2"},
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1"},
 			},
 			expected: false,
 		},
 		{
 			name: "should consider different ordering of GitHub app token scope repos as equal",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1", "repo2"},
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo2", "repo1"},
 			},
 			expected: true,
 		},
 		{
 			name: "should ignore duplicates when comparing GitHub app token scope repos",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1", "repo1", "repo2"},
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo2", "repo1"},
 			},
 			expected: true,
 		},
 		{
 			name: "should detect different repos despite duplicates",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1", "repo1", "repo2"},
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				GithubAppTokenScopeRepos: []string{"repo1", "repo3", "repo3"},
 			},
 			expected: false,
 		},
 		{
 			name: "should consider equal settings as equal",
-			settings1: compapiv1alpha1.RepositorySettings{
+			settings1: compv1alpha1.RepositorySettings{
 				CommentStrategy:          "",
 				GithubAppTokenScopeRepos: []string{"repo1", "repo2"},
 			},
-			settings2: compapiv1alpha1.RepositorySettings{
+			settings2: compv1alpha1.RepositorySettings{
 				CommentStrategy:          "",
 				GithubAppTokenScopeRepos: []string{"repo1", "repo2"},
 			},
@@ -496,8 +490,8 @@ func TestEqualRepositorySettings(t *testing.T) {
 		},
 		{
 			name:      "should consider empty settings as equal",
-			settings1: compapiv1alpha1.RepositorySettings{},
-			settings2: compapiv1alpha1.RepositorySettings{},
+			settings1: compv1alpha1.RepositorySettings{},
+			settings2: compv1alpha1.RepositorySettings{},
 			expected:  true,
 		},
 	}
@@ -596,12 +590,12 @@ func TestGetVersionsForAction(t *testing.T) {
 func TestHasPipelineRefGit(t *testing.T) {
 	tests := []struct {
 		name     string
-		refGit   *compapiv1alpha1.PipelineRefGit
+		refGit   *compv1alpha1.PipelineRefGit
 		expected bool
 	}{
 		{
 			name: "should return true when all fields set",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
@@ -610,14 +604,14 @@ func TestHasPipelineRefGit(t *testing.T) {
 		},
 		{
 			name: "should return true when only url set",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				Url: "https://github.com/test/repo",
 			},
 			expected: true,
 		},
 		{
 			name:     "should return false when all fields empty",
-			refGit:   &compapiv1alpha1.PipelineRefGit{},
+			refGit:   &compv1alpha1.PipelineRefGit{},
 			expected: false,
 		},
 		{
@@ -664,12 +658,12 @@ func TestHasPipelineRefName(t *testing.T) {
 func TestHasPipelineSpecFromBundle(t *testing.T) {
 	tests := []struct {
 		name           string
-		specFromBundle *compapiv1alpha1.PipelineSpecFromBundle
+		specFromBundle *compv1alpha1.PipelineSpecFromBundle
 		expected       bool
 	}{
 		{
 			name: "should return true when both fields set",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 				Name:   "docker-build",
 			},
@@ -677,14 +671,14 @@ func TestHasPipelineSpecFromBundle(t *testing.T) {
 		},
 		{
 			name: "should return true when only bundle set",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 			},
 			expected: true,
 		},
 		{
 			name:           "should return false when all fields empty",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{},
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{},
 			expected:       false,
 		},
 		{
@@ -705,7 +699,7 @@ func TestHasPipelineSpecFromBundle(t *testing.T) {
 func TestValidatePipelineRefGitFields(t *testing.T) {
 	tests := []struct {
 		name        string
-		refGit      *compapiv1alpha1.PipelineRefGit
+		refGit      *compv1alpha1.PipelineRefGit
 		errorPrefix string
 		wantErrors  int
 		errorSubstr string
@@ -718,7 +712,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should accept all fields set",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
@@ -728,7 +722,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing url",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				PathInRepo: ".tekton/pipeline.yaml",
 				Revision:   "main",
 			},
@@ -738,7 +732,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing pathInRepo",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				Url:      "https://github.com/test/repo",
 				Revision: "main",
 			},
@@ -748,7 +742,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing revision",
-			refGit: &compapiv1alpha1.PipelineRefGit{
+			refGit: &compv1alpha1.PipelineRefGit{
 				Url:        "https://github.com/test/repo",
 				PathInRepo: ".tekton/pipeline.yaml",
 			},
@@ -758,7 +752,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 		},
 		{
 			name:        "should reject all missing fields",
-			refGit:      &compapiv1alpha1.PipelineRefGit{},
+			refGit:      &compv1alpha1.PipelineRefGit{},
 			errorPrefix: "version v1",
 			wantErrors:  3,
 		},
@@ -785,7 +779,7 @@ func TestValidatePipelineRefGitFields(t *testing.T) {
 func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 	tests := []struct {
 		name           string
-		specFromBundle *compapiv1alpha1.PipelineSpecFromBundle
+		specFromBundle *compv1alpha1.PipelineSpecFromBundle
 		errorPrefix    string
 		wantErrors     int
 		errorSubstr    string
@@ -798,7 +792,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name: "should accept both fields set",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 				Name:   "docker-build",
 			},
@@ -807,7 +801,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing bundle",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 				Name: "docker-build",
 			},
 			errorPrefix: "test",
@@ -816,7 +810,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name: "should reject missing name",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 				Bundle: "quay.io/repo/bundle:latest",
 			},
 			errorPrefix: "test",
@@ -825,7 +819,7 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 		},
 		{
 			name:           "should reject all missing fields",
-			specFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{},
+			specFromBundle: &compv1alpha1.PipelineSpecFromBundle{},
 			errorPrefix:    "version v1",
 			wantErrors:     2,
 		},
@@ -852,13 +846,13 @@ func TestValidatePipelineSpecFromBundleFields(t *testing.T) {
 func TestHasPipelineDefConfig(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipelineDef *compapiv1alpha1.PipelineDefinition
+		pipelineDef *compv1alpha1.PipelineDefinition
 		expected    bool
 	}{
 		{
 			name: "should return true for PipelineRefGit",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
-				PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
+				PipelineRefGit: &compv1alpha1.PipelineRefGit{
 					Url: "https://github.com/test/repo",
 				},
 			},
@@ -866,15 +860,15 @@ func TestHasPipelineDefConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for PipelineRefName",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
 				PipelineRefName: "docker-build",
 			},
 			expected: true,
 		},
 		{
 			name: "should return true for PipelineSpecFromBundle",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
-				PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
+				PipelineSpecFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 					Bundle: "quay.io/repo/bundle:latest",
 				},
 			},
@@ -882,7 +876,7 @@ func TestHasPipelineDefConfig(t *testing.T) {
 		},
 		{
 			name:        "should return false for empty definition",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{},
+			pipelineDef: &compv1alpha1.PipelineDefinition{},
 			expected:    false,
 		},
 		{
@@ -903,13 +897,13 @@ func TestHasPipelineDefConfig(t *testing.T) {
 func TestHasPipelineConfig(t *testing.T) {
 	tests := []struct {
 		name     string
-		pipeline *compapiv1alpha1.ComponentBuildPipeline
+		pipeline *compv1alpha1.ComponentBuildPipeline
 		expected bool
 	}{
 		{
 			name: "should return true for PullAndPush",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				PullAndPush: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				PullAndPush: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -917,8 +911,8 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for Pull",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Pull: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Pull: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -926,8 +920,8 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name: "should return true for Push",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{
-				Push: &compapiv1alpha1.PipelineDefinition{
+			pipeline: &compv1alpha1.ComponentBuildPipeline{
+				Push: &compv1alpha1.PipelineDefinition{
 					PipelineRefName: "docker-build",
 				},
 			},
@@ -935,7 +929,7 @@ func TestHasPipelineConfig(t *testing.T) {
 		},
 		{
 			name:     "should return false for empty pipeline",
-			pipeline: &compapiv1alpha1.ComponentBuildPipeline{},
+			pipeline: &compv1alpha1.ComponentBuildPipeline{},
 			expected: false,
 		},
 		{
@@ -956,13 +950,13 @@ func TestHasPipelineConfig(t *testing.T) {
 func TestExtractPipelineDef(t *testing.T) {
 	tests := []struct {
 		name        string
-		pipelineDef *compapiv1alpha1.PipelineDefinition
+		pipelineDef *compv1alpha1.PipelineDefinition
 		validate    func(t *testing.T, result *PipelineDef)
 	}{
 		{
 			name: "should extract PipelineRefGit",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
-				PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
+				PipelineRefGit: &compv1alpha1.PipelineRefGit{
 					Url:        "https://github.com/test/repo",
 					PathInRepo: ".tekton/pipeline.yaml",
 					Revision:   "main",
@@ -977,7 +971,7 @@ func TestExtractPipelineDef(t *testing.T) {
 		},
 		{
 			name: "should extract PipelineRefName",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
 				PipelineRefName: "docker-build",
 			},
 			validate: func(t *testing.T, result *PipelineDef) {
@@ -988,8 +982,8 @@ func TestExtractPipelineDef(t *testing.T) {
 		},
 		{
 			name: "should extract PipelineSpecFromBundle",
-			pipelineDef: &compapiv1alpha1.PipelineDefinition{
-				PipelineSpecFromBundle: &compapiv1alpha1.PipelineSpecFromBundle{
+			pipelineDef: &compv1alpha1.PipelineDefinition{
+				PipelineSpecFromBundle: &compv1alpha1.PipelineSpecFromBundle{
 					Bundle: "quay.io/repo/bundle:latest",
 					Name:   "docker-build",
 				},
@@ -1021,7 +1015,7 @@ func TestExtractPipelineDef(t *testing.T) {
 func TestValidatePipelines(t *testing.T) {
 	tests := []struct {
 		name              string
-		component         *compapiv1alpha1.Component
+		component         *compv1alpha1.Component
 		wantErrors        int
 		wantPipelineCount int
 		errorSubstr       string
@@ -1029,17 +1023,16 @@ func TestValidatePipelines(t *testing.T) {
 	}{
 		{
 			name: "should validate and extract pipelines from default and versions",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-						Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+						Pull: &compv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
 					},
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{Name: "v1", Revision: "main"},
-								{Name: "v2", Revision: "develop"},
-							}}}},
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{Name: "v1", Revision: "main"},
+							{Name: "v2", Revision: "develop"},
+						}}},
 			},
 			wantErrors:        0,
 			wantPipelineCount: 2, // both versions inherit from default
@@ -1056,23 +1049,22 @@ func TestValidatePipelines(t *testing.T) {
 		},
 		{
 			name: "should merge default pipeline with version-specific pipeline",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-						Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pull"},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+						Pull: &compv1alpha1.PipelineDefinition{PipelineRefName: "default-pull"},
 					},
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{
-									Name:     "v1",
-									Revision: "main",
-									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-										Push: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
-									},
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{
+								Name:     "v1",
+								Revision: "main",
+								BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+									Push: &compv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
 								},
-								{Name: "v2", Revision: "develop"},
-							}}}},
+							},
+							{Name: "v2", Revision: "develop"},
+						}}},
 			},
 			wantErrors:        0,
 			wantPipelineCount: 2,
@@ -1089,37 +1081,36 @@ func TestValidatePipelines(t *testing.T) {
 		},
 		{
 			name: "should handle default PullAndPush with version-specific Pull, Push, and PullAndPush",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pullandpush"},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compv1alpha1.PipelineDefinition{PipelineRefName: "default-pullandpush"},
 					},
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{
-									Name:     "v1",
-									Revision: "main",
-									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-										Pull: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pull"},
-									},
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{
+								Name:     "v1",
+								Revision: "main",
+								BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+									Pull: &compv1alpha1.PipelineDefinition{PipelineRefName: "custom-pull"},
 								},
-								{
-									Name:     "v2",
-									Revision: "develop",
-									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-										Push: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
-									},
+							},
+							{
+								Name:     "v2",
+								Revision: "develop",
+								BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+									Push: &compv1alpha1.PipelineDefinition{PipelineRefName: "custom-push"},
 								},
-								{
-									Name:     "v3",
-									Revision: "release",
-									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-										PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "custom-pullandpush"},
-									},
+							},
+							{
+								Name:     "v3",
+								Revision: "release",
+								BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+									PullAndPush: &compv1alpha1.PipelineDefinition{PipelineRefName: "custom-pullandpush"},
 								},
-								{Name: "v4", Revision: "staging"},
-							}}}},
+							},
+							{Name: "v4", Revision: "staging"},
+						}}},
 			},
 			wantErrors:        0,
 			wantPipelineCount: 4,
@@ -1144,55 +1135,52 @@ func TestValidatePipelines(t *testing.T) {
 		},
 		{
 			name: "should detect validation errors in default pipeline",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
-						Pull:        &compapiv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
+						Pull:        &compv1alpha1.PipelineDefinition{PipelineRefName: "docker-build"},
 					},
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{Name: "v1", Revision: "main"},
-							}}}},
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{Name: "v1", Revision: "main"},
+						}}},
 			},
 			wantErrors:  1,
 			errorSubstr: "cannot specify pull-and-push together with pull or push",
 		},
 		{
 			name: "should detect validation errors in version-specific pipeline",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								{
-									Name:     "v1",
-									Revision: "main",
-									BuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-										Pull: &compapiv1alpha1.PipelineDefinition{
-											PipelineRefGit: &compapiv1alpha1.PipelineRefGit{
-												Url: "https://github.com/test/repo",
-												// Missing required fields
-											},
-										}}}}}}},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							{
+								Name:     "v1",
+								Revision: "main",
+								BuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+									Pull: &compv1alpha1.PipelineDefinition{
+										PipelineRefGit: &compv1alpha1.PipelineRefGit{
+											Url: "https://github.com/test/repo",
+											// Missing required fields
+										},
+									}}}}}},
 			},
 			wantErrors:  2, // missing pathInRepo and revision
 			errorSubstr: "is required",
 		},
 		{
 			name: "should propagate default PullAndPush to version with nil BuildPipeline",
-			component: &compapiv1alpha1.Component{
-				Spec: compapiv1alpha1.ComponentSpec{
-					DefaultBuildPipeline: &compapiv1alpha1.ComponentBuildPipeline{
-						PullAndPush: &compapiv1alpha1.PipelineDefinition{PipelineRefName: "default-pipeline"},
+			component: &compv1alpha1.Component{
+				Spec: compv1alpha1.ComponentSpec{
+					DefaultBuildPipeline: &compv1alpha1.ComponentBuildPipeline{
+						PullAndPush: &compv1alpha1.PipelineDefinition{PipelineRefName: "default-pipeline"},
 					},
-					Source: compapiv1alpha1.ComponentSource{
-						ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-							Versions: []compapiv1alpha1.ComponentVersion{
-								// Explicitly set to nil to test this critical scenario
-								{Name: "v1", Revision: "main", BuildPipeline: nil},
-							}}}},
+					Source: compv1alpha1.ComponentSource{
+						Versions: []compv1alpha1.ComponentVersion{
+							// Explicitly set to nil to test this critical scenario
+							{Name: "v1", Revision: "main", BuildPipeline: nil},
+						}}},
 			},
 			wantErrors:        0,
 			wantPipelineCount: 1,
@@ -1250,17 +1238,15 @@ func TestValidatePipelines(t *testing.T) {
 }
 
 func TestDetermineVersionsToCreateConfiguration(t *testing.T) {
-	getComponent := func(allVersions bool, version string, versions []string) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(allVersions bool, version string, versions []string) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testcomponent",
 				Namespace: "workspace-name",
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL: "https://github.com/user/repo.git",
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL: "https://github.com/user/repo.git",
 				},
 			},
 		}
@@ -1283,7 +1269,7 @@ func TestDetermineVersionsToCreateConfiguration(t *testing.T) {
 
 	tests := []struct {
 		name                             string
-		component                        compapiv1alpha1.Component
+		component                        compv1alpha1.Component
 		wantVersionsToCreatePRFor        []string
 		wantInvalidVersionsToCreatePRFor []string
 	}{
@@ -1332,21 +1318,19 @@ func TestDetermineVersionsToCreateConfiguration(t *testing.T) {
 }
 
 func TestDetermineVersionsToOnboardAndOffboard(t *testing.T) {
-	getComponent := func(specVersions []compapiv1alpha1.ComponentVersion, statusVersions []compapiv1alpha1.ComponentVersionStatus) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(specVersions []compv1alpha1.ComponentVersion, statusVersions []compv1alpha1.ComponentVersionStatus) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testcomponent",
 				Namespace: "workspace-name",
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL:   "https://github.com/user/repo.git",
-						Versions: specVersions,
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL:   "https://github.com/user/repo.git",
+					Versions: specVersions,
 				},
 			},
-			Status: compapiv1alpha1.ComponentStatus{
+			Status: compv1alpha1.ComponentStatus{
 				Versions: statusVersions,
 			},
 		}
@@ -1355,22 +1339,22 @@ func TestDetermineVersionsToOnboardAndOffboard(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		component              compapiv1alpha1.Component
+		component              compv1alpha1.Component
 		wantVersionsToOnboard  []string
 		wantVersionsToOffboard []string
 	}{
 		{
 			name: "should identify versions to onboard",
 			component: getComponent(
-				[]compapiv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
-				[]compapiv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}}),
+				[]compv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
+				[]compv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}}),
 			wantVersionsToOnboard:  []string{"v2"},
 			wantVersionsToOffboard: []string{},
 		},
 		{
 			name: "should identify all versions to onboard when status is empty",
 			component: getComponent(
-				[]compapiv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
+				[]compv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
 				nil),
 			wantVersionsToOnboard:  []string{"v1", "v2"},
 			wantVersionsToOffboard: []string{},
@@ -1378,8 +1362,8 @@ func TestDetermineVersionsToOnboardAndOffboard(t *testing.T) {
 		{
 			name: "should identify versions to offboard",
 			component: getComponent(
-				[]compapiv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}},
-				[]compapiv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
+				[]compv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}},
+				[]compv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
 			),
 			wantVersionsToOnboard:  []string{},
 			wantVersionsToOffboard: []string{"v2"},
@@ -1387,8 +1371,8 @@ func TestDetermineVersionsToOnboardAndOffboard(t *testing.T) {
 		{
 			name: "should identify both versions to onboard and offboard simultaneously",
 			component: getComponent(
-				[]compapiv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v3", Revision: "feature"}},
-				[]compapiv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
+				[]compv1alpha1.ComponentVersion{{Name: "v1", Revision: "main"}, {Name: "v3", Revision: "feature"}},
+				[]compv1alpha1.ComponentVersionStatus{{Name: "v1", Revision: "main"}, {Name: "v2", Revision: "develop"}},
 			),
 			wantVersionsToOnboard:  []string{"v3"},
 			wantVersionsToOffboard: []string{"v2"},
@@ -1417,19 +1401,17 @@ func TestDetermineVersionsToOnboardAndOffboard(t *testing.T) {
 }
 
 func TestDetermineVersionsToTriggerBuild(t *testing.T) {
-	getComponent := func(triggerVersion string, triggerVersions []string) compapiv1alpha1.Component {
-		component := compapiv1alpha1.Component{
+	getComponent := func(triggerVersion string, triggerVersions []string) compv1alpha1.Component {
+		component := compv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testcomponent",
 				Namespace: "workspace-name",
 			},
-			Spec: compapiv1alpha1.ComponentSpec{
-				Source: compapiv1alpha1.ComponentSource{
-					ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-						GitURL: "https://github.com/user/repo.git",
-					},
+			Spec: compv1alpha1.ComponentSpec{
+				Source: compv1alpha1.ComponentSource{
+					GitURL: "https://github.com/user/repo.git",
 				},
-				Actions: compapiv1alpha1.ComponentActions{TriggerBuild: triggerVersion, TriggerBuilds: triggerVersions},
+				Actions: compv1alpha1.ComponentActions{TriggerBuild: triggerVersion, TriggerBuilds: triggerVersions},
 			},
 		}
 		return component
@@ -1442,7 +1424,7 @@ func TestDetermineVersionsToTriggerBuild(t *testing.T) {
 
 	tests := []struct {
 		name                                 string
-		component                            compapiv1alpha1.Component
+		component                            compv1alpha1.Component
 		versionsToOnboard                    []string
 		versionsToCreatePRFor                []string
 		wantVersionsToTriggerBuildFor        []string

--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO remove whole file after only new model is used
+// TODO remove whole file after only new model is used and old model is gone
 package controllers
 
 import (
@@ -54,8 +54,8 @@ import (
 
 const (
 	contextTimeout = 300 * time.Second
-	// PipelineRunTypeLabelName contains the type of the PipelineRunType
-	PipelineRunTypeLabelName = "pipelines.appstudio.openshift.io/type"
+	// PipelineRunTypeLabelNameOldModel contains the type of the PipelineRunType
+	PipelineRunTypeLabelNameOldModel = "pipelines.appstudio.openshift.io/type"
 	// PipelineRunBuildType is the type denoting a build PipelineRun.
 	PipelineRunBuildType = "build"
 	// PacEventTypeAnnotationName represents the current event type
@@ -450,7 +450,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 		targets = append(targets, newTargets...)
 	}
 
-	gitRepoAtShaLink := pipelineRun.Annotations[gitRepoAtShaAnnotationName]
+	gitRepoAtShaLink := pipelineRun.Annotations[gitRepoAtShaAnnotationNameOldModel]
 	if len(targets) > 0 {
 		log.Info("will create renovate job")
 		simpleBranchName := false
@@ -525,7 +525,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 	// the finalizer.
 
 	pipelines := tektonapi.PipelineRunList{}
-	err = r.Client.List(ctx, &pipelines, client.InNamespace(pipelineRun.Namespace), client.MatchingLabels{PipelineRunTypeLabelName: PipelineRunBuildType, ComponentNameLabelName: updatedComponent.Name})
+	err = r.Client.List(ctx, &pipelines, client.InNamespace(pipelineRun.Namespace), client.MatchingLabels{PipelineRunTypeLabelNameOldModel: PipelineRunBuildType, ComponentNameLabelNameOldModel: updatedComponent.Name})
 	if err != nil {
 		// I don't think we want to retry this, it should be really rare anyway
 		// and would require an even more complex label based state machine.
@@ -733,12 +733,12 @@ func IsBuildPushPipelineRun(object client.Object) bool {
 	if pipelineRun, ok := object.(*tektonapi.PipelineRun); ok {
 
 		// Ensure the PipelineRun belongs to a Component
-		if pipelineRun.Labels == nil || pipelineRun.Labels[ComponentNameLabelName] == "" {
+		if pipelineRun.Labels == nil || pipelineRun.Labels[ComponentNameLabelNameOldModel] == "" {
 			// PipelineRun does not belong to a Component
 			return false
 		}
 		if pipelineRun.Labels != nil && pipelineRun.Annotations != nil {
-			if pipelineRun.Labels[PipelineRunTypeLabelName] == PipelineRunBuildType && (strings.EqualFold(pipelineRun.Annotations[PacEventTypeAnnotationName], PacEventPushType) || strings.EqualFold(pipelineRun.Annotations[PacEventTypeAnnotationName], PacEventIncomingType)) {
+			if pipelineRun.Labels[PipelineRunTypeLabelNameOldModel] == PipelineRunBuildType && (strings.EqualFold(pipelineRun.Annotations[PacEventTypeAnnotationName], PacEventPushType) || strings.EqualFold(pipelineRun.Annotations[PacEventTypeAnnotationName], PacEventIncomingType)) {
 				return true
 			}
 		}
@@ -749,7 +749,7 @@ func IsBuildPushPipelineRun(object client.Object) bool {
 // GetComponentFromPipelineRun loads from the cluster the Component referenced in the given PipelineRun. If the PipelineRun doesn't
 // specify a Component we return nil, if the component is not specified we return an error
 func GetComponentFromPipelineRun(c client.Client, ctx context.Context, pipelineRun *tektonapi.PipelineRun) (*compapiv1alpha1.Component, error) {
-	if componentName, found := pipelineRun.Labels[ComponentNameLabelName]; found {
+	if componentName, found := pipelineRun.Labels[ComponentNameLabelNameOldModel]; found {
 		component := &compapiv1alpha1.Component{}
 		err := c.Get(ctx, types.NamespacedName{
 			Namespace: pipelineRun.Namespace,

--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -1124,10 +1124,10 @@ func createBuildPipelineRun(name, namespace, component, imageBuiltFrom string) *
 		},
 	}
 	run := tektonapi.PipelineRun{}
-	run.Labels = map[string]string{ComponentNameLabelName: component, PipelineRunTypeLabelName: PipelineRunBuildType}
-	run.Annotations = map[string]string{PacEventTypeAnnotationName: PacEventPushType, NudgeFilesAnnotationName: ".*Dockerfile.*, .*.yaml, .*Containerfile.*", gitRepoAtShaAnnotationName: "https://github.com/foo/bar/-/tree/4b00cdb6ceb84d3953d8987e3e06f967a6d86e76"}
+	run.Labels = map[string]string{ComponentNameLabelNameOldModel: component, ApplicationNameLabelName: HASAppName, PipelineRunTypeLabelNameOldModel: PipelineRunBuildType}
+	run.Annotations = map[string]string{PacEventTypeAnnotationName: PacEventPushType, NudgeFilesAnnotationName: ".*Dockerfile.*, .*.yaml, .*Containerfile.*", gitRepoAtShaAnnotationNameOldModel: "https://github.com/foo/bar/-/tree/4b00cdb6ceb84d3953d8987e3e06f967a6d86e76"}
 	if imageBuiltFrom != "" {
-		run.Annotations[gitRepoAtShaAnnotationName] = imageBuiltFrom
+		run.Annotations[gitRepoAtShaAnnotationNameOldModel] = imageBuiltFrom
 	}
 	run.Namespace = namespace
 	run.Name = name

--- a/internal/controller/pac_pipelinerun_pruner_controller_oldmodel.go
+++ b/internal/controller/pac_pipelinerun_pruner_controller_oldmodel.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO remove whole file after only new model is used and old model is gone
+
 package controllers //nolint:dupl
 
 import (
@@ -32,23 +34,25 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	l "github.com/konflux-ci/build-service/pkg/logs"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-// PaCPipelineRunPrunerReconciler watches AppStudio Component object in order to clean up
+// PaCPipelineRunPrunerReconcilerOldModel watches AppStudio Component object in order to clean up
 // running PipelineRuns created by Pipeline-as-Code when the Component gets deleted.
-type PaCPipelineRunPrunerReconciler struct {
+// nolint:dupl
+type PaCPipelineRunPrunerReconcilerOldModel struct {
 	Client        client.Client
 	Scheme        *runtime.Scheme
 	EventRecorder events.EventRecorder
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PaCPipelineRunPrunerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+// nolint:dupl
+func (r *PaCPipelineRunPrunerReconcilerOldModel) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&compv1alpha1.Component{}, builder.WithPredicates(predicate.Funcs{
+		For(&compapiv1alpha1.Component{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
 				return false
 			},
@@ -62,16 +66,18 @@ func (r *PaCPipelineRunPrunerReconciler) SetupWithManager(mgr ctrl.Manager) erro
 				return false
 			},
 		})).
-		Named("PaCPipelineRunPruner").
+		Named("PaCPipelineRunPrunerOld").
 		Complete(r)
 }
 
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;delete;deletecollection;update;patch
 
-func (r *PaCPipelineRunPrunerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile for pipeline pruner
+// nolint:dupl
+func (r *PaCPipelineRunPrunerReconcilerOldModel) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx).WithName("PaCPipelineRunPruner")
 
-	var component compv1alpha1.Component
+	var component compapiv1alpha1.Component
 	err := r.Client.Get(ctx, req.NamespacedName, &component)
 	if err == nil {
 		// The Component has been recreated.
@@ -92,10 +98,11 @@ func (r *PaCPipelineRunPrunerReconciler) Reconcile(ctx context.Context, req ctrl
 }
 
 // PrunePipelineRuns deletes PipelineRuns, if any, assocoated with the given Component.
-func (r *PaCPipelineRunPrunerReconciler) PrunePipelineRuns(ctx context.Context, req ctrl.Request) error {
+// nolint:dupl
+func (r *PaCPipelineRunPrunerReconcilerOldModel) PrunePipelineRuns(ctx context.Context, req ctrl.Request) error {
 	log := ctrllog.FromContext(ctx)
 
-	componentPipelineRunsRequirement, err := labels.NewRequirement(ComponentNameLabelName, selection.Equals, []string{req.Name})
+	componentPipelineRunsRequirement, err := labels.NewRequirement(ComponentNameLabelNameOldModel, selection.Equals, []string{req.Name})
 	if err != nil {
 		return err
 	}

--- a/internal/controller/pac_pipelinerun_pruner_controller_test.go
+++ b/internal/controller/pac_pipelinerun_pruner_controller_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 var _ = Describe("Component PipelineRuns pruner controller", func() {
-
-	// TODO remove after only new model is used
+	// TODO remove after only new model is used and old model is gone
 	Context("Test Component PipelineRuns pruning Old Model", func() {
 
 		var (
@@ -46,35 +45,35 @@ var _ = Describe("Component PipelineRuns pruner controller", func() {
 		})
 
 		It("should not fail if nothing to prune", func() {
-			Expect(listComponentPipelineRuns(resourcePrunerKey)).To(BeEmpty())
+			Expect(listComponentPipelineRunsOldModel(resourcePrunerKey)).To(BeEmpty())
 
-			deleteComponent(resourcePrunerKey)
+			deleteComponentOldModel(resourcePrunerKey)
 			waitNoPipelineRunsForComponent(resourcePrunerKey)
 		})
 
 		It("should prune single PipelineRun", func() {
-			createPaCPipelineRunWithName(resourcePrunerKey, resourcePrunerKey.Name)
-			Expect(listComponentPipelineRuns(resourcePrunerKey)).To(HaveLen(1))
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, resourcePrunerKey.Name)
+			Expect(listComponentPipelineRunsOldModel(resourcePrunerKey)).To(HaveLen(1))
 
-			deleteComponent(resourcePrunerKey)
+			deleteComponentOldModel(resourcePrunerKey)
 			waitNoPipelineRunsForComponent(resourcePrunerKey)
 		})
 
 		It("should prune all PipelineRuns", func() {
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-pull-request-j7gpx")
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-pull-request-j05ew")
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-push-vk1t5")
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-push-b9i8p")
-			Expect(listComponentPipelineRuns(resourcePrunerKey)).To(HaveLen(4))
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-pull-request-j7gpx")
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-pull-request-j05ew")
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-push-vk1t5")
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-push-b9i8p")
+			Expect(listComponentPipelineRunsOldModel(resourcePrunerKey)).To(HaveLen(4))
 
-			deleteComponent(resourcePrunerKey)
+			deleteComponentOldModel(resourcePrunerKey)
 			waitNoPipelineRunsForComponent(resourcePrunerKey)
 		})
 
 		It("should prune only PipelineRuns that belong to the Component", func() {
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-pull-request-j7gpx")
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-push-vk1t5")
-			Expect(listComponentPipelineRuns(resourcePrunerKey)).To(HaveLen(2))
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-pull-request-j7gpx")
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-push-vk1t5")
+			Expect(listComponentPipelineRunsOldModel(resourcePrunerKey)).To(HaveLen(2))
 
 			anotherComponentKey := types.NamespacedName{Namespace: namespace, Name: "component2"}
 			createCustomComponentWithBuildRequest(componentConfigOldModel{
@@ -84,14 +83,14 @@ var _ = Describe("Component PipelineRuns pruner controller", func() {
 
 			anotherComponentPipelineRun1Name := "component2-on-pull-request-5r2je"
 			anotherComponentPipelineRun2Name := "component2-on-push-owt1l"
-			createPaCPipelineRunWithName(anotherComponentKey, anotherComponentPipelineRun1Name)
-			createPaCPipelineRunWithName(anotherComponentKey, anotherComponentPipelineRun2Name)
-			Expect(listComponentPipelineRuns(anotherComponentKey)).To(HaveLen(2))
+			createPaCPipelineRunWithNameOldModel(anotherComponentKey, anotherComponentPipelineRun1Name)
+			createPaCPipelineRunWithNameOldModel(anotherComponentKey, anotherComponentPipelineRun2Name)
+			Expect(listComponentPipelineRunsOldModel(anotherComponentKey)).To(HaveLen(2))
 
-			deleteComponent(resourcePrunerKey)
+			deleteComponentOldModel(resourcePrunerKey)
 			waitNoPipelineRunsForComponent(resourcePrunerKey)
 
-			anotherComponentPipelineRuns := listComponentPipelineRuns(anotherComponentKey)
+			anotherComponentPipelineRuns := listComponentPipelineRunsOldModel(anotherComponentKey)
 			Expect(anotherComponentPipelineRuns).To(HaveLen(2))
 			for _, pipelineRun := range anotherComponentPipelineRuns {
 				switch pipelineRun.Name {
@@ -103,14 +102,14 @@ var _ = Describe("Component PipelineRuns pruner controller", func() {
 				}
 			}
 
-			deleteComponent(anotherComponentKey)
+			deleteComponentOldModel(anotherComponentKey)
 			waitNoPipelineRunsForComponent(anotherComponentKey)
 		})
 
 		It("should not prune PipelineRuns that belong to the Component with the same name in a different namespace", func() {
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-pull-request-z2opy")
-			createPaCPipelineRunWithName(resourcePrunerKey, "component-on-push-pk8u5")
-			Expect(listComponentPipelineRuns(resourcePrunerKey)).To(HaveLen(2))
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-pull-request-z2opy")
+			createPaCPipelineRunWithNameOldModel(resourcePrunerKey, "component-on-push-pk8u5")
+			Expect(listComponentPipelineRunsOldModel(resourcePrunerKey)).To(HaveLen(2))
 
 			anotherComponentNamespace := "pipelines-pruner-test-namespace-old"
 			createNamespace(anotherComponentNamespace)
@@ -123,14 +122,14 @@ var _ = Describe("Component PipelineRuns pruner controller", func() {
 
 			anotherComponentPipelineRun1Name := "component2-on-pull-request-ia8c4"
 			anotherComponentPipelineRun2Name := "component2-on-push-l0dni"
-			createPaCPipelineRunWithName(anotherComponentKey, anotherComponentPipelineRun1Name)
-			createPaCPipelineRunWithName(anotherComponentKey, anotherComponentPipelineRun2Name)
-			Expect(listComponentPipelineRuns(anotherComponentKey)).To(HaveLen(2))
+			createPaCPipelineRunWithNameOldModel(anotherComponentKey, anotherComponentPipelineRun1Name)
+			createPaCPipelineRunWithNameOldModel(anotherComponentKey, anotherComponentPipelineRun2Name)
+			Expect(listComponentPipelineRunsOldModel(anotherComponentKey)).To(HaveLen(2))
 
-			deleteComponent(resourcePrunerKey)
+			deleteComponentOldModel(resourcePrunerKey)
 			waitNoPipelineRunsForComponent(resourcePrunerKey)
 
-			anotherComponentPipelineRuns := listComponentPipelineRuns(anotherComponentKey)
+			anotherComponentPipelineRuns := listComponentPipelineRunsOldModel(anotherComponentKey)
 			Expect(anotherComponentPipelineRuns).To(HaveLen(2))
 			for _, pipelineRun := range anotherComponentPipelineRuns {
 				switch pipelineRun.Name {
@@ -142,7 +141,7 @@ var _ = Describe("Component PipelineRuns pruner controller", func() {
 				}
 			}
 
-			deleteComponent(anotherComponentKey)
+			deleteComponentOldModel(anotherComponentKey)
 			waitNoPipelineRunsForComponent(anotherComponentKey)
 			deleteNamespace(anotherComponentNamespace)
 		})

--- a/internal/controller/renovate_util.go
+++ b/internal/controller/renovate_util.go
@@ -1,4 +1,4 @@
-// TODO remove whole file after only new model is used
+// TODO remove whole file after only new model is used and old model is gone
 package controllers
 
 import (
@@ -160,18 +160,17 @@ func NewComponentDependenciesUpdater(client client.Client, scheme *runtime.Schem
 // GetUpdateTargetsBasicAuth This method returns targets for components based on basic auth
 func (u ComponentDependenciesUpdater) GetUpdateTargetsBasicAuth(ctx context.Context, componentList []compapiv1alpha1.Component, imageRepositoryHost, imageRepositoryUsername, imageRepositoryPassword string) []updateTarget {
 	log := logger.FromContext(ctx)
-	newModel := false
 	targetsToUpdate := []updateTarget{}
 
 	for _, comp := range componentList {
 		component := comp
-		gitProvider, err := getGitProvider(component, newModel)
+		gitProvider, err := getGitProviderOldModel(component)
 		if err != nil {
 			log.Error(err, "error detecting git provider", "ComponentName", component.Name, "ComponentNamespace", component.Namespace)
 			continue
 		}
 
-		repoUrl := getGitRepoUrl(component, newModel)
+		repoUrl := getGitRepoUrlOldModel(component)
 		scmComponent, err := git.NewScmComponent(gitProvider, repoUrl, component.Spec.Source.GitSource.Revision, component.Name, component.Namespace)
 		if err != nil {
 			log.Error(err, "error parsing component", "ComponentName", component.Name, "ComponentNamespace", component.Namespace)
@@ -247,7 +246,6 @@ func (u ComponentDependenciesUpdater) GetUpdateTargetsBasicAuth(ctx context.Cont
 // GetUpdateTargetsGithubApp This method returns targets for components based on github app
 func (u ComponentDependenciesUpdater) GetUpdateTargetsGithubApp(ctx context.Context, componentList []compapiv1alpha1.Component, imageRepositoryHost, imageRepositoryUsername, imageRepositoryPassword string) []updateTarget {
 	log := logger.FromContext(ctx)
-	newModel := false
 	// Check if GitHub Application is used, if not then skip
 	pacSecret := corev1.Secret{}
 	globalPaCSecretKey := types.NamespacedName{Namespace: common.BuildServiceNamespaceName, Name: common.PipelinesAsCodeGitHubAppSecretName}
@@ -282,7 +280,7 @@ func (u ComponentDependenciesUpdater) GetUpdateTargetsGithubApp(ctx context.Cont
 			continue
 		}
 
-		gitProvider, err := getGitProvider(component, newModel)
+		gitProvider, err := getGitProviderOldModel(component)
 		if err != nil {
 			log.Error(err, "error detecting git provider", "ComponentName", component.Name, "ComponentNamespace", component.Namespace)
 			continue
@@ -293,7 +291,7 @@ func (u ComponentDependenciesUpdater) GetUpdateTargetsGithubApp(ctx context.Cont
 
 		gitSource := component.Spec.Source.GitSource
 
-		url := getGitRepoUrl(component, newModel)
+		url := getGitRepoUrlOldModel(component)
 		log.Info("getting app installation for component repository", "ComponentName", component.Name, "ComponentNamespace", component.Namespace, "RepositoryUrl", url)
 		githubAppInstallation, slugTmp, err := github.GetAppInstallationsForRepository(githubAppIdStr, privateKey, url)
 		if err != nil {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	imagerepositoryapi "github.com/konflux-ci/image-controller/api/v1alpha1"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
@@ -79,7 +80,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	applicationApiDepVersion := "v0.0.0-20260529131129-a9594acdc104"
+	applicationApiDepVersion := "v0.0.0-20260727123715-2999a91451c6"
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "hack", "routecrd", "route.yaml"),
@@ -101,7 +102,11 @@ var _ = BeforeSuite(func() {
 	err = routev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	// TODO remove after only new model is used and old model is gone
 	err = compapiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = compv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = tektonapi.AddToScheme(scheme.Scheme)
@@ -125,7 +130,9 @@ var _ = BeforeSuite(func() {
 	defaultNS := &corev1.Namespace{}
 	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: HASAppNamespace}, defaultNS)).Should(Succeed())
 	defaultNS.SetLabels(map[string]string{
-		appstudioWorkspaceNameLabel: "build",
+		konfluxWorkspaceNameLabel: "build",
+		// TODO remove after only new model is used and old model is gone
+		appstudioWorkspaceNameLabelOldModel: "build-old",
 	})
 	Expect(k8sClient.Update(ctx, defaultNS)).Should(Succeed())
 
@@ -149,6 +156,16 @@ var _ = BeforeSuite(func() {
 	err = (&ComponentBuildReconciler{
 		Client:             k8sManager.GetClient(),
 		Scheme:             k8sManager.GetScheme(),
+		EventRecorder:      k8sManager.GetEventRecorder("ComponentBuildReconciler"),
+		PaCWebhookMapping:  pacWebhookMapping,
+		CredentialProvider: k8s.NewGitCredentialProvider(k8sManager.GetClient()),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// TODO remove after only new model is used and old model is gone
+	err = (&ComponentBuildReconcilerOldModel{
+		Client:             k8sManager.GetClient(),
+		Scheme:             k8sManager.GetScheme(),
 		EventRecorder:      k8sManager.GetEventRecorder("ComponentOnboarding"),
 		PaCWebhookMapping:  pacWebhookMapping,
 		CredentialProvider: k8s.NewGitCredentialProvider(k8sManager.GetClient()),
@@ -159,6 +176,14 @@ var _ = BeforeSuite(func() {
 		Client:        k8sManager.GetClient(),
 		Scheme:        k8sManager.GetScheme(),
 		EventRecorder: k8sManager.GetEventRecorder("PaCPipelineRunPruner"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// TODO remove after only new model is used and old model is gone
+	err = (&PaCPipelineRunPrunerReconcilerOldModel{
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		EventRecorder: k8sManager.GetEventRecorder("PaCPipelineRunPrunerOld"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -41,6 +41,7 @@ import (
 
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	imgcv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
@@ -62,11 +63,11 @@ const (
 )
 
 const (
-	// TODO remove after only new model is used
+	// TODO remove after only new model is used and old model is gone
 	HASAppName = "test-application"
-	// TODO remove after only new model is used
+	// TODO remove after only new model is used and old model is gone
 	HASCompName = "test-component"
-	// TODO remove after only new model is used
+	// TODO remove after only new model is used and old model is gone
 	HASAppNamespace         = "default"
 	DefaultCompName         = "test-component"
 	DefaultCompNamespace    = "default"
@@ -90,17 +91,17 @@ var (
 type componentConfig struct {
 	componentKey       types.NamespacedName
 	containerImage     string
-	versions           []compapiv1alpha1.ComponentVersion
+	versions           []compv1alpha1.ComponentVersion
 	gitURL             string
 	annotations        map[string]string
 	finalizers         []string
-	actions            compapiv1alpha1.ComponentActions
-	repositorySettings compapiv1alpha1.RepositorySettings
-	defaultPipeline    *compapiv1alpha1.ComponentBuildPipeline
+	actions            compv1alpha1.ComponentActions
+	repositorySettings compv1alpha1.RepositorySettings
+	defaultPipeline    *compv1alpha1.ComponentBuildPipeline
 	skipOffboardingPr  bool
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 type componentConfigOldModel struct {
 	componentKey     types.NamespacedName
 	containerImage   string
@@ -112,7 +113,7 @@ type componentConfigOldModel struct {
 	finalizers       []string
 }
 
-func getComponentData(config componentConfig) *compapiv1alpha1.Component {
+func getComponentData(config componentConfig) *compv1alpha1.Component {
 	name := config.componentKey.Name
 	if name == "" {
 		name = DefaultCompName
@@ -132,13 +133,11 @@ func getComponentData(config componentConfig) *compapiv1alpha1.Component {
 	versions := config.versions
 	// Only add default version if versions is nil (not set), not if it's explicitly empty []
 	if versions == nil {
-		versions = []compapiv1alpha1.ComponentVersion{
+		versions = []compv1alpha1.ComponentVersion{
 			{Name: DefaultVersionName, Revision: DefaultRevisionName, Context: ""},
 		}
 	}
 	annotations := make(map[string]string)
-	// Always set new model annotation for components created with getComponentData
-	annotations["build.appstudio.openshift.io/component_model_version"] = "v2"
 	if config.annotations != nil {
 		for key, value := range config.annotations {
 			annotations[key] = value
@@ -148,9 +147,9 @@ func getComponentData(config componentConfig) *compapiv1alpha1.Component {
 	if len(config.finalizers) != 0 {
 		finalizers = append(finalizers, config.finalizers...)
 	}
-	return &compapiv1alpha1.Component{
+	return &compv1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "appstudio.redhat.com/v1alpha1",
+			APIVersion: "konflux-ci.dev/v1alpha1",
 			Kind:       "Component",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,23 +158,21 @@ func getComponentData(config componentConfig) *compapiv1alpha1.Component {
 			Annotations: annotations,
 			Finalizers:  finalizers,
 		},
-		Spec: compapiv1alpha1.ComponentSpec{
+		Spec: compv1alpha1.ComponentSpec{
 			Actions:              config.actions,
 			RepositorySettings:   config.repositorySettings,
 			DefaultBuildPipeline: config.defaultPipeline,
 			ContainerImage:       image,
 			SkipOffboardingPr:    config.skipOffboardingPr,
-			Source: compapiv1alpha1.ComponentSource{
-				ComponentSourceUnion: compapiv1alpha1.ComponentSourceUnion{
-					GitURL:   gitUrl,
-					Versions: versions,
-				},
+			Source: compv1alpha1.ComponentSource{
+				GitURL:   gitUrl,
+				Versions: versions,
 			},
 		},
 	}
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func getComponentDataOldModel(config componentConfigOldModel) *compapiv1alpha1.Component {
 	name := config.componentKey.Name
 	if name == "" {
@@ -239,16 +236,16 @@ func getComponentDataOldModel(config componentConfigOldModel) *compapiv1alpha1.C
 	}
 }
 
-func getSampleComponentData(componentKey types.NamespacedName) *compapiv1alpha1.Component {
+func getSampleComponentData(componentKey types.NamespacedName) *compv1alpha1.Component {
 	return getComponentData(componentConfig{componentKey: componentKey})
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func getSampleComponentDataOldModel(componentKey types.NamespacedName) *compapiv1alpha1.Component {
 	return getComponentDataOldModel(componentConfigOldModel{componentKey: componentKey})
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // createComponentAndProcessBuildRequest create a component with specified build request and
 // waits until the request annotation is removed, which means the request was processed by the operator.
 // Use createCustomComponentWithBuildRequest if there is no need to wait.
@@ -257,7 +254,7 @@ func createComponentAndProcessBuildRequest(config componentConfigOldModel, build
 	waitComponentAnnotationGone(config.componentKey, BuildRequestAnnotationName)
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func createCustomComponentWithoutBuildRequest(config componentConfigOldModel) {
 	component := getComponentDataOldModel(config)
 	if component.Annotations == nil {
@@ -265,10 +262,10 @@ func createCustomComponentWithoutBuildRequest(config componentConfigOldModel) {
 	}
 
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-	getComponent(config.componentKey)
+	getComponentOldModel(config.componentKey)
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func createCustomComponentWithBuildRequest(config componentConfigOldModel, buildRequest string) {
 	component := getComponentDataOldModel(config)
 	if component.Annotations == nil {
@@ -277,12 +274,12 @@ func createCustomComponentWithBuildRequest(config componentConfigOldModel, build
 	component.Annotations[BuildRequestAnnotationName] = buildRequest
 
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-	getComponent(config.componentKey)
+	getComponentOldModel(config.componentKey)
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func setComponentBuildRequestOldModel(componentKey types.NamespacedName, buildRequest string) {
-	component := getComponent(componentKey)
+	component := getComponentOldModel(componentKey)
 	if component.Annotations == nil {
 		component.Annotations = make(map[string]string)
 	}
@@ -291,7 +288,7 @@ func setComponentBuildRequestOldModel(componentKey types.NamespacedName, buildRe
 	Expect(k8sClient.Update(ctx, component)).To(Succeed())
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // createComponentOldModel creates sample component resource and verifies it was properly created
 func createComponentOldModel(componentLookupKey types.NamespacedName) {
 	component := getSampleComponentDataOldModel(componentLookupKey)
@@ -300,7 +297,7 @@ func createComponentOldModel(componentLookupKey types.NamespacedName) {
 }
 
 // createComponent creates custom component resource and verifies it was properly created
-func createComponent(sampleComponentData *compapiv1alpha1.Component) *compapiv1alpha1.Component {
+func createComponent(sampleComponentData *compv1alpha1.Component) *compv1alpha1.Component {
 	Expect(k8sClient.Create(ctx, sampleComponentData)).Should(Succeed())
 
 	lookupKey := types.NamespacedName{
@@ -311,7 +308,7 @@ func createComponent(sampleComponentData *compapiv1alpha1.Component) *compapiv1a
 	return getComponent(lookupKey)
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 // createComponentCustomOldModel creates custom component resource and verifies it was properly created
 func createComponentCustomOldModel(sampleComponentData *compapiv1alpha1.Component) {
 	Expect(k8sClient.Create(ctx, sampleComponentData)).Should(Succeed())
@@ -321,10 +318,22 @@ func createComponentCustomOldModel(sampleComponentData *compapiv1alpha1.Componen
 		Namespace: sampleComponentData.Namespace,
 	}
 
-	getComponent(lookupKey)
+	getComponentOldModel(lookupKey)
 }
 
-func getComponent(componentKey types.NamespacedName) *compapiv1alpha1.Component {
+func getComponent(componentKey types.NamespacedName) *compv1alpha1.Component {
+	component := &compv1alpha1.Component{}
+	Eventually(func() bool {
+		if err := k8sClient.Get(ctx, componentKey, component); err != nil {
+			return false
+		}
+		return component.ResourceVersion != ""
+	}, timeout, interval).Should(BeTrue())
+	return component
+}
+
+// TODO remove after only new model is used and old model is gone
+func getComponentOldModel(componentKey types.NamespacedName) *compapiv1alpha1.Component {
 	component := &compapiv1alpha1.Component{}
 	Eventually(func() bool {
 		if err := k8sClient.Get(ctx, componentKey, component); err != nil {
@@ -341,7 +350,7 @@ func getComponent(componentKey types.NamespacedName) *compapiv1alpha1.Component 
 // This includes: Repository, ServiceAccount, and incoming Secret.
 func deleteComponentAndOwnedResources(componentKey types.NamespacedName) {
 	// Get component to determine repository name before deletion
-	component := &compapiv1alpha1.Component{}
+	component := &compv1alpha1.Component{}
 	if err := k8sClient.Get(ctx, componentKey, component); err != nil {
 		if !k8sErrors.IsNotFound(err) {
 			Fail(err.Error())
@@ -399,6 +408,29 @@ func deleteComponentAndOwnedResources(componentKey types.NamespacedName) {
 }
 
 func deleteComponent(componentKey types.NamespacedName) {
+	component := &compv1alpha1.Component{}
+
+	// Check if the component exists
+	if err := k8sClient.Get(ctx, componentKey, component); k8sErrors.IsNotFound(err) {
+		return
+	}
+
+	// Delete
+	Eventually(func() error {
+		if err := k8sClient.Get(ctx, componentKey, component); err != nil {
+			return err
+		}
+		return k8sClient.Delete(ctx, component)
+	}, timeout, interval).Should(Succeed())
+
+	// Wait for delete to finish
+	Eventually(func() bool {
+		return k8sErrors.IsNotFound(k8sClient.Get(ctx, componentKey, component))
+	}, timeout, interval).Should(BeTrue())
+}
+
+// TODO remove after only new model is used and old model is gone
+func deleteComponentOldModel(componentKey types.NamespacedName) {
 	component := &compapiv1alpha1.Component{}
 
 	// Check if the component exists
@@ -420,6 +452,7 @@ func deleteComponent(componentKey types.NamespacedName) {
 	}, timeout, interval).Should(BeTrue())
 }
 
+// TODO remove after only new model is used and old model is gone
 func waitFinalizerOnComponent(componentKey types.NamespacedName, finalizerName string, finalizerShouldBePresent bool) {
 	component := &compapiv1alpha1.Component{}
 	Eventually(func() bool {
@@ -435,23 +468,25 @@ func waitFinalizerOnComponent(componentKey types.NamespacedName, finalizerName s
 	}, timeout, interval).Should(BeTrue())
 }
 
+// TODO remove after only new model is used and old model is gone
 func waitPaCFinalizerOnComponent(componentKey types.NamespacedName) {
-	waitFinalizerOnComponent(componentKey, PaCProvisionFinalizer, true)
+	waitFinalizerOnComponent(componentKey, PaCProvisionFinalizerOldModel, true)
 }
 
+// TODO remove after only new model is used and old model is gone
 func waitPaCFinalizerOnComponentGone(componentKey types.NamespacedName) {
-	waitFinalizerOnComponent(componentKey, PaCProvisionFinalizer, false)
+	waitFinalizerOnComponent(componentKey, PaCProvisionFinalizerOldModel, false)
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func waitDoneMessageOnComponentOldModel(componentKey types.NamespacedName) {
 	Eventually(func() bool {
-		buildStatus := readBuildStatus(getComponent(componentKey))
+		buildStatus := readBuildStatus(getComponentOldModel(componentKey))
 		return buildStatus.Message == "done"
 	}, timeout, interval).Should(BeTrue())
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func expectPacBuildStatusOldModel(componentKey types.NamespacedName, state string, errID int, errMessage string, mergeURL string) {
 	// in 1 test component is usually created (which triggers reconcile and adds message=done)
 	// and then component is updated (and waits for message=done apart from other things)
@@ -459,14 +494,14 @@ func expectPacBuildStatusOldModel(componentKey types.NamespacedName, state strin
 	// message might be still done from previous reconcile, but even though requested action already finished,
 	// it didn't update status yet so it will get status from previous reconcile
 	Eventually(func() bool {
-		buildStatus := readBuildStatus(getComponent(componentKey))
+		buildStatus := readBuildStatus(getComponentOldModel(componentKey))
 		Expect(buildStatus).ToNot(BeNil())
 		Expect(buildStatus.PaC).ToNot(BeNil())
 
 		return buildStatus.PaC.State == state
 	}, timeout, interval).Should(BeTrue())
 
-	buildStatus := readBuildStatus(getComponent(componentKey))
+	buildStatus := readBuildStatus(getComponentOldModel(componentKey))
 	Expect(buildStatus).ToNot(BeNil())
 	Expect(buildStatus.PaC).ToNot(BeNil())
 	Expect(buildStatus.PaC.State).To(Equal(state))
@@ -491,6 +526,19 @@ func listComponentPipelineRuns(componentKey types.NamespacedName) []tektonapi.Pi
 	return pipelineRuns.Items
 }
 
+// TODO remove after only new model is used and old model is gone
+func listComponentPipelineRunsOldModel(componentKey types.NamespacedName) []tektonapi.PipelineRun {
+	pipelineRuns := &tektonapi.PipelineRunList{}
+	labelSelectors := client.ListOptions{
+		Raw:       &metav1.ListOptions{LabelSelector: ComponentNameLabelNameOldModel + "=" + componentKey.Name},
+		Namespace: componentKey.Namespace,
+	}
+	err := k8sClient.List(ctx, pipelineRuns, &labelSelectors)
+	Expect(err).ToNot(HaveOccurred())
+	return pipelineRuns.Items
+}
+
+// TODO remove after only new model is used and old model is gone
 func deleteComponentPipelineRuns(componentKey types.NamespacedName) {
 	for _, pipelineRun := range listComponentPipelineRuns(componentKey) {
 		if err := k8sClient.Delete(ctx, &pipelineRun); err != nil {
@@ -520,11 +568,32 @@ func createPaCPipelineRunWithName(resourceKey types.NamespacedName, pipelineRunN
 	}, timeout, interval).Should(BeTrue())
 }
 
+// TODO remove after only new model is used and old model is gone
+func createPaCPipelineRunWithNameOldModel(resourceKey types.NamespacedName, pipelineRunName string) {
+	pipelineRun := &tektonapi.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineRunName,
+			Namespace: resourceKey.Namespace,
+			Labels: map[string]string{
+				ComponentNameLabelNameOldModel: resourceKey.Name,
+				ApplicationNameLabelName:       "test-application",
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pipelineRun)).Should(Succeed())
+
+	pipelineRunKey := types.NamespacedName{Namespace: pipelineRun.Namespace, Name: pipelineRun.Name}
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, pipelineRunKey, pipelineRun)
+		return err == nil
+	}, timeout, interval).Should(BeTrue())
+}
+
 func ensureNoPipelineRunsCreated(componentLookupKey types.NamespacedName) {
 	pipelineRuns := &tektonapi.PipelineRunList{}
 	Consistently(func() bool {
 		labelSelectors := client.ListOptions{
-			Raw:       &metav1.ListOptions{LabelSelector: ComponentNameLabelName + "=" + componentLookupKey.Name},
+			Raw:       &metav1.ListOptions{LabelSelector: ComponentNameLabelNameOldModel + "=" + componentLookupKey.Name},
 			Namespace: componentLookupKey.Namespace,
 		}
 		Expect(k8sClient.List(ctx, pipelineRuns, &labelSelectors)).To(Succeed())
@@ -536,7 +605,7 @@ func waitNoPipelineRunsForComponent(componentLookupKey types.NamespacedName) {
 	pipelineRuns := &tektonapi.PipelineRunList{}
 	Eventually(func() bool {
 		labelSelectors := client.ListOptions{
-			Raw:       &metav1.ListOptions{LabelSelector: ComponentNameLabelName + "=" + componentLookupKey.Name},
+			Raw:       &metav1.ListOptions{LabelSelector: ComponentNameLabelNameOldModel + "=" + componentLookupKey.Name},
 			Namespace: componentLookupKey.Namespace,
 		}
 		Expect(k8sClient.List(ctx, pipelineRuns, &labelSelectors)).To(Succeed())
@@ -544,8 +613,9 @@ func waitNoPipelineRunsForComponent(componentLookupKey types.NamespacedName) {
 	}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 }
 
+// TODO remove after only new model is used and old model is gone
 func createImageRepositoryForComponent(componentKey types.NamespacedName) *imgcv1alpha1.ImageRepository {
-	component := getComponent(componentKey)
+	component := getComponentOldModel(componentKey)
 
 	imageRepository := &imgcv1alpha1.ImageRepository{
 		ObjectMeta: metav1.ObjectMeta{
@@ -671,7 +741,7 @@ func createSCMSecret(resourceKey types.NamespacedName, data map[string]string, s
 	}, timeout, interval).Should(Succeed())
 }
 
-// TODO remove after only new model is used
+// TODO remove after only new model is used and old model is gone
 func createSCMSecretOldModel(resourceKey types.NamespacedName, data map[string]string, secretType corev1.SecretType, annotations map[string]string) {
 	labels := map[string]string{
 		"appstudio.redhat.com/credentials": "scm",
@@ -733,14 +803,6 @@ func waitSecretCreated(resourceKey types.NamespacedName) {
 	}, timeout, interval).Should(BeTrue())
 }
 
-func waitSecretGone(resourceKey types.NamespacedName) {
-	secret := &corev1.Secret{}
-	Eventually(func() bool {
-		err := k8sClient.Get(ctx, resourceKey, secret)
-		return k8sErrors.IsNotFound(err)
-	}, timeout, interval).Should(BeTrue())
-}
-
 func createNamespace(name string) {
 	namespace := corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
@@ -786,7 +848,7 @@ func waitPaCRepositoryCreated(resourceKey types.NamespacedName) *pacv1alpha1.Rep
 // When secretName is empty, it verifies GitProvider is nil (GitHub App authentication).
 // When secretName is provided, it validates token-based authentication with the secret.
 // The expected URL is determined using getGitRepoUrl, and GitProvider type using getGitProvider.
-func validatePaCRepository(component *compapiv1alpha1.Component, secretName, secretKey string, skipBuildsMap map[string]bool) *pacv1alpha1.Repository {
+func validatePaCRepository(component *compv1alpha1.Component, secretName, secretKey string, skipBuildsMap map[string]bool) *pacv1alpha1.Repository {
 	// Generate repository name from git URL
 	expectedRepoName, err := generatePaCRepositoryNameFromGitUrl(component.Spec.Source.GitURL)
 	Expect(err).NotTo(HaveOccurred())
@@ -795,11 +857,11 @@ func validatePaCRepository(component *compapiv1alpha1.Component, secretName, sec
 	repository := waitPaCRepositoryCreated(resourceKey)
 
 	// Get expected URL using getGitRepoUrl
-	expectedURL := getGitRepoUrl(*component, true)
+	expectedURL := getGitRepoUrl(*component)
 	Expect(repository.Spec.URL).To(Equal(expectedURL))
 
 	// Get git provider type
-	gitProvider, err := getGitProvider(*component, true)
+	gitProvider, err := getGitProvider(*component)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Validate GitProvider
@@ -905,9 +967,10 @@ func deleteAllPaCRepositories(namesapce string) {
 	Expect(k8sClient.DeleteAllOf(ctx, &pacv1alpha1.Repository{}, opts)).To(Succeed())
 }
 
+// TODO remove after only new model is used and old model is gone
 func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationName string) {
 	Eventually(func() bool {
-		component := getComponent(componentKey)
+		component := getComponentOldModel(componentKey)
 		annotations := component.GetAnnotations()
 		if annotations == nil {
 			return true
@@ -917,9 +980,10 @@ func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationNa
 	}, timeout, interval).Should(BeTrue())
 }
 
+// TODO remove after only new model is used and old model is gone
 func waitComponentAnnotationExists(componentKey types.NamespacedName, annotationName string) {
 	Eventually(func() bool {
-		component := getComponent(componentKey)
+		component := getComponentOldModel(componentKey)
 		annotations := component.GetAnnotations()
 		if annotations == nil {
 			return false
@@ -929,8 +993,8 @@ func waitComponentAnnotationExists(componentKey types.NamespacedName, annotation
 	}, timeout, interval).Should(BeTrue())
 }
 
-func waitForComponentStatusVersions(componentKey types.NamespacedName, expectedCount int) *compapiv1alpha1.Component {
-	var component *compapiv1alpha1.Component
+func waitForComponentStatusVersions(componentKey types.NamespacedName, expectedCount int) *compv1alpha1.Component {
+	var component *compv1alpha1.Component
 	Eventually(func() bool {
 		component = getComponent(componentKey)
 		return len(component.Status.Versions) == expectedCount
@@ -938,8 +1002,8 @@ func waitForComponentStatusVersions(componentKey types.NamespacedName, expectedC
 	return component
 }
 
-func waitForComponentStatusMessage(componentKey types.NamespacedName, shouldBeEmpty bool) *compapiv1alpha1.Component {
-	var component *compapiv1alpha1.Component
+func waitForComponentStatusMessage(componentKey types.NamespacedName, shouldBeEmpty bool) *compv1alpha1.Component {
+	var component *compv1alpha1.Component
 	Eventually(func() bool {
 		component = getComponent(componentKey)
 		if shouldBeEmpty {
@@ -950,8 +1014,8 @@ func waitForComponentStatusMessage(componentKey types.NamespacedName, shouldBeEm
 	return component
 }
 
-func waitForComponentSpecActionEmpty(componentKey types.NamespacedName, actionType string, checkType string) *compapiv1alpha1.Component {
-	var component *compapiv1alpha1.Component
+func waitForComponentSpecActionEmpty(componentKey types.NamespacedName, actionType string, checkType string) *compv1alpha1.Component {
+	var component *compv1alpha1.Component
 	Eventually(func() bool {
 		component = getComponent(componentKey)
 		if actionType == "create-pr" {
@@ -1312,7 +1376,7 @@ func verifyPacWebhookIncomingPostData(data map[string]interface{}, repository, s
 // OnboardingTime is automatically verified: not empty when succeeded, empty when failed
 // message: verifies exact Message field value (empty string = verify empty)
 // skipBuilds: verifies skip builds for the version
-func verifyComponentVersionStatus(versionStatus compapiv1alpha1.ComponentVersionStatus, versionName, revision, onboardingStatus, configurationMergeURL, message string, skipBuilds bool) {
+func verifyComponentVersionStatus(versionStatus compv1alpha1.ComponentVersionStatus, versionName, revision, onboardingStatus, configurationMergeURL, message string, skipBuilds bool) {
 	Expect(versionStatus.Name).To(Equal(versionName))
 	Expect(versionStatus.Revision).To(Equal(revision))
 	Expect(versionStatus.OnboardingStatus).To(Equal(onboardingStatus))


### PR DESCRIPTION
Add support for the new Component CRD under konflux-ci.dev/v1alpha1 API group
(defined in application-api) alongside existing appstudio.redhat.com/v1alpha1,
enabling both API groups to coexist during migration to the new model.

Dual Controller Infrastructure:
- Created ComponentBuildReconciler (new model) watching konflux-ci.dev/v1alpha1
- Renamed ComponentBuildReconciler to ComponentBuildReconcilerOldModel watching appstudio.redhat.com/v1alpha1
- Duplicated PaCPipelineRunPruner controller for both API groups
- Separated controllers in component_build_controller.go (old) and component_build_controller_v2.go (new)
- Duplicated methods with 'OldModel' suffix for old model reconciler
- Shared controller files now import both API groups

Renamed appstudio → konflux labels/annotations/constants in new model:
- PaCProvisionFinalizer: pac.component.appstudio.openshift.io/finalizer → konflux-ci.dev/component-finalizer
- ComponentNameLabelName: appstudio.openshift.io/component → build.konflux-ci.dev/component
- PipelineRunTypeLabelName: pipelines.appstudio.openshift.io/type → pipelines.konflux-ci.dev/type
- PartOfLabelValue: "appstudio" → "konflux" (PartOfAppStudioLabelValue → PartOfKonfluxLabelValue)
- ContextAnnotationName: appstudio.openshift.io/context → build.konflux-ci.dev/context
- VersionAnnotationName: appstudio.openshift.io/version → build.konflux-ci.dev/version
- gitCommitShaAnnotationName: build.appstudio.redhat.com/commit_sha → build.konflux-ci.dev/commit_sha
- gitRepoAtShaAnnotationName: build.appstudio.openshift.io/repo → build.konflux-ci.dev/repo
- gitPRAnnotationName: build.appstudio.redhat.com/pull_request_number → build.konflux-ci.dev/pull_request_number
- gitTargetBranchAnnotationName: build.appstudio.redhat.com/target_branch → build.konflux-ci.dev/target_branch
- commonBuildSecretLabelName: build.appstudio.openshift.io/common-secret → build.konflux-ci.dev/common-secret
  (both models link secrets with both labels during migration)
- appstudioWorkspaceNameLabel: appstudio.redhat.com/workspace_name → konflux-ci.dev/workspace_name
- pacCustomParamKonfluxWorkspace: "appstudio_workspace" → "konflux_workspace"
Each renamed constant has a corresponding OldModel-suffixed variant retaining the old value.

Critical Migration Safety Fixes:
- Fixed 4 ComponentList query locations to check BOTH API groups during migration:
  * RemovePacWebhook - prevents webhook deletion when components in different groups share Git URL
  * UnconfigureRepositoryForPacOldModel - same protection from old model controller
  * cleanupPaCRepositoryIncomingsAndSkipBuildParams - collects revisions from both groups
  * cleanupPaCRepositoryIncomingsOldModel - same for old model with recalculation pattern
- Replaced name-based component exclusion with DeletionTimestamp check in webhook deletion
  and incoming cleanup - prevents race condition and handles dual-group scenario correctly

Dual-Label Queries During Migration:
- linkCommonSecretsToBuildPipelineServiceAccount: both reconcilers query both old and new
  common secret labels with deduplication
- ensurePaCRepository: checks both workspace labels with correct priority per model
- pacRepoAddParamWorkspaceName split into separate new/old model functions

Pruner Controller Simplification:
- Removed Application label requirement from both pruners — the different ComponentName label key
  now cleanly distinguishes new vs old model PipelineRuns

Nudge Controller:
- Updated component_dependency_update_controller.go to use OldModel-suffixed constants
  for PipelineRun label/annotation lookups

Cleanup Improvements:
- Removed manual incoming secret deletion; now relies on Kubernetes GC via owner references
- Refactored old model incoming cleanup to use recalculation pattern matching new model approach
- Marked all old model code with standardized TODO comments for future removal

[STONEBLD-4824](https://redhat.atlassian.net/browse/STONEBLD-4824)

Signed-off-by: Robert Cerven <rcerven@redhat.com>

[STONEBLD-4824]: https://redhat.atlassian.net/browse/STONEBLD-4824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ