### PR TITLE
fix: use main for manifests

### DIFF
--- a/e2e-tests/pipelines/konflux-e2e-tests.yaml
+++ b/e2e-tests/pipelines/konflux-e2e-tests.yaml
@@ -98,7 +98,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-ci
           - name: revision
-            value: d91a9ece92d5e0a5ec6408a0a3dc2ec0fa4e0215
+            value: 8a3219a261dca651737a0890c3868c7363af2877
           - name: pathInRepo
             value: .tekton/tasks/deploy-konflux/task.yaml
       params:
@@ -126,7 +126,7 @@ spec:
         - name: git-url
           value: https://github.com/konflux-ci/konflux-ci
         - name: revision
-          value: d91a9ece92d5e0a5ec6408a0a3dc2ec0fa4e0215
+          value: main
     - name: pre-pull-images
       runAfter:
         - deploy-konflux


### PR DESCRIPTION
## Description

- When using a specific commit from `konflux-ci/konflux-ci` we were using the same revision of other components in CI, causing CI to fail when we depend on other component's latest changes. So we should use `main` revision so that we get the latest always during konflux deployment.
- And for the konflux deploy task, use latest revision.

## Related Issues

Tests failing on [this PR](https://github.com/konflux-ci/build-service/pull/669)