### PR TITLE
feat: component nudging is skipped when in a namespace exists NudgeConfig CR

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,7 @@ rules:
   resources:
   - imagerepositories
   - imagerepositories/status
+  - nudgeconfigs
   - releaseplanadmissions
   verbs:
   - get

--- a/hack/nudgeconfigcrd/nudgeconfig.yaml
+++ b/hack/nudgeconfigcrd/nudgeconfig.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nudgeconfigs.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: NudgeConfig
+    listKind: NudgeConfigList
+    plural: nudgeconfigs
+    singular: nudgeconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: NudgeConfig is the schema for nudge configuration.
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/internal/controller/component_dependency_update_controller.go
+++ b/internal/controller/component_dependency_update_controller.go
@@ -33,7 +33,10 @@ import (
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"knative.dev/pkg/apis"
@@ -75,6 +78,8 @@ const (
 
 	FailureRetryTime  = time.Minute * 5 // We retry after 5 minutes on failure
 	DefaultNudgeFiles = ".*Dockerfile.*, .*.yaml, .*Containerfile.*"
+
+	integrationNudgeConfigName = "nudge-config"
 )
 
 // The amount of time we wait before attempting to update the component, to try and avoid contention issues
@@ -151,15 +156,14 @@ func (r *ComponentDependencyUpdateReconciler) SetupWithManager(manager ctrl.Mana
 		Complete(r)
 }
 
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=nudgeconfigs,verbs=get;list;watch
+
 // Reconcile handles component dependency updates.
-// The following line for configmaps is informational, the actual permissions are defined in component_build_controller.
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;list;watch;update;patch;delete
-// +kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete;deletecollection
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 func (r *ComponentDependencyUpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, contextTimeout)
@@ -212,6 +216,25 @@ func (r *ComponentDependencyUpdateReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, nil
 	}
 	log.Info("component has BuildNudgesRef set", "ComponentName", component.Name, "BuildNudgesRef", component.Spec.BuildNudgesRef)
+
+	// check if integration nudgeConfig exists, if it does skip nudging and just set nudge processed annotation
+	integrationNudgeConfig := &unstructured.Unstructured{}
+	integrationNudgeConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "appstudio.redhat.com",
+		Version: "v1beta2",
+		Kind:    "NudgeConfig",
+	})
+	err = r.Client.Get(ctx, types.NamespacedName{Name: integrationNudgeConfigName, Namespace: pipelineRun.Namespace}, integrationNudgeConfig)
+	if err != nil {
+		if !errors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
+			log.Error(err, "Failed to get nudgeConfig", "NudgeConfigName", integrationNudgeConfigName)
+			return ctrl.Result{}, err
+		}
+	} else {
+		patch := client.MergeFrom(pipelineRun.DeepCopy())
+		log.Info("skipping nudging, because NudgeConfig exists in the namespace", "NudgeConfigName", integrationNudgeConfigName)
+		return r.removePipelineFinalizer(ctx, pipelineRun, patch)
+	}
 
 	// verify that there exist some components to be nudged
 	allComponents := compapiv1alpha1.ComponentList{}

--- a/internal/controller/component_dependency_update_controller_test.go
+++ b/internal/controller/component_dependency_update_controller_test.go
@@ -35,6 +35,8 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -355,6 +357,33 @@ var _ = Describe("Component nudge controller", func() {
 				}
 			}
 			Expect(caMounted).Should(BeTrue())
+		})
+
+		It("Test skip nudge when nudgeConfig exists", func() {
+			// create nudgeConfig
+			nudgeConfig := unstructured.Unstructured{}
+			nudgeConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "appstudio.redhat.com",
+				Version: "v1beta2",
+				Kind:    "NudgeConfig",
+			})
+			nudgeConfig.SetNamespace(UserNamespace)
+			nudgeConfig.SetName(integrationNudgeConfigName)
+
+			err := k8sClient.Create(context.TODO(), &nudgeConfig)
+			Expect(err).ToNot(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), &nudgeConfig)
+
+			createBuildPipelineRun("test-pipeline-1", UserNamespace, baseComponentName, "")
+			Eventually(func() bool {
+				pr := getPipelineRun("test-pipeline-1", UserNamespace)
+				// skipped pipeline will never have finalizer set
+				if controllerutil.ContainsFinalizer(pr, NudgeFinalizer) {
+					return false
+				}
+				// but it will have processed annotation set
+				return pr.Annotations != nil && pr.Annotations[NudgeProcessedAnnotationName] != ""
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 		})
 
 		It("Test build performs nudge on success, image repository partial auth", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -83,6 +83,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "hack", "routecrd", "route.yaml"),
+			filepath.Join("..", "..", "hack", "nudgeconfigcrd", "nudgeconfig.yaml"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "konflux-ci", "application-api@"+applicationApiDepVersion, "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "tektoncd", "pipeline@v1.10.2", "config", "300-crds"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "openshift-pipelines", "pipelines-as-code@v0.43.0", "config"),


### PR DESCRIPTION
named "nudge-config", controller will just set "build.appstudio.openshift.io/component-nudge-processed" annotation on pipelineRun and consider it processed.

This is used for migration of nudging to integration service.

[STONEINTG-1672](https://redhat.atlassian.net/browse/STONEINTG-1672)

## Description

<!-- Explain the overall changes and their purpose. -->

## Testing

<!-- Describe how the changes were tested. -->

## Related Issues

<!-- Reference related issues: Fixes #123, Related to #456 -->

[STONEINTG-1672]: https://redhat.atlassian.net/browse/STONEINTG-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KONFLUX-14905]: https://redhat.atlassian.net/browse/KONFLUX-14905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ